### PR TITLE
Don't setup the db on every entry. Add tty for debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
   rails:
     build: .
     image: compliance-backend-rails
+    tty: true
+    stdin_open: true
     restart: on-failure
     entrypoint: ./entrypoint.sh
     ports:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,6 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /app/tmp/pids/server.pid
 
-bundle exec rake db:setup
+bundle exec rake db:migrate
 
 bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
`db:setup` re-creates the database, dropping all tables. This isn't what we want for development use.