### PR TITLE
Use delete instead of delete! in case \n isn't found

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -11,7 +11,10 @@ class Rule < ApplicationRecord
   has_many :rule_results, dependent: :delete_all
   has_many :hosts, through: :rule_results, source: :host
 
+  validates :title, presence: true
   validates :ref_id, uniqueness: true, presence: true
+  validates :description, presence: true
+  validates :severity, presence: true
   validates_associated :profile_rules
   validates_associated :rule_results
 

--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -19,11 +19,11 @@ class RuleOscapObject
   end
 
   def description
-    @description ||= @rule_xml.at_css('description').text.delete!("\n")
+    @description ||= @rule_xml.at_css('description').text.delete("\n")
   end
 
   def rationale
-    @rationale ||= @rule_xml.at_css('rationale').children.text.delete!("\n")
+    @rationale ||= @rule_xml.at_css('rationale').children.text.delete("\n")
   end
 end
 
@@ -76,7 +76,7 @@ module XCCDFReport
       def save_rules
         new_profiles = Profile.where(ref_id: profiles.keys)
         add_profiles_to_old_rules(rules_already_saved, new_profiles)
-        Rule.import(
+        Rule.import!(
           new_rules.each_with_object([]) do |rule, new_rules|
             new_rule = Rule.new(profiles: new_profiles).from_oscap_object(rule)
             new_rules << new_rule

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -74,7 +74,7 @@ class XCCDFReportParser
 
   def save_rule_results
     results = rule_results.map(&:result)
-    RuleResult.import(
+    RuleResult.import!(
       rule_results_rule_ids.zip(results)
       .each_with_object([]) do |rule_result, rule_results|
         rule_results << RuleResult.new(host: host_id, rule_id: rule_result[0],

--- a/test/services/csv_exporter_test.rb
+++ b/test/services/csv_exporter_test.rb
@@ -8,12 +8,12 @@ class CsvExporterTest < ActiveSupport::TestCase
     assert_equal "Id\n", result.next
     assert_equal result.count, Rule.count + 1
     assert_difference('CsvExporter.export(Rule, [:id]).count') do
-      Rule.create(ref_id: SecureRandom.uuid)
+      Rule.new(ref_id: SecureRandom.uuid).save(validate: false)
     end
   end
 
   test 'ignore limit' do
-    10.times { Rule.create(ref_id: SecureRandom.uuid) }
+    10.times { Rule.new(ref_id: SecureRandom.uuid).save(validate: false) }
     result = CsvExporter.export(Rule.all.limit(5), [:id])
     assert result.count > 5
   end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -126,8 +126,8 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
     end
 
     should 'save new rules in the database, ignore old rules' do
-      rule1 = Rule.create(ref_id: @arbitrary_rules[0])
-      rule2 = Rule.create(ref_id: @arbitrary_rules[1])
+      (rule1 = Rule.new(ref_id: @arbitrary_rules[0])).save(validate: false)
+      (rule2 = Rule.new(ref_id: @arbitrary_rules[1])).save(validate: false)
       assert_difference('Rule.count', 365) do
         new_rules = @report_parser.save_rules
         old_rules_found = Rule.where(id: new_rules.ids).find_all do |rule|
@@ -138,7 +138,7 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
     end
 
     should 'not try to append already assigned profiles to a rule' do
-      rule = Rule.create(ref_id: @arbitrary_rules[0])
+      (rule = Rule.new(ref_id: @arbitrary_rules[0])).save(validate: false)
       rule.profiles << profiles(:one)
       assert_nothing_raised do
         @report_parser.add_profiles_to_old_rules(


### PR DESCRIPTION
delete! returns nil if the substring isn't found. delete always returns
the string, regardless of if the substring is found and deleted