### PR TITLE
Always assign inventory ID to a new compliance DB host

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -35,10 +35,8 @@ class HostInventoryAPI
   end
 
   def sync
-    unless host_already_in_inventory
-      new_host = create_host_in_inventory
-      @host.id = new_host.dig('id')
-    end
+    inventory_host = host_already_in_inventory || create_host_in_inventory
+    @host.id ||= inventory_host.dig('id')
     @host.save
     @host
   end

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -7,9 +7,10 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   setup do
     @account = OpenStruct.new(account_number: 'account_number')
     @host = OpenStruct.new(id: 'hostid', account: 'account_number')
+    @new_host = OpenStruct.new(account: 'account_number')
     @url = 'http://localhost'
     @b64_identity = '1234abcd'
-    @api = HostInventoryAPI.new(@host, @account, @url, @b64_identity)
+    @api = HostInventoryAPI.new(@new_host, @account, @url, @b64_identity)
     @connection = mock('faraday_connection')
     HostInventoryAPI.any_instance.stubs(:connection).returns(@connection)
   end
@@ -34,7 +35,7 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   end
 
   test 'sync for host already in inventory' do
-    @api.expects(:host_already_in_inventory).returns(true)
+    @api.expects(:host_already_in_inventory).returns(@host)
     @api.expects(:create_host_in_inventory).never
     assert_equal @host, @api.sync
   end


### PR DESCRIPTION
Hopefully this will fix the issues we've been seeing in the compliance systems table