### PR TITLE
Modify public REST API to get profiles for a host

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,15 +4,31 @@
 class ProfilesController < ApplicationController
   def index
     render json: ProfileSerializer.new(
-      policy_scope(Profile.includes(:rules, :hosts))
+      policy_scope(index_relation)
       .paginate(page: params[:page], per_page: params[:per_page])
       .sort_by(&:score)
     )
+  end
+
+  def index_relation
+    relation = Profile.includes(:rules, :hosts)
+    if profile_index_params[:hostname]
+      relation = relation
+                 .where(hosts: { name: profile_index_params[:hostname] })
+                 .includes(:profile_hosts)
+    end
+    relation
   end
 
   def show
     profile = Profile.friendly.find(params[:id])
     authorize profile
     render json: ProfileSerializer.new(profile)
+  end
+
+  private
+
+  def profile_index_params
+    params.permit(:hostname)
   end
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -3,4 +3,40 @@
 require 'test_helper'
 
 class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    ProfilesController.any_instance.stubs(:authenticate_user)
+    @relation = mock('relation')
+  end
+
+  test 'index lists all profiles' do
+    @relation.expects(:paginate).returns(@relation)
+    @relation.expects(:sort_by).returns(@relation)
+    ProfileSerializer.expects(:new)
+    ProfilesController.any_instance.expects(:policy_scope).returns(@relation)
+    get profiles_url
+
+    assert_response :success
+  end
+
+  test 'index filters by hostname' do
+    @relation.expects(:paginate).returns(@relation)
+    @relation.expects(:sort_by).returns(@relation)
+    ProfileSerializer.expects(:new)
+    ProfilesController.any_instance.expects(:policy_scope).returns(@relation)
+    Profile.expects(:includes).returns(@relation)
+    @relation.expects(:where).with(hosts: { name: 'foo' }).returns(@relation)
+    @relation.expects(:includes).with(:profile_hosts).returns(@relation)
+    get profiles_url(hostname: 'foo')
+
+    assert_response :success
+  end
+
+  test 'show' do
+    ProfilesController.any_instance.expects(:authorize)
+    Profile.expects(:friendly).returns(@relation)
+    @relation.expects(:find).with('1')
+    get profile_url(1)
+
+    assert_response :success
+  end
 end


### PR DESCRIPTION
@dLobatog WIP for feedback: This endpoint is required for the client. ~Should we be using subscription-manager ID or host fqdn (or allow either)? There's also an `insights_id` supplied by the canonical facts, but I'm not sure if we're storing that anywhere?~ it seems we don't store sub-man ID or insights_id anywhere, so hostname is the only identifier for hosts. Please correct me if that's not the case.

~(Also WIP for tests)~