### PR TITLE
Return faster rule objects failed

### DIFF
--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -127,10 +127,12 @@ SystemType = GraphQL::ObjectType.define do
     type types[RuleType]
     description 'Rules failed by a system'
     resolve lambda { |host, _args, _ctx|
-      RuleResult.includes(:rule).where(
-        host: host,
-        result: %w[error fail notchecked]
-      ).map(&:rule).uniq
+      Rule.where(
+        id: RuleResult.includes(:rule).where(
+          host: host,
+          result: %w[error fail notchecked]
+        ).pluck(:rule_id).uniq
+      )
     }
   end
 


### PR DESCRIPTION
Searching and returning the rules in bulk vs using `map` seems to return dramatically better results. Before, I could click on "Remediate with Ansible" and get a 503 because the response might take 100s. This takes around 1s for the same operation.