### PR TITLE
Remove double slash from inventory URI

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -9,7 +9,7 @@ require 'json'
 class HostInventoryAPI
   def initialize(host, account, url, b64_identity)
     @host = host
-    @url = "#{URI.parse(url)}/#{ENV['PATH_PREFIX']}/inventory/v1/hosts"
+    @url = "#{URI.parse(url)}#{ENV['PATH_PREFIX']}/inventory/v1/hosts"
     @account = account
     @b64_identity = b64_identity
   end


### PR DESCRIPTION
Before: `https://ci.cloud.paas.upshift.redhat.com//api/inventory/v1/hosts`

After: `https://ci.cloud.paas.upshift.redhat.com/api/inventory/v1/hosts`

The one with two slashes returns a 404.