### PR TITLE
Add health check endpoint to the kafka consumer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'docker-api'
 gem 'faraday'
 gem 'friendly_id', '~> 5.2.4'
 gem 'scoped_search'
+gem 'sinatra'
 gem 'will_paginate'
 gem 'prometheus_exporter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
     msgpack (1.2.10)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    mustermann (1.0.3)
     newrelic_rpm (6.2.0.354)
     nio4r (2.3.1)
     nokogiri (1.10.3)
@@ -300,6 +301,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
     slack-notifier (2.3.2)
     slop (3.6.0)
     spring (2.0.2)
@@ -316,6 +322,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    tilt (2.0.9)
     tty-color (0.4.3)
     tty-command (0.8.2)
       pastel (~> 0.7.0)
@@ -380,6 +387,7 @@ DEPENDENCIES
   shoulda-context
   shoulda-matchers
   sidekiq
+  sinatra
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+ping = Thread.new do
+  require 'sinatra'
+
+  get '/' do
+  end
+
+  Sinatra::Application.run!
+end
+
 # Receives messages from the Kafka topic, converts them into jobs
 # for processing
 class ComplianceReportsConsumer < ApplicationConsumer


### PR DESCRIPTION
Towards https://projects.engineering.redhat.com/browse/RHICOMPL-56

This is one possible solution. Openshift allows us to either supply an HTTP endpoint or a command to run in the pod. I played around with the ideas:

- Using `ss` to look for established connections; would need to install ss as a dependency
- Creating a `compliance.ping` kafka topic and using the already-installed ruby-kafka to produce a message and wait for a response; this isn't good IMO because it also tests the readiness/liveness of the kafka service, not just our consumer
- Running a tiny HTTP endpoint on an unpublished, internal port as part of the consumer; requires an additional gem+dependencies (This PR implements this option)

I'm totally open to other ideas. The insights-upload consumer does it this way as well (one k8s service for a consumer _and_ an HTTP endpoint), but they use HTTP for more than just the health check, of course.