### PR TITLE
Jenkins slave pod should include the db container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,49 +12,53 @@ node {
     }
 }
 
-def filesChanged() {
-    def affectedFiles = []
-    currentBuild.changeSets.each { changeSet ->
-        changeSet.items.each { entry ->
-            entry.affectedFiles.each { file ->
-                affectedFiles.add(file.path)
-            }
-        }
-    }
-    "Gemfile" in affectedFiles || "openshift/Jenkins/Dockerfile" in affectedFiles
-}
-
 def runStages() {
-    openShift.withNode(image: "docker-registry.default.svc:5000/jenkins/jenkins-slave-base-centos7-ruby25-openscap:latest") {
-        
-        checkout scm
 
-        if (filesChanged()) {
-            stage("Bundle install") {
-                runBundleInstall()
-            }            
-        }
+    label = "test-${UUID.randomUUID().toString()}"
 
-        stage("Prepare the db") {
-            withStatusContext.dbMigrate {
-                sh "bundle exec rake db:migrate --trace"
-                sh "bundle exec rake db:test:prepare"
+    podTemplate(
+        label: label,
+        slaveConnectTimeout: 120,
+        serviceAccount: pipelineVars.jenkinsSvcAccount,
+        cloud: "openshift",
+        namespace: pipelineVars.defaultNameSpace,
+        yaml: readTrusted("openshift/Jenkins/slave_pod_template.yaml")
+    ) {
+        node(label) {
+
+            checkout scm
+
+            changedFiles = changedFiles()
+
+            if ("Gemfile" in changedFiles) {
+                stage("Bundle install") {
+                    runBundleInstall()
+                }            
             }
-        }
 
-        stage("Unit tests") {
-            withStatusContext.unitTest {
-                sh "bundle exec rake validate"
+            stage("Prepare the db") {
+                withStatusContext.dbMigrate {
+                    sh "bundle exec rake db:migrate --trace"
+                    sh "bundle exec rake db:test:prepare"
+                }
             }
-        }
 
-        if (currentBuild.currentResult == "SUCCESS" && env.BRANCH_NAME == "master" && filesChanged()) {
-            // If Gemfiles or Jenknis slave's Dockerfile changed we need to rebuild the jenkins slave image
-            stage("Rebuild the image") {
-                openshiftBuild(
-                    bldCfg: "jenkins-slave-base-centos7-ruby25-openscap",
-                    namespace: "jenkins",
-                )
+            stage("Unit tests") {
+                withStatusContext.unitTest {
+                    sh "bundle exec rake validate"
+                }
+            }
+
+            if (currentBuild.currentResult == "SUCCESS" &&
+                env.BRANCH_NAME == "master" &&
+                ("Gemfile" in changedFiles || "openshift/Jenkins/Dockerfile" in changedFiles)) {
+                // If Gemfiles or Jenknis slave's Dockerfile changed we need to rebuild the jenkins slave image
+                stage("Rebuild the image") {
+                    openshiftBuild(
+                        bldCfg: "jenkins-slave-base-centos7-ruby25-openscap",
+                        namespace: "jenkins",
+                    )
+                }
             }
         }
     }

--- a/openshift/Jenkins/Dockerfile
+++ b/openshift/Jenkins/Dockerfile
@@ -34,15 +34,6 @@ RUN chown -R 1001:0 $HOME && \
 
 ENV LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
-    DATABASE_SERVICE_NAME="compliance-db" \
-    COMPLIANCE_DB_SERVICE_HOST="compliance-db.compliance-ci.svc" \
-    POSTGRESQL_USER="compliance_user" \
-    POSTGRESQL_PASSWORD="compliance_password" \
-    POSTGRESQL_ADMIN_PASSWORD="db_admin_password" \
-    POSTGRESQL_DATABASE="compliance" \
-    POSTGRESQL_MAX_CONNECTIONS="100" \
-    POSTGRESQL_SHARED_BUFFERS="12MB" \
-    RAILS_ENV="test" \
     PATH="$PATH:/opt/rh/$RUBY_SCL/root/usr/bin" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rh/$RUBY_SCL/root/usr/lib64" \
     MANPATH="$MANPATH:/opt/rh/$RUBY_SCL/root/usr/share/man" \

--- a/openshift/Jenkins/slave_pod_template.yaml
+++ b/openshift/Jenkins/slave_pod_template.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: compliance-backend-jenkins-slave
+spec:
+  containers:
+  - env:
+    - name: POSTGRESQL_USER
+      value: compliance_user
+    - name: POSTGRESQL_PASSWORD
+      value: compliance_password
+    - name: POSTGRESQL_ADMIN_PASSWORD
+      value: db_admin_password
+    - name: POSTGRESQL_DATABASE
+      value: compliance
+    - name: POSTGRESQL_MAX_CONNECTIONS
+      value: "100"
+    - name: POSTGRESQL_SHARED_BUFFERS
+      value: 12MB
+    image: centos/postgresql-96-centos7:latest
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      exec:
+        command:
+        - /usr/libexec/check-container
+        - --live
+      failureThreshold: 3
+      initialDelaySeconds: 120
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 10
+    name: postgresql
+    readinessProbe:
+      exec:
+        command:
+        - /usr/libexec/check-container
+      failureThreshold: 3
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    resources:
+      limits:
+        cpu: 300m
+        memory: 512Mi
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    volumeMounts:
+    - mountPath: /var/lib/pgsql/data
+      name: shared
+      subPath: data
+    - mountPath: /var/run/postgresql
+      name: shared
+      subPath: sockets
+  - env:
+    - name: DATABASE_SERVICE_NAME
+      value: compliance-db
+    - name: COMPLIANCE_DB_SERVICE_HOST
+      value: /var/run/sockets
+    - name: POSTGRESQL_USER
+      value: compliance_user
+    - name: POSTGRESQL_PASSWORD
+      value: compliance_password
+    - name: POSTGRESQL_ADMIN_PASSWORD
+      value: db_admin_password
+    - name: POSTGRESQL_DATABASE
+      value: compliance
+    - name: SECRET_KEY_BASE
+      value: secret_key_base
+    - name: POSTGRESQL_MAX_CONNECTIONS
+      value: "100"
+    - name: POSTGRESQL_SHARED_BUFFERS
+      value: 12MB
+    - name: RAILS_ENV
+      value: test
+    image: docker-registry.default.svc:5000/jenkins/jenkins-slave-base-centos7-ruby25-openscap:latest
+    imagePullPolicy: Always
+    name: jnlp
+    args:
+      - "$(JENKINS_SECRET)"
+      - "$(JENKINS_NAME)"
+    resources:
+      limits:
+        cpu: 300m
+        memory: 1Gi
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    volumeMounts:
+    - mountPath: /var/run/sockets
+      name: shared
+      subPath: sockets
+  dnsPolicy: ClusterFirst
+  volumes:
+  - emptyDir: {}
+    name: shared


### PR DESCRIPTION
Currently, each time when the unit tests run a preprovisioned db container is used. This PR adds the db container to the Jenkins slave pod. The slave and the db communicate with each other via unix socket.