### PR TITLE
Send report through ActionJob

### DIFF
--- a/app/controllers/concerns/exception_notifier.rb
+++ b/app/controllers/concerns/exception_notifier.rb
@@ -11,9 +11,8 @@ module ExceptionNotifier
   private
 
   def prepare_exception_notifier
-    request.env["exception_notifier.exception_data"] = {
+    request.env['exception_notifier.exception_data'] = {
       current_user: current_user
     }
   end
 end
-

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -6,7 +6,7 @@ class ParseReportJob < ApplicationJob
     parser = XCCDFReportParser.new(file, account, b64_identity)
     parser.save_rule_results
   ensure
-    File.delete(file)
+    File.delete(parser.report_path) if File.exist? parser.report_path
   end
 
   rescue_from(OpenSCAP::OpenSCAPError) do |e|

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -12,11 +12,15 @@ class XCCDFReportParser
   include ::XCCDFReport::XMLReport
   include ::XCCDFReport::Profiles
 
-  def initialize(report_path, account, b64_identity)
-    @report_path = report_path
+  attr_reader :report_path
+
+  def initialize(report_contents, account, b64_identity)
+    file = Tempfile.new(SecureRandom.uuid)
+    file.write(report_contents)
+    @report_path = file.path
     @b64_identity = b64_identity
     @account = Account.find_or_create_by(account_number: account)
-    @source = ::OpenSCAP::Source.new(report_path)
+    @source = ::OpenSCAP::Source.new(@report_path)
     @benchmark = ::OpenSCAP::Xccdf::Benchmark.new(@source)
   end
 

--- a/test/controllers/systems_controller_test.rb
+++ b/test/controllers/systems_controller_test.rb
@@ -16,10 +16,11 @@ class SystemsControllerTest < ActionDispatch::IntegrationTest
 
   test 'index accepts search' do
     scope = mock('scope')
-    SystemsController.any_instance.expects(:policy_scope).with(Host).returns(scope)
+    SystemsController.any_instance.expects(:policy_scope).with(Host)
+                     .returns(scope)
     scope.expects(:search_for).with('foo=bar')
 
-    get systems_url, params: {search: 'foo=bar'}
+    get systems_url, params: { search: 'foo=bar' }
 
     assert_response :success
   end

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -7,7 +7,7 @@ class RuleTest < ActiveSupport::TestCase
   should validate_presence_of :ref_id
 
   setup do
-    fake_report = file_fixture('xccdf_report.xml').to_path
+    fake_report = file_fixture('xccdf_report.xml').read
     @report_parser = ::XCCDFReportParser.new(fake_report, users(:test), 'foo')
     @rule_objects = @report_parser.rule_objects
     @selinux_rule_id = 'xccdf_org.ssgproject.content_rule'\

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class XCCDFReportParserTest < ActiveSupport::TestCase
   setup do
-    fake_report = file_fixture('xccdf_report.xml').to_path
+    fake_report = file_fixture('xccdf_report.xml').read
     @profile = {
       'xccdf_org.ssgproject.content_profile_standard' =>
       'Standard System Security Profile for Fedora'
@@ -40,7 +40,7 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
     end
 
     should 'not save more than one profile when there are no test results' do
-      fake_report = file_fixture('rhel-xccdf-report.xml').to_path
+      fake_report = file_fixture('rhel-xccdf-report.xml').read
       @profile = {
         'xccdf_org.ssgproject.content_profile_rht-ccp' =>
         'Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)'


### PR DESCRIPTION
This allows us to have Sidekiq workers without sharing any volumes. The
report is send as a string over to Redis, serialized as an ActiveJob
job.