### PR TITLE
Basic API to remove hosts

### DIFF
--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -18,6 +18,13 @@ class SystemsController < ApplicationController
     end
   end
 
+  def destroy
+    host = Host.find(params[:id])
+    authorize host
+    host.destroy
+    render HostSerializer.new(host)
+  end
+
   private
 
   def csv_params

--- a/app/policies/host_policy.rb
+++ b/app/policies/host_policy.rb
@@ -10,6 +10,10 @@ class HostPolicy < ApplicationPolicy
     match_account?
   end
 
+  def destroy?
+    match_account?
+  end
+
   # Only show hosts in our user account
   class Scope < ::ApplicationPolicy::Scope
     def resolve

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   scope "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}" do
     resources :profiles, only: [:index, :show]
     resources :rule_results, only: [:index]
-    resources :systems, only: [:index]
+    resources :systems, only: [:index, :destroy]
     resources :rules, only: [:index, :show]
     mount Rswag::Api::Engine => '/'
     mount Rswag::Ui::Engine => '/'

--- a/test/controllers/systems_controller_test.rb
+++ b/test/controllers/systems_controller_test.rb
@@ -22,4 +22,24 @@ class SystemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test 'destroy hosts with authorized user' do
+    User.current = users(:test)
+    users(:test).update(account: accounts(:test))
+    hosts(:one).update(account: accounts(:test))
+    assert_difference('Host.count', -1) do
+      delete "#{systems_url}/#{hosts(:one).id}"
+    end
+    assert_response :success
+  end
+
+  test 'does not destroy hosts that do not belong to the user' do
+    User.current = users(:test)
+    users(:test).update(account: accounts(:test))
+    hosts(:one).update(account: nil)
+    assert_difference('Host.count', 0) do
+      delete "#{systems_url}/#{hosts(:one).id}"
+    end
+    assert_response :forbidden
+  end
 end


### PR DESCRIPTION
Call the API using `DELETE /systems/host-id-in-the-inventory`. It only allows to remove hosts within your account scope.