### PR TITLE
RHICOMPL-193 - Remove account_id from account

### DIFF
--- a/db/migrate/20190531075839_remove_account_id_from_account.rb
+++ b/db/migrate/20190531075839_remove_account_id_from_account.rb
@@ -1,0 +1,5 @@
+class RemoveAccountIdFromAccount < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :accounts, :account_id
+  end
+end


### PR DESCRIPTION
The account_id (not the ID) field from the accounts table is empty and unused in the app. It can be safely removed. From prod:

 
```
irb(main):009:0> Account.all.map(&:account_id).uniq
=> [nil]
```