### PR TITLE
Save old rules in new profiles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,9 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     pundit (2.0.0)
@@ -260,6 +263,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -308,6 +312,7 @@ DEPENDENCIES
   openscap
   pg
   pry-byebug
+  pry-remote
   puma (~> 3.11)
   pundit
   racecar

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -70,15 +70,22 @@ class XCCDFReportParser
     end
   end
 
+  def rule_already_saved(rule, profiles)
+    found_rule = Rule.find_by(ref_id: rule.id)
+    return false if found_rule.blank?
+
+    found_rule.profiles << profiles
+    found_rule.save
+  end
+
   def save_rules
     save_profiles
+    new_profiles = Profile.where(ref_id: profiles.keys)
     rule_objects.each_with_object([]) do |rule, new_rules|
       rule_object = rule[1]
-      next if Rule.find_by(ref_id: rule_object.id)
+      next if rule_already_saved(rule_object, new_profiles)
 
-      new_rule = Rule.new(
-        profiles: Profile.where(ref_id: profiles.keys)
-      ).from_oscap_object(rule_object)
+      new_rule = Rule.new(profiles: new_profiles).from_oscap_object(rule_object)
       new_rule.save
       new_rules << new_rule
     end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,1 @@
-host_inventory_url: http://localhost:8000
+host_inventory_url: https://insights-inventory-platform-ci.5a9f.insights-dev.openshiftapps.com

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -13,7 +13,8 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
                                              accounts(:test).account_number,
                                              'b64_fake_identity')
     # A hack to skip API calls in the test env for the time being
-    HostInventoryAPI.stubs(:host_already_in_inventory).returns(true)
+    HostInventoryAPI.any_instance.stubs(:host_already_in_inventory)
+                    .returns(true)
   end
 
   context 'profile' do


### PR DESCRIPTION
Before this commit, if you submitted a report containing rules which
were used in a profile before, the profile would be saved without adding
these rules to the profile, so in the UI the rules page would not show
any rules.