### PR TITLE
Add profiles to rules response in GraphQL

### DIFF
--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -12,6 +12,7 @@ RuleType = GraphQL::ObjectType.define do
   field :rationale, types.String
   field :description, !types.String
   field :severity, !types.String
+  field :profiles, -> { types[ProfileType] }
   field :compliant do
     type !types.Boolean
     argument :system_id, !types.String, 'Is a system compliant?'
@@ -144,7 +145,7 @@ SystemType = GraphQL::ObjectType.define do
       RuleResult.includes(:rule).where(
         host: host,
         result: %w[error fail notchecked]
-      ).map(&:rule)
+      ).map(&:rule).uniq
     }
   end
 


### PR DESCRIPTION
This allows us to retrieve the profile on the frontend for each rule. This is needed to construct the query for Remediations, which looks like this:

ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled - where `standard` is the profile for the rule with ref_id `xccdf_org....`