### PR TITLE
Rename payload_id to request_id

### DIFF
--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -9,7 +9,7 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
     @consumer = ComplianceReportsConsumer.new
     @message.expects(:value).returns(
       '{"account": "000001", "principal": "default_principal", '\
-      '"validation":1,"payload_id":"036738d6f4e541c4aa8cfc9f46f5a140",'\
+      '"validation":1,"request_id":"036738d6f4e541c4aa8cfc9f46f5a140",'\
       '"size": 327, "service": "compliance", "url": "/tmp/uploads'\
       '/insights-upload-quarantine/036738d6f4e541c4aa8cfc9f46f5a140"}'
     ).at_least_once
@@ -23,7 +23,7 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
       @consumer.expects(:validation_message).returns('success')
       @consumer.expects(:produce).with(
         {
-          'payload_id': '036738d6f4e541c4aa8cfc9f46f5a140',
+          'request_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'service': 'compliance',
           'validation': 'success'
         }.to_json,


### PR DESCRIPTION
As per https://projects.engineering.redhat.com/browse/RHCLOUD-516 - for now both will be supported by payload_id will be removed