### PR TITLE
Parse rule identifiers and references from report XML

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -10,6 +10,11 @@ class Rule < ApplicationRecord
   has_many :profiles, through: :profile_rules, source: :profile
   has_many :rule_results, dependent: :delete_all
   has_many :hosts, through: :rule_results, source: :host
+  has_many :rule_references_rules
+  has_many :rule_references, through: :rule_references_rules
+  alias references rule_references
+  has_one :rule_identifier
+  alias identifier rule_identifier
 
   validates :title, presence: true
   validates :ref_id, uniqueness: true, presence: true
@@ -24,7 +29,6 @@ class Rule < ApplicationRecord
     self.rationale = oscap_rule.rationale
     self.description = oscap_rule.description
     self.severity = oscap_rule.severity
-    self.references = oscap_rule.references
     self
   end
 

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -24,6 +24,7 @@ class Rule < ApplicationRecord
     self.rationale = oscap_rule.rationale
     self.description = oscap_rule.description
     self.severity = oscap_rule.severity
+    self.references = oscap_rule.references
     self
   end
 

--- a/app/models/rule_identifier.rb
+++ b/app/models/rule_identifier.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Stores the identifier for a rule
+class RuleIdentifier < ApplicationRecord
+  belongs_to :rule
+end

--- a/app/models/rule_identifier.rb
+++ b/app/models/rule_identifier.rb
@@ -3,4 +3,7 @@
 # Stores the identifier for a rule
 class RuleIdentifier < ApplicationRecord
   belongs_to :rule
+
+  validates :label, presence: true
+  validates :system, presence: true
 end

--- a/app/models/rule_reference.rb
+++ b/app/models/rule_reference.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Models rule references
+class RuleReference < ApplicationRecord
+  scoped_search on: %i[href label]
+  has_many :rule_references_rules
+  has_many :rules, through: :rule_references_rules
+
+  validates :label, presence: true, uniqueness: { scope: :href, message: 'and href combination already taken' }
+
+  def self.from_oscap_objects(oscap_references)
+    oscap_references.map do |oscap_reference|
+      find_or_initialize_by(oscap_reference)
+    end
+  end
+end

--- a/app/models/rule_reference.rb
+++ b/app/models/rule_reference.rb
@@ -7,6 +7,7 @@ class RuleReference < ApplicationRecord
   has_many :rules, through: :rule_references_rules
 
   validates :label, presence: true, uniqueness: { scope: :href, message: 'and href combination already taken' }
+  validates :href, presence: true, allow_blank: true
 
   def self.from_oscap_objects(oscap_references)
     oscap_references.map do |oscap_reference|

--- a/app/models/rule_references_rule.rb
+++ b/app/models/rule_references_rule.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Models rule result references
+class RuleReferencesRule < ApplicationRecord
+  belongs_to :rule_reference
+  belongs_to :rule
+end

--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -28,8 +28,17 @@ class RuleOscapObject
 
   def references
     @references ||= @rule_xml.css('reference').map do |node|
-      {'href' => node['href'], 'text' => node.text }
+      { href: node['href'], label: node.text }
     end
+  end
+
+  def identifier
+    @identifier ||= @rule_xml.at_css('ident')&.text
+  end
+
+  def identifier_system
+    @identifier_system ||= (ident = @rule_xml.at_css('ident')) &&
+                           ident['system']
   end
 end
 
@@ -75,15 +84,40 @@ module XCCDFReport
         end
       end
 
+      def save_rule_references
+        return @rule_references if @rule_references
+
+        @rule_references = []
+        new_rules.map do |rule|
+          @rule_references << RuleReference.from_oscap_objects(rule.references)
+        end
+        RuleReference.import(@rule_references.flatten,
+                             columns: %i[href label],
+                             ignore: true)
+      end
+
       def save_rules
         new_profiles = Profile.where(ref_id: profiles.keys)
         add_profiles_to_old_rules(rules_already_saved, new_profiles)
-        Rule.import!(
-          new_rules.each_with_object([]) do |rule, new_rules|
-            new_rule = Rule.new(profiles: new_profiles).from_oscap_object(rule)
-            new_rules << new_rule
-          end, recursive: true
-        )
+        new_rule_records = new_rules
+                           .each_with_object([]).map do |oscap_rule, _new_rules|
+          rule_object = Rule.new(profiles: new_profiles).from_oscap_object(oscap_rule)
+          if oscap_rule.identifier
+            rule_object.rule_identifier = RuleIdentifier
+                                          .new(label: oscap_rule.identifier, system: oscap_rule.identifier_system)
+          end
+          rule_object
+        end
+        rule_import = Rule.import!(new_rule_records, recursive: true)
+        associate_rule_references(new_rule_records)
+        rule_import
+      end
+
+      def associate_rule_references(rules)
+        @rule_references ||= []
+        rules.zip(@rule_references).each do |rule, references|
+          rule.update(rule_references: references) if references
+        end
       end
     end
   end

--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -25,6 +25,12 @@ class RuleOscapObject
   def rationale
     @rationale ||= @rule_xml.at_css('rationale').children.text.delete("\n")
   end
+
+  def references
+    @references ||= @rule_xml.css('reference').map do |node|
+      {'href' => node['href'], 'text' => node.text }
+    end
+  end
 end
 
 module XCCDFReport
@@ -33,10 +39,6 @@ module XCCDFReport
     extend ActiveSupport::Concern
 
     included do
