### PR TITLE
Update host inventory response, add tests

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -34,7 +34,7 @@ class HostInventoryAPI
     end
     return false unless response.success?
 
-    JSON.parse(response.body)
+    JSON.parse(response.body).dig('data')&.first&.dig('host')
   rescue Faraday::ClientError => e
     Rails.logger.error e
   end
@@ -51,11 +51,11 @@ class HostInventoryAPI
   private
 
   def create_host_body
-    {
+    [{
       'facts': [{ 'facts': { 'fqdn': @host.name }, 'namespace': 'inventory' }],
       'fqdn': @host.name,
       'display_name': @host.name,
       'account': @account.account_number
-    }.to_json
+    }].to_json
   end
 end

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'host_inventory_api'
+
+class HostInventoryApiTest < ActiveSupport::TestCase
+  setup do
+    @account = OpenStruct.new(account_number: 'account_number')
+    @host = OpenStruct.new(id: 'hostid', account: 'account_number')
+    @url = 'http://localhost'
+    @b64_identity = '1234abcd'
+    @api = HostInventoryAPI.new(@host, @account, @url, @b64_identity)
+  end
+
+  test 'host_already_in_inventory no host' do
+    response = OpenStruct.new(body: { results: [] }.to_json)
+    Faraday.expects(:get).returns(response)
+    assert_nil @api.host_already_in_inventory
+  end
+
+  test 'host_already_in_inventory host exists' do
+    response = OpenStruct.new(body: { results: [@host.to_h] }.to_json)
+    Faraday.expects(:get).returns(response)
+    assert_equal @host.id, @api.host_already_in_inventory['id']
+  end
+
+  test 'create_host_in_inventory' do
+    response = OpenStruct.new(body: { data: [{ host: @host.to_h }] }.to_json,
+                              success?: true)
+    Faraday.expects(:post).returns(response)
+    assert_equal @host.id, @api.create_host_in_inventory['id']
+  end
+
+  test 'sync for host already in inventory' do
+    @api.expects(:host_already_in_inventory).returns(true)
+    @api.expects(:create_host_in_inventory).never
+    assert_equal @host, @api.sync
+  end
+
+  test 'sync for host not already in inventory' do
+    @api.expects(:host_already_in_inventory)
+    @api.expects(:create_host_in_inventory).returns(@host)
+    assert_equal @host, @api.sync
+  end
+end


### PR DESCRIPTION
@dLobatog The sidekiq ParseReportJob was failing for me. It seems the response and request format has changed. Now it seems we have the ability to send and receive multiple hosts at a time.