### PR TITLE
Set asset prefix in devel to /api/compliance/assets

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,8 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  config.assets.prefix = '/api/compliance/assets'
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
@dLobatog does this break `https://ci.foo.redhat.com:1337/api/compliance/graphiql` for you?