### PR TITLE
Handle malformed auth tokens

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -21,7 +21,7 @@ module Authentication
     return if performed? || !user.persisted?
 
     User.current = user
-  rescue JSON::ParserError
+  rescue JSON::ParserError, NoMethodError
     unauthenticated 'Error parsing the X-RH-IDENTITY header'
   end
 


### PR DESCRIPTION
If there are missing fields, we end up calling `:[]` on `nil`. Catching
NoMethodError allows us to display a more helpful error to users