### PR TITLE
Return nil when profile not found in GraphQL

### DIFF
--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -112,14 +112,14 @@ SystemType = GraphQL::ObjectType.define do
     type !types.Int
     argument :profile_id, types.String, 'Filter results by profile ID'
     resolve lambda { |obj, args, _ctx|
-      obj.rules_passed(Profile.find(args['profile_id']))
+      obj.rules_passed(Profile.find_by(id: args['profile_id']))
     }
   end
   field :rules_failed do
     type !types.Int
     argument :profile_id, types.String, 'Filter results by profile ID'
     resolve lambda { |obj, args, _ctx|
-      obj.rules_failed(Profile.find(args['profile_id']))
+      obj.rules_failed(Profile.find_by(id: args['profile_id']))
     }
   end
 


### PR DESCRIPTION
Using `find` will throw an exception and make GraphQL return a 404 automatically if you don't pass a profile_id argument to the fields changed here. We just want that to be `nil` so that we find `rules_passed` and `failed` for all profiles.