### PR TITLE
Allow nil Rule description in graphql

### DIFF
--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -10,7 +10,7 @@ RuleType = GraphQL::ObjectType.define do
   field :title, !types.String
   field :ref_id, !types.String
   field :rationale, types.String
-  field :description, !types.String
+  field :description, types.String
   field :severity, !types.String
   field :profiles, -> { types[ProfileType] }
   field :compliant do


### PR DESCRIPTION
While we have DB validations for `presence: true` on description, we have some old `Rule` objects in the prod DB that do have nil descriptions. This should fix the graphql response for that case.