### PR TITLE
Improve import performance

### DIFF
--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -35,8 +35,9 @@ module XCCDFReport
       end
 
       def new_rules
+        ref_ids = rules_already_saved.map(&:ref_id)
         rule_objects.reject do |rule|
-          rules_already_saved.map(&:ref_id).include? rule.id
+          ref_ids.include? rule.id
         end
       end
 


### PR DESCRIPTION
On my laptop in development; The following tests are starting with an empty compliance DB (system doesn't exist). The second `ParseReportJob` is only adding `RuleResult` objects, not adding a new system:

Before:

```
sidekiq_1     | 2019-03-25T15:02:48.118Z 1 TID-gni3gspll ParseReportJob JID-5663a4a771325a343c025fb6 INFO: start
sidekiq_1     | 2019-03-25T15:03:16.839Z 1 TID-gni3gspll ParseReportJob JID-5663a4a771325a343c025fb6 INFO: done: 28.721 sec
sidekiq_1     | 2019-03-25T15:03:28.610Z 1 TID-gni3gspv1 ParseReportJob JID-d0f323e7ffd503b262b524f5 INFO: start
sidekiq_1     | 2019-03-25T15:03:30.754Z 1 TID-gni3gspv1 ParseReportJob JID-d0f323e7ffd503b262b524f5 INFO: done: 2.144 sec
```

After:

```
sidekiq_1     | 2019-03-25T15:01:21.677Z 1 TID-gpkug1hyh ParseReportJob JID-3f6d7f97eb12dab9420b95e3 INFO: start
sidekiq_1     | 2019-03-25T15:01:28.186Z 1 TID-gpkug1hyh ParseReportJob JID-3f6d7f97eb12dab9420b95e3 INFO: done: 6.509 sec
sidekiq_1     | 2019-03-25T15:01:42.104Z 1 TID-gpkug1h65 ParseReportJob JID-a012dd7e5a8c922a594005bf INFO: start
sidekiq_1     | 2019-03-25T15:01:43.527Z 1 TID-gpkug1h65 ParseReportJob JID-a012dd7e5a8c922a594005bf INFO: done: 1.423 sec
```

That's a 4.4X performance improvement on initial upload!!