### PR TITLE
Host names are not unique in the inventory, even by account

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -16,7 +16,7 @@ class Host < ApplicationRecord
 
   has_many :profiles, through: :profile_hosts, source: :profile
 
-  validates :name, presence: true, uniqueness: { scope: :account_id }
+  validates :name, presence: true
 
   class << self
     def filter_by_compliance(_filter, operator, value)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 
 class HostTest < ActiveSupport::TestCase
   should validate_presence_of :name
-  should validate_uniqueness_of(:name).scoped_to(:account_id)
 
   test 'compliant returns a hash with all compliance statuses' do
     host = hosts(:one)


### PR DESCRIPTION
We should allow duplicate named hosts in our DB as well. If we don't, we
could find a host by ID in the inventory but fail to create it in our DB
because the host name already exists in our DB with a different ID.

![image](https://user-images.githubusercontent.com/761923/58116786-1efd3900-7bcb-11e9-9343-10b9745d9e68.png)
