### PR TITLE
Only new profiles are assigned to old rules

### DIFF
--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -74,7 +74,12 @@ class XCCDFReportParser
     found_rule = Rule.find_by(ref_id: rule.id)
     return false if found_rule.blank?
 
-    found_rule.profiles << profiles
+    new_profiles = []
+    profiles.each do |profile|
+      new_profiles.append(profile) unless found_rule.profiles.include?(profile)
+    end
+
+    found_rule.profiles << new_profiles
     found_rule.save
   end
 

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -124,5 +124,15 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
         assert_empty old_rules_found
       end
     end
+
+    should 'not try to append already assigned profiles to a rule' do
+      rule = Rule.create(ref_id: @arbitrary_rules[0])
+      rule.profiles << profiles(:one)
+      assert_nothing_raised do
+        @report_parser.rule_already_saved(rule, [profiles])
+      end
+      assert_equal 1, rule.profiles.count
+      assert_equal profiles(:one), rule.profiles.first
+    end
   end
 end


### PR DESCRIPTION
This fixes a problem when you upload a report twice and get an error like `Consumer crashes with "ActiveRecord::RecordInvalid (Validation failed: Rule has already been taken)"`. 
It happened because the parser tried to assign a profile to a rule even if it already had that assignment. This PR ensures only the profiles that are new to each rule are assigned. 