### PR TITLE
Enable Sidekiq client on racecar

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -18,7 +18,9 @@ if $0.include?('sidekiq')
       PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
     end
   end
+end
 
+if $0.include?('sidekiq') || $0.include?('racecar')
   Sidekiq.configure_client do |config|
     config.redis = {
       url: "redis://#{Settings.redis_url}",


### PR DESCRIPTION
This would leave the following setup:

* Sidekiq runs client/server (it enqueues jobs and it's sidekiq itself, so server must be enabled)
* Racecar runs client (it must enqueue jobs)
* Puma and Prometheus do NOT run neither client nor server (they don't enqueue jobs)

This means on all of the apps but Sidekiq should be saving some MBs as one of the dependencies will not even be initialized. 

Notice sidekiq client is not enabled in the consumer at the moment, which makes jobs fail to enqueue there in CI.