### PR TITLE
Always save the host, even if it exists in the inventory

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -38,8 +38,8 @@ class HostInventoryAPI
     unless host_already_in_inventory
       new_host = create_host_in_inventory
       @host.id = new_host.dig('id')
-      @host.save
     end
+    @host.save
     @host
   end
 


### PR DESCRIPTION
https://github.com/RedHatInsights/compliance-backend/pull/100 causes a bug which, on compliance report upload, the profile and rules get saved, but the Host and RuleResults don't get saved.