### PR TITLE
Import rules and rule results in bulk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem 'scoped_search'
 gem 'will_paginate'
 gem 'prometheus_exporter'
 
+gem 'activerecord-import'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 5.2.2)
       activesupport (= 5.2.2)
       arel (>= 9.0)
+    activerecord-import (1.0.1)
+      activerecord (>= 3.2)
     activestorage (5.2.2)
       actionpack (= 5.2.2)
       activerecord (= 5.2.2)
@@ -309,6 +311,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   bootsnap (>= 1.1.0)
   bullet
   byebug

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -4,7 +4,7 @@
 class ParseReportJob < ApplicationJob
   def perform(file, account, b64_identity)
     parser = XCCDFReportParser.new(file, account, b64_identity)
-    parser.save_rule_results
+    parser.save_all
   ensure
     File.delete(parser.report_path) if File.exist? parser.report_path
   end

--- a/app/services/concerns/xccdf_report/profiles.rb
+++ b/app/services/concerns/xccdf_report/profiles.rb
@@ -8,11 +8,13 @@ module XCCDFReport
 
     included do
       def profiles
+        return @profiles if @profiles.present?
+
         result = {}
         @benchmark.profiles.each do |id, oscap_profile|
           result[id] = oscap_profile.title if test_result.id.include?(id)
         end
-        result
+        @profiles = result
       end
 
       def save_profiles

--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module XCCDFReport
+  # Methods related to parsing rules
+  module Rules
+    extend ActiveSupport::Concern
+
+    included do
+      def rule_ids
+        test_result.rr.keys
+      end
+
+      def rule_objects
+        return @rule_objects if @rule_objects.present?
+
+        @rule_objects ||= @benchmark.items.select do |_, v|
+          v.is_a?(OpenSCAP::Xccdf::Rule)
+        end
+        @rule_objects = @rule_objects.map { |rule| rule[1] }
+      end
+
+      def rules_already_saved
+        return @rules_already_saved if @rules_already_saved.present?
+
+        @rules_already_saved = Rule.where(ref_id: rule_objects.map(&:id))
+                                   .includes(:profiles)
+      end
+
+      def add_profiles_to_old_rules(rules, new_profiles)
+        rules.each do |rule|
+          new_profiles.each do |profile|
+            rule.profiles << profile unless rule.profiles.include?(profile)
+          end
+        end
+      end
+
+      def new_rules
+        rule_objects.reject do |rule|
+          rules_already_saved.map(&:ref_id).include? rule.id
+        end
+      end
+
+      def save_rules
+        new_profiles = Profile.where(ref_id: profiles.keys)
+        add_profiles_to_old_rules(rules_already_saved, new_profiles)
+        Rule.import(
+          new_rules.each_with_object([]) do |rule, new_rules|
+            new_rule = Rule.new(profiles: new_profiles).from_oscap_object(rule)
+            new_rules << new_rule
+          end, recursive: true
+        )
+      end
+    end
+  end
+end

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -10,11 +10,9 @@ class RuleTest < ActiveSupport::TestCase
     fake_report = file_fixture('xccdf_report.xml').read
     @report_parser = ::XCCDFReportParser.new(fake_report, users(:test), 'foo')
     @rule_objects = @report_parser.rule_objects
-    @selinux_rule_id = 'xccdf_org.ssgproject.content_rule'\
-      '_selinux_all_devicefiles_labeled'
   end
 
   test 'creates rules from ruby-openscap Rule object' do
-    Rule.new.from_oscap_object(@rule_objects[@selinux_rule_id])
+    Rule.new.from_oscap_object(@rule_objects.first)
   end
 end

--- a/test/services/concerns/xccdf_report/rules_test.rb
+++ b/test/services/concerns/xccdf_report/rules_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf_report/rules'
+require 'openscap/source'
+require 'openscap/xccdf/benchmark'
+
+class RulesTest < ActiveSupport::TestCase
+  include XCCDFReport::Rules
+  include XCCDFReport::Profiles
+
+  def test_result
+    OpenStruct.new(id: ['xccdf_org.ssgproject.content_profile_standard'])
+  end
+
+  setup do
+    @report_path = 'test/fixtures/files/xccdf_report.xml'
+    @source = ::OpenSCAP::Source.new(@report_path)
+    @benchmark = ::OpenSCAP::Xccdf::Benchmark.new(@source)
+  end
+
+  test 'save all rules as new' do
+    assert_difference('Rule.count', 367) do
+      save_rules
+    end
+  end
+
+  test 'returns rules already saved in the report' do
+    rule = Rule.new.from_oscap_object(rule_objects.first)
+    rule.save
+    assert_includes rules_already_saved, rule
+  end
+
+  test 'save all rules and add profiles to pre existing one' do
+    profile = Profile.create(ref_id: profiles.keys.first,
+                             name: profiles.keys.first)
+    rule = Rule.new.from_oscap_object(rule_objects.first)
+    rule.save
+    assert_difference('Rule.count', 366) do
+      save_rules
+    end
+
+    assert_includes rule.profiles, profile
+  end
+end


### PR DESCRIPTION
** WIP **

This brings the parsing and importing of rules and rule_results down to only a few queries:

1 SELECT  * FROM hosts WHERE id == report host 
1 SELECT * FROM rules WHERE rules.ref_id IN (list of ref ids from report)  
1 INSERT INTO RULES (all rules)
1 INSERT INTO RULE_RESULTS (all rule results)

In practice this brings down the parsing to around 1s for a normal report, which should hopefully lower our sidekiq load.