### PR TITLE
Validate compliance reports

### DIFF
--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -6,16 +6,39 @@ class ComplianceReportsConsumer < Racecar::Consumer
   subscribes_to 'compliance'
 
   def process(message)
-    logger.info "Received message, enqueueing: #{message.value}"
-    job = ParseReportJob.perform_later(
-      SafeDownloader.new.download(
-        JSON.parse(message.value)['url']
-      ).path
+    value = JSON.parse(message.value)
+    logger.info "Received message, enqueueing: #{message}"
+    path = "tmp/storage/#{value['hash']}"
+    SafeDownloader.new.download(value['url'], path)
+    validation = validation_message(path)
+    enqueue_job(path, value['hash'], validation)
+    produce(
+      validation_payload(value['hash'], validation),
+      topic: 'uploadvalidation'
     )
-    logger.info "Message enqueued: #{message.value} as #{job.job_id}"
   end
 
   private
+
+  def enqueue_job(path, hash, validation)
+    if validation == 'success'
+      job = ParseReportJob.perform_later(path)
+      logger.info "Message enqueued: #{hash} as #{job.job_id}"
+    else
+      logger.error("Error parsing report: #{hash}")
+    end
+  end
+
+  def validation_message(path)
+    XCCDFReportParser.new(path)
+    'success'
+  rescue StandardError
+    'failure'
+  end
+
+  def validation_payload(hash, result)
+    { 'hash': hash, 'validation': result }.to_json
+  end
 
   def logger
     Rails.logger

--- a/app/services/safe_downloader.rb
+++ b/app/services/safe_downloader.rb
@@ -16,11 +16,13 @@ class SafeDownloader
     DownloadError
   ].freeze
 
-  def download(url, max_size: nil)
+  def download(url, path, max_size: nil)
     url = encode_url(url)
     options = create_options(max_size)
     downloaded_file = url.open(options)
     patch_if_less_than_10k(downloaded_file)
+    IO.copy_stream(downloaded_file, path)
+    downloaded_file
   rescue *DOWNLOAD_ERRORS => error
     raise if error.instance_of?(RuntimeError) && error.message !~ /redirection/
 

--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -7,15 +7,21 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
 
   test 'report message is parsed and job is enqueued' do
     message = stub(:message)
-    tempfile = stub(:tempfile)
-    tempfile.expects(:path).returns('/tmp/fakepath').at_least_once
     # rubocop:disable Style/StringLiterals
     # rubocop:disable Metrics/LineLength
     message.expects(:value).returns("{\"rh_account\": \"000001\", \"principal\": \"default_principal\", \"validation\": 1, \"hash\": \"036738d6f4e541c4aa8cfc9f46f5a140\", \"size\": 327, \"service\": \"compliance\", \"url\": \"/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cfc9f46f5a140\"}").at_least_once
     # rubocop:enable Style/StringLiterals
     # rubocop:enable Metrics/LineLength
-    SafeDownloader.any_instance.expects(:download).returns(tempfile)
+    SafeDownloader.any_instance.expects(:download)
     consumer = ComplianceReportsConsumer.new
+    consumer.expects(:validation_message).with(
+      'tmp/storage/036738d6f4e541c4aa8cfc9f46f5a140'
+    ).returns('success')
+    consumer.expects(:produce).with(
+      { 'hash': '036738d6f4e541c4aa8cfc9f46f5a140',
+        'validation': 'success' }.to_json,
+      topic: 'uploadvalidation'
+    )
     assert_enqueued_jobs 1 do
       consumer.process(message)
     end


### PR DESCRIPTION
This commit sends a message back to the 'uploadvalidation' queue in
Insights. The message validates the payload whether the payload
contained a valid XCCDF Report or not.

Additionally I started storing reports in tmp/storage, as using a Ruby
Tempfile as it was doing before wasn't enough. The reason is that
Tempfiles get destroyed as soon as the garbage collector runs.
Therefore the timeline went like this:

 1. Consumer creates Tempfile
 2. Only the *path* is passed to ActiveJob.
 3. Consumer exits. Tempfile gets thrashed
 4. ActiveJob keeps on running, but the file has been destroyed