### PR TITLE
Remove redhat_id constraint as it was removed from header

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,6 @@
 
 # Represents an individual Insights-Compliance user
 class User < ApplicationRecord
-  validates :redhat_id, uniqueness: true # , presence: true
   validates :username, uniqueness: true, presence: true
   validates_associated :account
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,9 +3,7 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  should validate_uniqueness_of :redhat_id
   should validate_uniqueness_of :username
-  # should validate_presence_of :redhat_id
   should validate_presence_of :username
   should belong_to :account
 


### PR DESCRIPTION
The username and the account are used to login, so the redhat_id field now is irrelevant basically. Some users are reporting problems when logging in for the first time, as currently you cannot create 2 accounts with redhat_id = null