### PR TITLE
s/destroy/delete_all/ for active record dependents

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -4,9 +4,9 @@
 # these hosts will also show up in the insights-platform host inventory.
 class Host < ApplicationRecord
   scoped_search on: %i[id name account_id]
-  has_many :rule_results, dependent: :destroy
+  has_many :rule_results, dependent: :delete_all
   has_many :rules, through: :rule_results, source: :rule
-  has_many :profile_hosts, dependent: :destroy
+  has_many :profile_hosts, dependent: :delete_all
   has_many :profiles, through: :profile_hosts, source: :profile
   belongs_to :account, optional: true
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -6,9 +6,9 @@ class Profile < ApplicationRecord
   scoped_search on: %i[id name ref_id account_id compliance_threshold]
   friendly_id :ref_id, use: :slugged
 
-  has_many :profile_rules, dependent: :destroy
+  has_many :profile_rules, dependent: :delete_all
   has_many :rules, through: :profile_rules, source: :rule
-  has_many :profile_hosts, dependent: :destroy
+  has_many :profile_hosts, dependent: :delete_all
   has_many :hosts, through: :profile_hosts, source: :host
   belongs_to :policy, optional: true
   belongs_to :account, optional: true

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -6,9 +6,9 @@ class Rule < ApplicationRecord
   extend FriendlyId
   friendly_id :ref_id, use: :slugged
 
-  has_many :profile_rules, dependent: :destroy
+  has_many :profile_rules, dependent: :delete_all
   has_many :profiles, through: :profile_rules, source: :profile
-  has_many :rule_results, dependent: :destroy
+  has_many :rule_results, dependent: :delete_all
   has_many :hosts, through: :rule_results, source: :host
 
   validates :ref_id, uniqueness: true, presence: true


### PR DESCRIPTION
The difference, as I understand is:

destroy:

```rb
parent.children.each(&:destroy) # N queries, N callbacks
```

delete_all:

```rb
parent.children.delete_all # one query, no callbacks
```

We're not using any deletion callbacks that I could find, so we should be good.