### PR TITLE
Profile score should return a float

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -60,6 +60,6 @@ class Profile < ApplicationRecord
   def score
     return 1 if hosts.blank?
 
-    (hosts.count { |host| compliant?(host) }) / hosts.count
+    (hosts.count { |host| compliant?(host) }).to_f / hosts.count
   end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -42,7 +42,13 @@ class ProfileTest < ActiveSupport::TestCase
   end
 
   test 'score with non-blank hosts' do
-    assert_equal 0, profiles(:one).score
+    assert_equal 0.0, profiles(:one).score
+  end
+
+  test 'score returns at least one decimal' do
+    RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass')
+    profiles(:one).hosts << hosts(:two)
+    assert_equal 0.5, profiles(:one).score
   end
 
   context 'threshold' do

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -14,14 +14,16 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
                      .new(fake_report,
                           'account' => accounts(:test).account_number,
                           'b64_identity' => 'b64_fake_identity',
+                          'id' => @host_id,
                           'metadata' => {
                             'fqdn' => 'lenovolobato.lobatolan.home',
-                            'insights_id' => @host_id
                           })
     # A hack to skip API calls in the test env for the time being
     connection = mock('faraday_connection')
     HostInventoryAPI.any_instance.stubs(:connection).returns(connection)
-    get_body = { 'results' => [{ 'id' => @host_id, 'account' => accounts(:test) }] }
+    get_body = {
+      'results' => [{ 'id' => @host_id, 'account' => accounts(:test) }]
+    }
     connection.stubs(:get).returns(OpenStruct.new(body: get_body.to_json))
     post_body = {
       'data' => [{ 'host' => { 'name' => @report_parser.report_host } }]
@@ -60,10 +62,10 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
       @report_parser = ::XCCDFReportParser
                        .new(fake_report,
                             'account' => accounts(:test).account_number,
+                            'id' => @host_id,
                             'b64_identity' => 'b64_fake_identity',
                             'metadata' => {
                               'fqdn' => 'lenovolobato.lobatolan.home',
-                              'insights_id' => @host_id
                             })
       assert_equal 1, @report_parser.profiles.count
     end
@@ -85,7 +87,8 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
       HostInventoryAPI.any_instance
                       .stubs(:host_already_in_inventory)
                       .returns('id' => @host_id)
-      Host.create(id: @host_id, name: @report_parser.report_host, account: accounts(:test))
+      Host.create(id: @host_id, name: @report_parser.report_host,
+                  account: accounts(:test))
 
       assert_difference('Host.count', 0) do
         new_host = @report_parser.save_host


### PR DESCRIPTION
This is important for the dashboard, as it's making a request to api/profiles, which returns all profiles with scores - the score displayed is an integer even if you see 1 out of 2 hosts compliant, the only options are 0 or 1. It should display 0.5 in that case.  