### PR TITLE
Added a new label for pods

### DIFF
--- a/openshift/templates/compliance-backend.yml
+++ b/openshift/templates/compliance-backend.yml
@@ -70,6 +70,7 @@ objects:
         name: "${NAME}"
         labels:
           name: "${NAME}"
+          app: "${NAME}"
       spec:
         containers:
         - name: "${NAME}"

--- a/openshift/templates/compliance-consumer.yaml
+++ b/openshift/templates/compliance-consumer.yaml
@@ -41,6 +41,7 @@ objects:
         name: "${NAME}"
         labels:
           name: "${NAME}"
+          app: "${NAME}"
       spec:
         containers:
         - name: "${NAME}"

--- a/openshift/templates/compliance-prometheus-exporter.yaml
+++ b/openshift/templates/compliance-prometheus-exporter.yaml
@@ -62,6 +62,7 @@ objects:
         name: "${NAME}"
         labels:
           name: "${NAME}"
+          app: "${NAME}"
       spec:
         containers:
         - name: "${NAME}"

--- a/openshift/templates/compliance-sidekiq.yaml
+++ b/openshift/templates/compliance-sidekiq.yaml
@@ -52,6 +52,7 @@ objects:
         name: "${NAME}"
         labels:
           name: "${NAME}"
+          app: "${NAME}"
       spec:
         containers:
         - name: "${NAME}"


### PR DESCRIPTION
This PR adds new label `app` with the name of the deployment config. It's required for test automation.