### PR TITLE
Ensure account number exists

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -4,4 +4,6 @@
 class Account < ApplicationRecord
   has_many :users, dependent: :nullify
   has_many :hosts, dependent: :nullify
+
+  validates :account_number, presence: true
 end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -4,4 +4,5 @@ require 'test_helper'
 
 class AccountTest < ActiveSupport::TestCase
   should have_many :users
+  should validate_presence_of :account_number
 end


### PR DESCRIPTION
This forces users without an Insights account number (e.g: someone who registers in redhat.com but does not have a subscription to see Insights) to logout - the frontend will get 401 and log out the user.