-      def rule_ids
-        test_result_node.xpath('.//xmlns:rule-result/@idref').map(&:value)
-      end
-
       def rule_objects
         return @rule_objects if @rule_objects.present?
 

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -2,7 +2,7 @@
 
 # Mimics openscap-ruby RuleResult interface
 class RuleResultOscapObject
-  attr_accessor :id, :result
+  attr_accessor :id, :result, :ident
 end
 
 # Takes in a path to an XCCDF file, returns all kinds of properties about it
@@ -55,10 +55,11 @@ class XCCDFReportParser
   end
 
   def rule_results
-    @rule_results ||= test_result_node.search('rule-result').map do |rr|
+    @rule_results ||= test_result_node.css('rule-result').map do |rr|
       rule_result_oscap = RuleResultOscapObject.new
-      rule_result_oscap.id = rr.attributes['idref'].value
-      rule_result_oscap.result = rr.search('result').first.text
+      rule_result_oscap.id = rr['idref']
+      rule_result_oscap.result = rr.at_css('result').text
+      rule_result_oscap.ident = rr.at_css('ident')&.text
       rule_result_oscap
     end
   end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -59,7 +59,6 @@ class XCCDFReportParser
       rule_result_oscap = RuleResultOscapObject.new
       rule_result_oscap.id = rr['idref']
       rule_result_oscap.result = rr.at_css('result').text
-      rule_result_oscap.ident = rr.at_css('ident')&.text
       rule_result_oscap
     end
   end
@@ -67,6 +66,7 @@ class XCCDFReportParser
   def save_all
     Host.transaction do
       save_profiles
+      save_rule_references
       save_rules
       save_host
       rules_already_saved.each do |rule|

--- a/db/migrate/20190517153452_create_rule_references.rb
+++ b/db/migrate/20190517153452_create_rule_references.rb
@@ -1,0 +1,8 @@
+class CreateRuleReferences < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rule_references, id: :uuid do |t|
+      t.string :href
+      t.string :label
+    end
+  end
+end

--- a/db/migrate/20190517153913_create_join_table_rule_reference_rules.rb
+++ b/db/migrate/20190517153913_create_join_table_rule_reference_rules.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableRuleReferenceRules < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :rules, :rule_references, column_options: { type: :uuid } do |t|
+      t.index [:rule_id, :rule_reference_id], name: 'idx_rule_id_and_rule_reference_id'
+      t.index [:rule_reference_id, :rule_id], name: 'idx_rule_rule_reference_id_and_rule_id'
+    end
+  end
+end

--- a/db/migrate/20190524170042_create_rule_identifier_table.rb
+++ b/db/migrate/20190524170042_create_rule_identifier_table.rb
@@ -1,0 +1,9 @@
+class CreateRuleIdentifierTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rule_identifiers, id: :uuid do |t|
+      t.string :label
+      t.string :system
+      t.references :rule, type: :uuid
+    end
+  end
+end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -107,7 +107,7 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
                      RuleResult.find(rule_results.ids.sample).host.name
         rule_names = RuleResult.where(id: rule_results.ids).map(&:rule)
                                .pluck(:ref_id)
-        assert rule_names.include?(@report_parser.rule_ids.sample)
+        assert rule_names.include?(@report_parser.rule_results.map(&:id).sample)
       end
     end
   end
@@ -129,7 +129,7 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
     end
 
     should 'list all rules' do
-      assert_empty(@arbitrary_rules - @report_parser.rule_ids)
+      assert_empty(@arbitrary_rules - @report_parser.rule_results.map(&:id))
     end
 
     should 'link the rules with the profile' do


### PR DESCRIPTION
Towards Aha! COMP-E-99

WIP for:

- More tests


Preliminary performance impact (tested locally with docker-compose):

Before:

```
ParseReportJob JID-1e96bb7b4f72c413dfd91b50 INFO: start
ParseReportJob JID-1e96bb7b4f72c413dfd91b50 INFO: done: 8.186 sec
ParseReportJob JID-72b589705281a3ea232e6fdd INFO: start
ParseReportJob JID-72b589705281a3ea232e6fdd INFO: done: 2.302 sec
ParseReportJob JID-6f71131a8caf4540eee9e718 INFO: start
ParseReportJob JID-6f71131a8caf4540eee9e718 INFO: done: 2.493 sec
ParseReportJob JID-fa8f9b509a16410a4185b4c5 INFO: start
ParseReportJob JID-fa8f9b509a16410a4185b4c5 INFO: done: 2.118 sec
ParseReportJob JID-4a0d0780019476f8974c2e81 INFO: start
ParseReportJob JID-4a0d0780019476f8974c2e81 INFO: done: 2.476 sec
```

After:

```
ParseReportJob JID-1a814121e1c07d9981c1b04f INFO: start
ParseReportJob JID-1a814121e1c07d9981c1b04f INFO: done: 24.544 sec
ParseReportJob JID-9a450dcf2da318efc26c891e INFO: start
ParseReportJob JID-9a450dcf2da318efc26c891e INFO: done: 2.281 sec
ParseReportJob JID-187cbfe45e7b203a1056060a INFO: start
ParseReportJob JID-187cbfe45e7b203a1056060a INFO: done: 2.491 sec
ParseReportJob JID-1aabc589c2fe8cb806e25446 INFO: start
ParseReportJob JID-1aabc589c2fe8cb806e25446 INFO: done: 3.987 sec
```

It appears new imports which create Rule objects will take longer (which is expected), but subsequent imports remain the same as before this change.