### PR TITLE
Remove tempfile when validation is 'failure'

### DIFF
--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -50,6 +50,8 @@ class ComplianceReportsConsumer < ApplicationConsumer
   rescue StandardError => error
     logger.error "Error validating report: #{@value['payload_id']}"\
       " - #{error.message}"
+    @file.close
+    @file.unlink
     'failure'
   end
 

--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -5,21 +5,23 @@ require 'test_helper'
 class ComplianceReportsConsumerTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
-  test 'report message is parsed and job is enqueued' do
-    message = stub(:message)
-    message.expects(:value).returns(
+  setup do
+    @message = stub(:message)
+    @consumer = ComplianceReportsConsumer.new
+    @message.expects(:value).returns(
       '{"account": "000001", "principal": "default_principal", '\
       '"validation":1,"payload_id":"036738d6f4e541c4aa8cfc9f46f5a140",'\
       '"size": 327, "service": "compliance", "url": "/tmp/uploads'\
       '/insights-upload-quarantine/036738d6f4e541c4aa8cfc9f46f5a140"}'
     ).at_least_once
+    @tempfile = Tempfile.new
+    SafeDownloader.expects(:download).returns(@tempfile)
+  end
 
+  test 'report message is parsed and job is enqueued' do
     begin
-      tempfile = Tempfile.new
-      SafeDownloader.expects(:download).returns(tempfile)
-      consumer = ComplianceReportsConsumer.new
-      consumer.expects(:validation_message).returns('success')
-      consumer.expects(:produce).with(
+      @consumer.expects(:validation_message).returns('success')
+      @consumer.expects(:produce).with(
         {
           'payload_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'service': 'compliance',
@@ -28,11 +30,24 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
         topic: Settings.platform_kafka_validation_topic
       )
       assert_enqueued_jobs 1 do
-        consumer.process(message)
+        @consumer.process(@message)
       end
     ensure
-      tempfile.close
-      tempfile.unlink
+      @tempfile.close
+      @tempfile.unlink
+    end
+  end
+
+  test 'file is deleted even when validation fails' do
+    XCCDFReportParser.expects(:new).raises(StandardError, 'something broke')
+    @tempfile.expects(:close)
+    # After calling .close, @tempfile changes its internal object id, so we
+    # need to expect any tempfile to close.
+    Tempfile.any_instance.expects(:unlink)
+    # Mock the actual 'sending the validation' to Kafka
+    @consumer.expects(:send_validation).with('failure').returns(true)
+    assert_enqueued_jobs 0 do
+      @consumer.process(@message)
     end
   end
 end


### PR DESCRIPTION
Before this commit, the tempfile would only be removed if the validation
succeeded and a job was enqueued.