### PR TITLE
Call trim after GC.start

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,8 @@ gem 'oj'
 gem 'newrelic_rpm'
 gem 'gitlab-sidekiq-fetcher', require: 'sidekiq-reliable-fetch'
 
+gem 'malloc_trim'
+
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    malloc_trim (0.1.0)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     metaclass (0.0.4)
@@ -356,6 +357,7 @@ DEPENDENCIES
   graphiql-rails
   graphql
   listen (>= 3.0.5, < 3.2)
+  malloc_trim
   minitest-reporters
   mocha
   newrelic_rpm

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -8,8 +8,10 @@ class ParseReportJob
     parser = XCCDFReportParser.new(ActiveSupport::Gzip.decompress(file),
                                    account, b64_identity)
     parser.save_all
-    GC.start
   rescue OpenSCAP::OpenSCAPError => e
     Sidekiq.logger.error "Failed to process message #{e}"
+  ensure
+    GC.start
+    MallocTrim.trim
   end
 end


### PR DESCRIPTION
In my local tests, report parsing grows the memory, and this will make the memory usage go back down, since it doesn't automatically.