### PR TITLE
Revert "Add rails to the sidekiq initializer (#144)"

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -20,7 +20,7 @@ if $0.include?('sidekiq')
   end
 end
 
-if $0.include?('sidekiq') || $0.include?('racecar') || $0.include?('rails')
+if $0.include?('sidekiq') || $0.include?('racecar')
   Sidekiq.configure_client do |config|
     config.redis = {
       url: "redis://#{Settings.redis_url}",


### PR DESCRIPTION
This reverts commit 96037c0d7900825cbbd7d65412bb8c23d4e23be0.

Trying to reproduce the issue in https://github.com/RedHatInsights/compliance-backend/pull/144 on CI. I tried scaling prometheus exporter to 0 pods, and the cpu metric was still available on compliance-backend, so this change really shouldn't affect the metrics API.