### PR TITLE
Zlib (de)compress the report string

### DIFF
--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -33,7 +33,7 @@ class ComplianceReportsConsumer < ApplicationConsumer
   def enqueue_job
     if validate == 'success'
       job = ParseReportJob.perform_async(
-        @file_contents,
+        ActiveSupport::Gzip.compress(@file_contents),
         @value['account'],
         @value['b64_identity']
       )

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -5,7 +5,8 @@ class ParseReportJob
   include Sidekiq::Worker
 
   def perform(file, account, b64_identity)
-    parser = XCCDFReportParser.new(file, account, b64_identity)
+    parser = XCCDFReportParser.new(ActiveSupport::Gzip.decompress(file),
+                                   account, b64_identity)
     parser.save_all
     GC.start
   rescue OpenSCAP::OpenSCAPError => e


### PR DESCRIPTION
This brings the data sent over to redis and back for an example report from 2019977 bytes to 221365 bytes, one order of magnitude less. The compression/decompression speed penalty is negligible.