### PR TITLE
Update docker files to use the rails image, add prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from ruby
+from ruby:2.5
 
 workdir /app
 
@@ -9,7 +9,3 @@ run apt-get update && apt-get install -y qt5-default libqt5webkit5-dev \
       postgresql-client
 
 run bundle
-
-add entrypoint.sh /app/
-
-expose 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,21 +4,34 @@ services:
     image: postgres
     restart: on-failure
     volumes:
-      - /tmp/insights-compliance-db:/var/lib/postgresql/data:Z
+      - /tmp/insights-compliance-db:/var/lib/postgresql/data:z
   rails:
     build: .
+    image: compliance-backend-rails
     restart: on-failure
     entrypoint: ./entrypoint.sh
     ports:
       - '3000:3000'
     volumes:
-      - .:/app:Z
+      - .:/app:z
     depends_on:
       - db
+      - prometheus
   racecar:
-    build: .
+    image: compliance-backend-rails
     restart: on-failure
-    entrypoint: bash -c 'KAFKAMQ=kafka:29092 bundle exec racecar ComplianceReportsConsumer'
+    entrypoint: bash -c 'KAFKAMQ=kafka:29092 bundle exec racecar -l log/racecar.log ComplianceReportsConsumer'
+    volumes:
+      - .:/app:z
+    depends_on:
+      - db
+      - prometheus
+  prometheus:
+    image: compliance-backend-rails
+    restart: on-failure
+    volumes:
+      - .:/app:z
+    entrypoint: bash -c 'bundle exec prometheus_exporter -c lib/graphql_collector.rb'
 networks:
   default:
     external:


### PR DESCRIPTION
When I first implemented this, I didn't realize a few things:

- `:Z` vs. `:z` in volume mounts. The former sets SELinux context to only that single container; the latter sets the SELinux context to containers in general, allowing multiple containers to mount the same local directory (this is what we want for rails+racecar+prometheus)
- You can use `build` and `image` together in docker-compose.yml (as is done for the rails service in this PR) to build a named image which can then be used in other services in the same docker-compose.yml. This turns out to be really useful for services that require the ruby environment (i.e. `bundle exec ...`)
- The `expose` keyword in a Dockerfile is identical to the port definition in docker-compose.yml. We don't want to expose 3000 at the image level, as only the rails service needs that port exposed (and other services cannot run a container based on the same image due to failure binding an already-bound port)
- A similar point can be made for the entrypoint - if we're using one image for 3 services, it's best to define the entrypoint at the service level rather than the image level.