### PR TITLE
Remove b64 identity and report content from ActiveJob logs

### DIFF
--- a/config/initializers/active_job_logger_patch.rb
+++ b/config/initializers/active_job_logger_patch.rb
@@ -1,0 +1,10 @@
+require 'active_job/logging'
+
+class ActiveJob::Logging::LogSubscriber
+  private def args_info(job)
+    if ParseReportJob == job.class.name && job.arguments.any?
+      return "for account: #{format(arguments[1]).inspect}"
+    end
+    super(job)
+  end
+end


### PR DESCRIPTION
Writing the report contents and b64 identity of the job clutters the logs for Sidekiq 