### PR TITLE
Remove GC and MallocTrim

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,8 +69,6 @@ gem 'oj'
 gem 'newrelic_rpm'
 gem 'gitlab-sidekiq-fetcher', require: 'sidekiq-reliable-fetch'
 
-gem 'malloc_trim'
-
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -8,8 +8,5 @@ class ParseReportJob
     parser = XCCDFReportParser.new(ActiveSupport::Gzip.decompress(file),
                                    account, b64_identity)
     parser.save_all
-  ensure
-    GC.start
-    MallocTrim.trim
   end
 end


### PR DESCRIPTION
These calls are not necessary since we stopped using the openscap
library to parse reports (it has a memory leak)