### PR TITLE
Don't migrate the DB during consumer pre-hook

### DIFF
--- a/openshift/templates/compliance-consumer.yaml
+++ b/openshift/templates/compliance-consumer.yaml
@@ -22,19 +22,6 @@ objects:
       description: Defines how to deploy the application server
       template.alpha.openshift.io/wait-for-ready: 'true'
   spec:
-    strategy:
-      type: Recreate
-      recreateParams:
-        pre:
-          failurePolicy: Abort
-          execNewPod:
-            command:
-            - bash
-            - -c
-            - |
-              set -e
-              RAILS_ENV="${RAILS_ENV}" bundle exec rake db:migrate
-            containerName: "${NAME}"
     triggers:
     - type: ImageChange
       imageChangeParams:


### PR DESCRIPTION
We run this on the compliance-backend which is deployed with the consumer, so there's no reason to run db:migrate twice (and it's failing for this deployment every time).