### PR TITLE
Raise errors in sidekiq logs. Use db transactions

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -10,6 +10,6 @@ class ParseReportJob < ApplicationJob
   end
 
   rescue_from(OpenSCAP::OpenSCAPError) do |e|
-    Rails.logger.error "Failed to process message #{e}"
+    Sidekiq.logger.error "Failed to process message #{e}"
   end
 end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -34,7 +34,7 @@ class XCCDFReportParser
     begin
       @test_result = ::OpenSCAP::Xccdf::TestResult.new(source)
     rescue ::OpenSCAP::OpenSCAPError => e
-      Rails.logger.error('Error: ', e)
+      Sidekiq.logger.error('Error: ', e)
     end
   end
 
@@ -66,10 +66,12 @@ class XCCDFReportParser
   end
 
   def save_all
-    save_profiles
-    save_rules
-    save_host
-    save_rule_results
+    Host.transaction do
+      save_profiles
+      save_rules
+      save_host
+      save_rule_results
+    end
   end
 
   def save_rule_results

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -10,24 +10,26 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     @url = 'http://localhost'
     @b64_identity = '1234abcd'
     @api = HostInventoryAPI.new(@host, @account, @url, @b64_identity)
+    @connection = mock('faraday_connection')
+    HostInventoryAPI.any_instance.stubs(:connection).returns(@connection)
   end
 
   test 'host_already_in_inventory no host' do
     response = OpenStruct.new(body: { results: [] }.to_json)
-    Faraday.expects(:get).returns(response)
+    @connection.expects(:get).returns(response)
     assert_nil @api.host_already_in_inventory
   end
 
   test 'host_already_in_inventory host exists' do
     response = OpenStruct.new(body: { results: [@host.to_h] }.to_json)
-    Faraday.expects(:get).returns(response)
+    @connection.expects(:get).returns(response)
     assert_equal @host.id, @api.host_already_in_inventory['id']
   end
 
   test 'create_host_in_inventory' do
     response = OpenStruct.new(body: { data: [{ host: @host.to_h }] }.to_json,
                               success?: true)
-    Faraday.expects(:post).returns(response)
+    @connection.expects(:post).returns(response)
     assert_equal @host.id, @api.create_host_in_inventory['id']
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,4 +43,3 @@ module ActionDispatch
     end
   end
 end
-


### PR DESCRIPTION
This should help with tracking down inventory API related outages/errors.