### PR TITLE
Add pagination and sorting to Profile index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem 'pundit'
 
 gem 'faraday'
 
+gem 'will_paginate'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    will_paginate (3.1.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -318,6 +319,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  will_paginate
 
 BUNDLED WITH
    1.16.4

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,7 +4,9 @@
 class ProfilesController < ApplicationController
   def index
     render json: ProfileSerializer.new(
-      policy_scope(Profile.includes(:rules, :hosts)).to_a
+      policy_scope(Profile.includes(:rules, :hosts))
+      .paginate(page: params[:page], per_page: params[:per_page])
+      .sort_by(&:score)
     )
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,4 +25,10 @@ class Profile < ApplicationRecord
       rule.compliant?(host)
     end
   end
+
+  def score
+    return 1 if hosts.blank?
+
+    (hosts.count { |host| compliant?(host) }) / hosts.count
+  end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -4,16 +4,11 @@
 class ProfileSerializer
   include FastJsonapi::ObjectSerializer
   set_type :profile
-  attributes :name, :ref_id, :description
+  attributes :name, :ref_id, :description, :score
   attribute :total_host_count do |profile|
     profile.hosts.count
   end
   attribute :compliant_host_count do |profile|
     profile.hosts.count { |host| profile.compliant?(host) }
-  end
-
-  attribute :score do |profile|
-    (profile.hosts.count { |host| profile.compliant?(host) }) /
-      profile.hosts.count
   end
 end


### PR DESCRIPTION
This should allow API consumers, like the Dashboard, to request the top
X profiles in order of least compliant to most compliant.

E.g, to get the 3 least compliant hosts:

https://prod.foo.redhat.com:1337/r/insights/platform/compliance/profiles?per_page=3

should be enough