### PR TITLE
Update Dockerfile for more incremental builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ from ruby:2.5
 
 workdir /app
 
-add . .
-
 run apt-get update && apt-get install -y qt5-default libqt5webkit5-dev \
       gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x libopenscap-dev \
       postgresql-client
 
-run bundle
+add Gemfile Gemfile.lock ./
+
+run bundle -j4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     restart: on-failure
     volumes:
       - .:/app:z
+    ports:
+      - '9394:9394'
     entrypoint: bash -c 'bundle exec prometheus_exporter -c lib/graphql_collector.rb'
   sidekiq:
     image: compliance-backend-rails
@@ -42,6 +44,8 @@ services:
     depends_on:
       - redis
     entrypoint: bash -c 'bundle exec sidekiq'
+    environment:
+      - MALLOC_ARENA_MAX=2
   redis:
     image: redis:latest
 networks:


### PR DESCRIPTION
add prometheus port and sidekiq env variables in docker-compose

The `MALLOC_ARENA_MAX` env variable helps keep the dev environment resources low.

The exposed prometheus port allows looking at the local exporter at `http://localhost:9394/metrics`.

The Dockerfile changes enable the ability to only install gems (not packages) when building the image with updated Gemfile[.lock].

This PR does not affect production (only docker-compose development).