### PR TITLE
Use Rails.cache for compliance results queries

### DIFF
--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -10,9 +10,9 @@ class ComplianceReportsConsumer < ApplicationConsumer
     logger.info "Received message, enqueueing: #{message.value}"
     download_file
     enqueue_job
-  rescue SafeDownloader::DownloadError => error
+  rescue SafeDownloader::DownloadError => e
     logger.error "Error parsing report: #{@value['payload_id']}"\
-      " - #{error.message}"
+      " - #{e.message}"
     send_validation('failure')
   end
 

--- a/app/services/concerns/xccdf_report/profiles.rb
+++ b/app/services/concerns/xccdf_report/profiles.rb
@@ -33,6 +33,7 @@ module XCCDFReport
 
       def host_new_profiles
         save_profiles.select do |profile| # rubocop:disable Style/InverseMethods
+          Rails.cache.delete("#{profile.id}/#{@host.id}/results")
           !profile.hosts.map(&:id).include? @host.id
         end
       end

--- a/app/services/image_scanner.rb
+++ b/app/services/image_scanner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Scanner JOb for Openshift Images
 class ImageScanner
   def initialize(imagestream, profile, b64_identity)
     @imagestream = imagestream

--- a/app/services/safe_downloader.rb
+++ b/app/services/safe_downloader.rb
@@ -22,11 +22,11 @@ class SafeDownloader
       tempfile = Tempfile.create(path)
       IO.copy_stream(downloaded_file, tempfile.path)
       tempfile
-    rescue *DOWNLOAD_ERRORS => error
-      raise DownloadError if error.instance_of?(RuntimeError) &&
-                             error.message !~ /redirection/
+    rescue *DOWNLOAD_ERRORS => e
+      raise DownloadError if e.instance_of?(RuntimeError) &&
+                             e.message !~ /redirection/
 
-      raise DownloadError, "download failed (#{url}): #{error.message}"
+      raise DownloadError, "download failed (#{url}): #{e.message}"
     end
 
     private

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -69,6 +69,9 @@ class XCCDFReportParser
       save_profiles
       save_rules
       save_host
+      rules_already_saved.each do |rule|
+        Rails.cache.delete("#{rule.id}/#{@host.id}/compliant")
+      end
       save_rule_results
     end
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,7 @@ Rails.application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
+  config.cache_store = :null_store
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -28,7 +28,7 @@ class MetadataTest < ActionDispatch::IntegrationTest
   context 'pagination' do
     setup do
       authenticate
-      Profile.update_all(account_id: accounts(:test).id)
+      Profile.all.find_each { |p| p.update(account_id: accounts(:test).id) }
     end
 
     should 'return correct pagination links' do

--- a/test/policies/account_policy_test.rb
+++ b/test/policies/account_policy_test.rb
@@ -4,7 +4,8 @@ require 'test_helper'
 
 class AccountPolicyTest < ActiveSupport::TestCase
   test 'only accounts within user scope should be accessible' do
-    assert_not_includes Pundit.policy_scope(users(:test), Account), accounts(:test)
+    assert_not_includes Pundit.policy_scope(users(:test), Account),
+                        accounts(:test)
     users(:test).account = accounts(:test)
     assert_includes Pundit.policy_scope(users(:test), Account), accounts(:test)
   end


### PR DESCRIPTION
Before: 
https://gist.github.com/dLobatog/0578f5bacc66f869a871757309a9a763
https://gist.github.com/dLobatog/c3b65aa9ea4f4f81356c5ecac9846cc7
After:
https://gist.github.com/dLobatog/3274a5854dcb43682a22b51404d427d9
https://gist.github.com/dLobatog/289d5b7f12a2728d2a4e045858a8fd65

It basically turns requests that take seconds into requests that take <100ms. The difference is very noticeable. It should also alleviate the load on our web backend pods. 