### PR TITLE
Use Sidekiq reliable fetch strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ gem 'prometheus_exporter'
 gem 'activerecord-import'
 gem 'oj'
 gem 'newrelic_rpm'
+gem 'gitlab-sidekiq-fetcher', require: 'sidekiq-reliable-fetch'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     exception_notification (4.3.0)
       actionmailer (>= 4.0, < 6)
       activesupport (>= 4.0, < 6)
-    excon (0.63.0)
+    excon (0.64.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     fast_jsonapi (1.5)
@@ -135,6 +135,8 @@ GEM
     ffi (1.10.0)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
+    gitlab-sidekiq-fetcher (0.4.0)
+      sidekiq (~> 5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.7.0)
@@ -179,7 +181,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
-    oj (3.7.11)
+    oj (3.7.12)
     openscap (0.4.8)
       ffi (>= 1.0.9)
     parallel (1.17.0)
@@ -350,6 +352,7 @@ DEPENDENCIES
   faraday
   fast_jsonapi
   friendly_id (~> 5.2.4)
+  gitlab-sidekiq-fetcher
   graphiql-rails
   graphql
   listen (>= 3.0.5, < 3.2)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
 Sidekiq.configure_server do |config|
+  Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
   config.redis = {
     url: "redis://#{Settings.redis_url}",
     network_timeout: 5 # Default is 1 second, let's be more lenient


### PR DESCRIPTION
https://gitlab.com/gitlab-org/sidekiq-reliable-fetch/tree/master

I tested this strategy the following way:

```ruby
class LongRunningJob
  include Sidekiq::Worker

  def perform
    puts('hello')
    sleep 60
    puts('bye')
  end
end
```
Then I decided to run a job, and kill sidekiq in the middle of the `sleep`:

```
2019-04-16T07:25:42.369Z 24215 TID-gspbbki7z LongRunningJob JID-1d2eb707667a6b9e6bb31534 INFO: start
hello

^C <- SIGINT SENT

2019-04-16T07:25:45.658Z 24215 TID-gspa9msmv INFO: Shutting down
2019-04-16T07:25:45.659Z 24215 TID-gspa9msmv INFO: Terminating quiet workers
2019-04-16T07:25:45.659Z 24215 TID-gspbbknyj INFO: Scheduler exiting...
2019-04-16T07:25:45.760Z 24215 TID-gspa9msmv INFO: Pausing to allow workers to finish...

2019-04-16T07:25:53.574Z 24215 TID-gspa9msmv WARN: Terminating 1 busy worker threads
2019-04-16T07:25:53.575Z 24215 TID-gspa9msmv WARN: Work still in progress [#<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"1d2eb707667a6b9e6bb31534\",\"created_at\":1555399536.917682,\"enqueued_at\":1555399536.918846}">]
2019-04-16T07:25:53.576Z 24215 TID-gspa9msmv INFO: Pushed 1 jobs back to Redis
2019-04-16T07:25:53.578Z 24215 TID-gspbbki7z LongRunningJob JID-1d2eb707667a6b9e6bb31534 INFO: fail: 11.21 sec
2019-04-16T07:25:53.579Z 24215 TID-gspa9msmv INFO: Bye!
```
The next time I run `sidekiq`, the old job is picked up and started again. 
Using SIGTERM it also works, which is the signal sent by OpenShift when our pod gets evicted (https://docs.openshift.com/container-platform/3.3/dev_guide/deployments/advanced_deployment_strategies.html)

``` 
2019-04-16T07:46:21.352Z 28999 TID-gol8pgxjr LongRunningJob JID-036c8e731d84ff140769cfcb INFO: start
hello
2019-04-16T07:46:22.437Z 28999 TID-gol8pgyu7 LongRunningJob JID-c1285f719c7cb633cd2ce7cc INFO: start
hello
2019-04-16T07:46:22.682Z 28999 TID-gol8pgy4n LongRunningJob JID-0d024f2edf0a0682b30fd8ea INFO: start
hello
2019-04-16T07:46:22.904Z 28999 TID-gol8pgyef LongRunningJob JID-51f8d2db0f249cb4fbff5f72 INFO: start
hello
2019-04-16T07:46:23.129Z 28999 TID-gol8pgz8z LongRunningJob JID-b2781d2949e5ff839b452f52 INFO: start
hello
2019-04-16T07:46:23.361Z 28999 TID-gol8pgy9n LongRunningJob JID-36940628ef98345daf477f06 INFO: start
hello
2019-04-16T07:46:23.582Z 28999 TID-gol8pgxxf LongRunningJob JID-5e63ff329a059a3d486dc203 INFO: start
hello
2019-04-16T07:46:52.310Z 28999 TID-gol7ubgz7 INFO: Shutting down
2019-04-16T07:46:52.312Z 28999 TID-gol7ubgz7 INFO: Terminating quiet workers
2019-04-16T07:46:52.314Z 28999 TID-gol8pgz4r INFO: Scheduler exiting...
2019-04-16T07:46:52.417Z 28999 TID-gol7ubgz7 INFO: Pausing to allow workers to finish...
2019-04-16T07:47:00.230Z 28999 TID-gol7ubgz7 WARN: Terminating 7 busy worker threads
2019-04-16T07:47:00.232Z 28999 TID-gol7ubgz7 WARN: Work still in progress [#<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"b2781d2949e5ff839b452f52\",\"created_at\":1555400783.128693,\"enqueued_at\":1555400783.128766}">, #<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"c1285f719c7cb633cd2ce7cc\",\"created_at\":1555400782.435561,\"enqueued_at\":1555400782.435703}">, #<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"36940628ef98345daf477f06\",\"created_at\":1555400783.360855,\"enqueued_at\":1555400783.360906}">, #<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"51f8d2db0f249cb4fbff5f72\",\"created_at\":1555400782.904011,\"enqueued_at\":1555400782.904046}">, #<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"5e63ff329a059a3d486dc203\",\"created_at\":1555400783.581484,\"enqueued_at\":1555400783.581584}">, #<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"0d024f2edf0a0682b30fd8ea\",\"created_at\":1555400782.681578,\"enqueued_at\":1555400782.681628}">, #<struct Sidekiq::BasicFetch::UnitOfWork queue="queue:default", job="{\"class\":\"LongRunningJob\",\"args\":[],\"retry\":3,\"queue\":\"default\",\"backtrace\":true,\"unique\":true,\"jid\":\"036c8e731d84ff140769cfcb\",\"created_at\":1555400781.350169,\"enqueued_at\":1555400781.350608}">]
2019-04-16T07:47:00.235Z 28999 TID-gol7ubgz7 INFO: Pushed 7 jobs back to Redis
2019-04-16T07:47:00.238Z 28999 TID-gol8pgyu7 LongRunningJob JID-c1285f719c7cb633cd2ce7cc INFO: fail: 37.8 sec
2019-04-16T07:47:00.239Z 28999 TID-gol8pgy9n LongRunningJob JID-36940628ef98345daf477f06 INFO: fail: 36.878 sec
2019-04-16T07:47:00.241Z 28999 TID-gol8pgz8z LongRunningJob JID-b2781d2949e5ff839b452f52 INFO: fail: 37.112 sec
2019-04-16T07:47:00.245Z 28999 TID-gol8pgyef LongRunningJob JID-51f8d2db0f249cb4fbff5f72 INFO: fail: 37.34 sec
2019-04-16T07:47:00.248Z 28999 TID-gol7ubgz7 INFO: Bye!
2019-04-16T07:47:00.250Z 28999 TID-gol8pgxxf LongRunningJob JID-5e63ff329a059a3d486dc203 INFO: fail: 36.668 sec
2019-04-16T07:47:00.252Z 28999 TID-gol8pgy4n LongRunningJob JID-0d024f2edf0a0682b30fd8ea INFO: fail: 37.57 sec
2019-04-16T07:47:00.254Z 28999 TID-gol8pgxjr LongRunningJob JID-036c8e731d84ff140769cfcb INFO: fail: 38.902 sec
```