### PR TITLE
Various performance improvements for report parsing job

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -5,8 +5,7 @@ class ParseReportJob < ApplicationJob
   def perform(file, account, b64_identity)
     parser = XCCDFReportParser.new(file, account, b64_identity)
     parser.save_all
-  ensure
-    File.delete(parser.report_path) if File.exist? parser.report_path
+    GC.start
   end
 
   rescue_from(OpenSCAP::OpenSCAPError) do |e|

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -5,9 +5,9 @@
 class Host < ApplicationRecord
   scoped_search on: %i[id name account_id]
   scoped_search on: :compliant, ext_method: 'filter_by_compliance',
-    only_explicit: true
+                only_explicit: true
   scoped_search on: :compliance_score, ext_method: 'filter_by_compliance_score',
-    only_explicit: true
+                only_explicit: true
   has_many :rule_results, dependent: :delete_all
   has_many :rules, through: :rule_results, source: :rule
   has_many :profile_hosts, dependent: :delete_all

--- a/app/services/concerns/xccdf_report/xml_report.rb
+++ b/app/services/concerns/xccdf_report/xml_report.rb
@@ -19,8 +19,8 @@ module XCCDFReport
         report_xml.namespaces['xmlns']
       end
 
-      def report_xml
-        @report_xml ||= File.open(@report_path) { |f| Nokogiri::XML(f) }
+      def report_xml(report_contents = '')
+        @report_xml ||= Nokogiri::XML.parse(report_contents)
       end
     end
   end

--- a/test/services/concerns/xccdf_report/xml_report_test.rb
+++ b/test/services/concerns/xccdf_report/xml_report_test.rb
@@ -7,7 +7,7 @@ class XMLReportTest < ActiveSupport::TestCase
   include XCCDFReport::XMLReport
 
   setup do
-    @report_path = 'test/fixtures/files/xccdf_report.xml'
+    report_xml(File.read('test/fixtures/files/xccdf_report.xml'))
   end
 
   test 'report_xml parses the XML report' do

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -141,7 +141,9 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
       rule = Rule.create(ref_id: @arbitrary_rules[0])
       rule.profiles << profiles(:one)
       assert_nothing_raised do
-        @report_parser.add_profiles_to_old_rules([rule], profiles)
+        @report_parser.add_profiles_to_old_rules(
+          Rule.where(ref_id: rule.ref_id), profiles
+        )
       end
       assert_equal 2, rule.profiles.count
       assert_includes rule.profiles, profiles(:one)


### PR DESCRIPTION
1. Running GC collection as soon as the job finishes. 
2. Storing the file in memory. This saves us I/O as we have to store a file in the filesystem, then read from it (Nokogiri), etc. Now `OpenScap::Source` is created from the report string, and so is Nokogiri. 
3. Using _ids rather than objects wherever possible, creating object with `host_id`, selecting only `id` form the tables.
4. In `add_profiles_to_old_rules`, I prefetch all profiles now so we can check if `rules` are in those profiles instead of fetching them for every row.

Some positive benchmarks - performance wise, the improvement is around 28%, from 1.1s on average (10 runs) to 0.72s on my computer. 
Memory wise - using memory_profiler, we create this many objects:
https://gist.github.com/dLobatog/aa20068c6dd784ea992edb35ef3b1efe
after *all* of the changes here, we got it 1 order of magnitude smaller.
https://gist.github.com/dLobatog/77281285a3e4d26530a5c08553fc0e78

Before:
```
Total allocated: 33630302 bytes (329357 objects)
Total retained:  2009203 bytes (23293 objects)
```
After:
```
Total allocated: 5055315 bytes (61207 objects)
Total retained:  1548926 bytes (18842 objects)

```