### PR TITLE
Ensure User.current is nil before tests, not after

### DIFF
--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -7,7 +7,7 @@ require 'test_helper'
 # ActionDispatch::IntegrationTest, it is testing the Profiles controller
 # instead for the time being
 class AuthenticationTest < ActionDispatch::IntegrationTest
-  teardown do
+  setup do
     User.current = nil
   end
 


### PR DESCRIPTION
To reliably reproduce the test failure, run tests with seed 29935. This PR fixes that failure.