### PR TITLE
Add pry-rails for pry in the rails console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :development do
   gem 'spring'
   gem 'bullet'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry-rails'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,8 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
@@ -327,6 +329,7 @@ DEPENDENCIES
   pg
   prometheus_exporter
   pry-byebug
+  pry-rails
   pry-remote
   puma (~> 3.11)
   pundit
@@ -342,12 +345,12 @@ DEPENDENCIES
   scoped_search
   shoulda-context
   shoulda-matchers
-  slack-notifier
   sidekiq
+  slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   will_paginate
 
 BUNDLED WITH
-   1.16.4
+   1.17.2


### PR DESCRIPTION
This is just for development purposes. Pry in the rails console is much nicer IMO:

Vanilla IRB:

```rb
irb(main):004:0> Profile.first
  Profile Load (2.0ms)  SELECT  "profiles".* FROM "profiles" ORDER BY "profiles"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> #<Profile id: "85356ce8-9a07-4dae-aead-173ba4b86660", name: "Standard System Security Profile for Red Hat Enter...", ref_id: "standard", policy_id: nil, created_at: "2019-03-04 14:16:48", updated_at: "2019-03-04 14:16:48", description: "This guide presents a catalog of security-relevant...", account_id: "8e3411a6-7a9a-4456-8a2e-b9a066ecf96a", slug: "standard">
```

With pry
```rb
[4] pry(main)> Profile.first
  Profile Load (1.7ms)  SELECT  "profiles".* FROM "profiles" ORDER BY "profiles"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> #<Profile:0x000055afd23aaac0
 id: "85356ce8-9a07-4dae-aead-173ba4b86660",
 name: "Standard System Security Profile for Red Hat Enterprise Linux 7",
 ref_id: "standard",
 policy_id: nil,
 created_at: Mon, 04 Mar 2019 14:16:48 UTC +00:00,
 updated_at: Mon, 04 Mar 2019 14:16:48 UTC +00:00,
 description:
  "This guide presents a catalog of security-relevant\nconfiguration settings for Red Hat Enterprise Linux 7. It is a rendering of\ncontent structured in the eXtensible Configuration Checklist Description Format (XCCDF)\nin order to support security automation.  The SCAP content is\nis available in the scap-security-guide package which is developed at\n\n    https://www.open-scap.org/security-policies/scap-security-guide.\n\nProviding system administrators with such guidance informs them how to securely\nconfigure systems under their control in a variety of network roles. Policy\nmakers and baseline creators can use this catalog of settings, with its\nassociated references to higher-level security control catalogs, in order to\nassist them in security baseline creation. This guide is a catalog, not a\nchecklist, and satisfaction of every item is not likely to be possible or\nsensible in many operational scenarios. However, the XCCDF format enables\ngranular selection and adjustment of settings, and their association with OVAL\nand OCIL content provides an automated checking capability. Transformations of\nthis document, and its associated automated checking content, are capable of\nproviding baselines that meet a diverse set of policy objectives. Some example\nXCCDF Profiles, which are selections of items that form checklists and\ncan be used as baselines, are available with this guide. They can be\nprocessed, in an automated fashion, with tools that support the Security\nContent Automation Protocol (SCAP). The DISA STIG for Red Hat Enterprise Linux 7,\nwhich provides required settings for US Department of Defense systems, is\none example of a baseline created from this guidance.\n",
 account_id: "8e3411a6-7a9a-4456-8a2e-b9a066ecf96a",
 slug: "standard">
```

There are many features; this is just an example.