### PR TITLE
Accept SETTINGS__PROMETHEUS_EXPORTER_HOST as env var

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -16,28 +16,25 @@ Config.setup do |config|
   # config.overwrite_arrays = true
 
   # Load environment variables from the `ENV` object and override any settings defined in files.
-  #
   config.use_env = true
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
-  # config.env_prefix = 'Settings'
+  config.env_prefix = 'SETTINGS'
 
   # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where
   # using dots in variable names might not be allowed (eg. Bash).
-  #
-  # config.env_separator = '.'
+  config.env_separator = '__'
 
   # Ability to process variables names:
   #   * nil  - no change
   #   * :downcase - convert to lower case
   #
-  # config.env_converter = :downcase
+  config.env_converter = :downcase
 
   # Parse numeric values as integers instead of strings.
-  #
-  # config.env_parse_values = true
+  config.env_parse_values = true
 
   # Validate presence and type of specific config values. Check https://github.com/dry-rb/dry-validation for details.
   #

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -5,7 +5,9 @@ if Rails.env != "test"
   client = PrometheusExporter::Client.new(
     host: Settings.prometheus_exporter_host,
     port: Settings.prometheus_exporter_port
+    # Add custom_labels for app_name here (consumer and webserver)
   )
+  PrometheusExporter::Metric::Base.default_prefix = 'compliance'
   PrometheusExporter::Client.default = client
 
   # This reports stats per request like HTTP status and timings


### PR DESCRIPTION
Before this PR, it required an environment variable like 'Settings.prometheus_exporter_host', which is not really possible to set in Bash. This adapts the image to support an env variable like "SETTINGS__NAMEOFSETTING", so "SETTINGS__PROMETHEUS_EXPORTER_HOST" works