### PR TITLE
RHICOMPL-186 - Stream the report instead of writing to tempfile

### DIFF
--- a/app/services/safe_downloader.rb
+++ b/app/services/safe_downloader.rb
@@ -17,11 +17,9 @@ class SafeDownloader
   ].freeze
 
   class << self
-    def download(url, path, max_size: nil)
+    def download(url, max_size: nil)
       downloaded_file = open_url(encode_url(url), create_options(max_size))
-      tempfile = Tempfile.create(path)
-      IO.copy_stream(downloaded_file, tempfile.path)
-      tempfile
+      IO.read(downloaded_file)
     rescue *DOWNLOAD_ERRORS => e
       raise DownloadError if e.instance_of?(RuntimeError) &&
                              e.message !~ /redirection/

--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -7,8 +7,7 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
   setup do
     @message = stub(:message)
     @consumer = ComplianceReportsConsumer.new
-    @tempfile = Tempfile.new
-    SafeDownloader.expects(:download).returns(@tempfile)
+    SafeDownloader.expects(:download).returns('report')
     ParseReportJob.clear
   end
 
@@ -66,10 +65,6 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
       '/insights-upload-quarantine/036738d6f4e541c4aa8cfc9f46f5a140"}'
     ).at_least_once
     XCCDFReportParser.expects(:new).raises(StandardError, 'something broke')
-    @tempfile.expects(:close)
-    # After calling .close, @tempfile changes its internal object id, so we
-    # need to expect any tempfile to close.
-    File.expects(:delete).with(@tempfile.path)
     # Mock the actual 'sending the validation' to Kafka
     @consumer.expects(:send_validation).with('failure').returns(true)
     @consumer.process(@message)

--- a/test/services/safe_downloader_test.rb
+++ b/test/services/safe_downloader_test.rb
@@ -5,26 +5,24 @@ require 'test_helper'
 class SafeDownloaderTest < ActiveSupport::TestCase
   setup do
     @url = 'http://example.com'
-    @path = 'test/path'
   end
 
   test 'download success' do
     URI::HTTP.any_instance.expects(:open)
-    Tempfile.expects(:create).with(@path).returns(OpenStruct.new(path: nil))
-    IO.expects(:copy_stream)
+    IO.expects(:read)
 
-    SafeDownloader.download(@url, @path)
+    SafeDownloader.download(@url)
   end
 
   test 'download with url parse failure' do
     assert_raises(SafeDownloader::DownloadError) do
-      SafeDownloader.download(:bad_url, @path)
+      SafeDownloader.download(:bad_url)
     end
   end
 
   test 'download with oversized file' do
     assert_raises(SafeDownloader::DownloadError) do
-      SafeDownloader.download(@url, @path, max_size: 1)
+      SafeDownloader.download(@url, max_size: 1)
     end
   end
 end


### PR DESCRIPTION
Before, it seems that we were only deleting the file when the validation failed.
It should not be necessary to do this, because we use `Tempfile` in `SafeDownloader`. That should remove the file automatically once it's no longer used in the ruby process memory context. According to our reports from QE it's not, so this is a way of covering our backs and delete it for sure after `process`  