### PR TITLE
Use time from xccdf report, not created_at for RuleResult

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -39,7 +39,7 @@ class Profile < ApplicationRecord
           SELECT rr2.*,
              rank() OVER (
                     PARTITION BY rule_id, host_id
-                    ORDER BY created_at DESC
+                    ORDER BY end_time DESC, created_at DESC
              )
           FROM rule_results rr2
           WHERE rr2.host_id = ? AND rr2.rule_id IN

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -33,7 +33,7 @@ class Rule < ApplicationRecord
           SELECT rr2.*,
              rank() OVER (
                     PARTITION BY rule_id, host_id
-                    ORDER BY created_at DESC
+                    ORDER BY end_time DESC, created_at DESC
              )
           FROM rule_results rr2
           WHERE rr2.host_id = ? AND rr2.rule_id = ?

--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -75,7 +75,7 @@ ProfileType = GraphQL::ObjectType.define do
       rule_ids = profile.rules.map(&:id)
       rule_results = RuleResult.where(rule_id: rule_ids,
                                       host_id: Host.find(args['system_id']).id)
-      rule_results.maximum(:updated_at) || 'Never'
+      rule_results.maximum(:end_time) || 'Never'
     }
   end
 end
@@ -145,7 +145,7 @@ SystemType = GraphQL::ObjectType.define do
         rule_results = obj.rule_results
       end
 
-      rule_results.maximum(:updated_at) || 'Never'
+      rule_results.maximum(:end_time) || 'Never'
     }
   end
 end

--- a/app/serializers/rule_result_serializer.rb
+++ b/app/serializers/rule_result_serializer.rb
@@ -3,7 +3,7 @@
 # JSON API serialization for an OpenSCAP RuleResult
 class RuleResultSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :created_at, :updated_at, :result
+  attributes :start_time, :end_time, :result
   belongs_to :host
   belongs_to :rule
 end

--- a/app/services/image_scanner.rb
+++ b/app/services/image_scanner.rb
@@ -41,7 +41,7 @@ class ImageScanner
       "#{image_name}:latest xccdf eval --fetch-remote-resources"\
       " --results #{report_filepath} --profile #{@profile} #{policy}"
     )
-    Sidekiq.logger.error('Error running oscap-docker: ', err)
-    Sidekiq.logger.info('Output from oscap-docker: ', out)
+    Sidekiq.logger.error("Error running oscap-docker: #{err}")
+    Sidekiq.logger.info("Output from oscap-docker: #{out}")
   end
 end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -33,7 +33,7 @@ class XCCDFReportParser
     begin
       @test_result = ::OpenSCAP::Xccdf::TestResult.new(source)
     rescue ::OpenSCAP::OpenSCAPError => e
-      Sidekiq.logger.error('Error: ', e)
+      Sidekiq.logger.error("Error: #{e}")
     end
   end
 
@@ -61,11 +61,11 @@ class XCCDFReportParser
   end
 
   def start_time
-    @start_time ||= DateTime.parse(test_result_node['start-time'])
+    @start_time ||= DateTime.parse(test_result_node['start-time']).in_time_zone
   end
 
   def end_time
-    @end_time ||= DateTime.parse(test_result_node['end-time'])
+    @end_time ||= DateTime.parse(test_result_node['end-time']).in_time_zone
   end
 
   def rule_results

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,0 @@
----
-ignore:
-  - app/models/schema.rb # don't test the schema! https://github.com/rmosolgo/graphql-ruby/blob/master/guides/schema/testing.md#dont-test-the-schema
-  - app/serializers # these just contain the description of the attributes of the API responses, no code (https://github.com/Netflix/fast_jsonapi)
-  - lib/graphql_collector.rb # empty class that has to be there for prometheus integration
-...

--- a/db/migrate/20190422190831_add_time_to_rule_results.rb
+++ b/db/migrate/20190422190831_add_time_to_rule_results.rb
@@ -1,0 +1,6 @@
+class AddTimeToRuleResults < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rule_results, :start_time, :datetime
+    add_column :rule_results, :end_time, :datetime
+  end
+end

--- a/test/fixtures/rule_results.yml
+++ b/test/fixtures/rule_results.yml
@@ -3,9 +3,9 @@
 one:
   host_id: one
   rule_id: one
-  result: passed
+  result: pass
 
 two:
   host_id: two
   rule_id: two
-  result: failed
+  result: fail

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -10,6 +10,7 @@ class ProfileTest < ActiveSupport::TestCase
   setup do
     hosts(:one).profiles << profiles(:one)
     profiles(:one).update(rules: [rules(:one), rules(:two)])
+    profiles(:one).stubs(:hosts).returns([hosts(:one)])
   end
 
   test 'host is not compliant there are no results for all rules' do
@@ -38,6 +39,10 @@ class ProfileTest < ActiveSupport::TestCase
     RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass')
     RuleResult.create(rule: rules(:two), host: hosts(:one), result: 'fail')
     assert 0.5, profiles(:one).compliance_score(hosts(:one))
+  end
+
+  test 'score with non-blank hosts' do
+    assert_equal 0, profiles(:one).score
   end
 
   context 'threshold' do

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -15,4 +15,14 @@ class RuleTest < ActiveSupport::TestCase
   test 'creates rules from ruby-openscap Rule object' do
     Rule.new.from_oscap_object(@rule_objects.first)
   end
+
+  test 'host one is not compliant?' do
+    assert_not rules(:one).compliant?(hosts(:one))
+  end
+
+  test 'host one is compliant?' do
+    rule_result = rule_results(:one)
+    RuleResult.expects(:find_by_sql).returns([rule_result])
+    assert rules(:one).compliant?(hosts(:one))
+  end
 end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -102,6 +102,11 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
     assert_equal(16.220237731933594, @report_parser.score)
   end
 
+  test 'handles parsing errors' do
+    OpenSCAP::Xccdf::TestResult.expects(:new).raises(OpenSCAP::OpenSCAPError)
+    @report_parser.test_result
+  end
+
   context 'rules' do
     setup do
       @arbitrary_rules = [

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  add_filter 'app/models/schema.rb' # don't test the schema! https://github.com/rmosolgo/graphql-ruby/blob/master/guides/schema/testing.md#dont-test-the-schema
+  add_filter 'app/serializers' # these just contain the description of the attributes of the API responses, no code (https://github.com/Netflix/fast_jsonapi)
+  add_filter 'lib/graphql_collector.rb' # empty class that has to be there for prometheus integration
+end
 
 if ENV['CODECOV_TOKEN']
   require 'codecov'


### PR DESCRIPTION
- Adds the start/end time to RuleResult
- Parses start/end time from TestResult xccdf report
- Updates graphql queries to use end_time as the date of last scan

Issues:
There is currently no time zone info in the report. It appears to be the local time zone of the machine on which it was run. Perhaps we could get this from metadata? For now though, I think this is a huge improvement. You can upload a report generated yesterday, and that time difference is reflected in the DB and UI.