### PR TITLE
RHICOMPL-195 - Check host presence before deletion

### DIFF
--- a/app/jobs/delete_host.rb
+++ b/app/jobs/delete_host.rb
@@ -9,5 +9,11 @@ class DeleteHost
       RuleResult.where(host_id: message['id']).delete_all
       Host.find(message['id']).destroy
     end
+
+  rescue ActiveRecord::RecordNotFound => error
+    Sidekiq.logger.info(
+      "#{error.message} (#{error.class}) "\
+      "- this host ID was not registered in Compliance"
+    )
   end
 end

--- a/openshift/templates/compliance-inventory-events-consumer.yaml
+++ b/openshift/templates/compliance-inventory-events-consumer.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  annotations:
+    description: Defines how to deploy the application server
+  labels:
+    app: compliance-inventory-events-consumer
+    template: compliance-inventory-events-consumer-template
+  name: compliance-inventory-events-consumer
+spec:
+  replicas: 1
+  selector:
+    name: compliance-inventory-events-consumer
+  strategy:
+    activeDeadlineSeconds: 21600
+    recreateParams:
+      timeoutSeconds: 600
+    resources: {}
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: compliance-inventory-events-consumer
+        name: compliance-inventory-events-consumer
+      name: compliance-inventory-events-consumer
+    spec:
+      containers:
+        - env:
+            - name: APPLICATION_TYPE
+              value: compliance-inventory
+            - name: DATABASE_SERVICE_NAME
+              value: compliance-db
+            - name: POSTGRESQL_USER
+              value: compliance_user
+            - name: POSTGRESQL_PASSWORD
+              value: compliance_password
+            - name: POSTGRESQL_ADMIN_PASSWORD
+              value: db_admin_password
+            - name: POSTGRESQL_DATABASE
+              value: compliance
+            - name: SECRET_KEY_BASE
+              value: secret_key_base
+            - name: POSTGRESQL_MAX_CONNECTIONS
+              value: '100'
+            - name: POSTGRESQL_SHARED_BUFFERS
+              value: 12MB
+            - name: RAILS_ENV
+              value: production
+            - name: KAFKAMQ
+              value: platform-mq-ci-kafka-bootstrap.platform-mq-ci.svc
+            - name: SETTINGS__PROMETHEUS_EXPORTER_HOST
+              value: compliance-prometheus-exporter.compliance-ci.svc
+            - name: RAILS_LOG_TO_STDOUT
+              value: 'true'
+            - name: SETTINGS__HOST_INVENTORY_URL
+              value: 'http://insights-inventory.platform-ci.svc:8080'
+            - name: PATH_PREFIX
+              value: /api
+            - name: APP_NAME
+              value: compliance
+            - name: SETTINGS__OPENSHIFT_TOKENS_SECRET
+              value: MTwXl7kVp4inTho3N6aiw/7fr8iBJv49HwodiPHIdaw=
+            - name: LD_PRELOAD
+              value: /usr/lib64/libjemalloc.so.1
+            - name: NEWRELIC_LICENSE
+              value: 1364549cbdc9bfd67f69586f778c5d4f07756163
+            - name: PASSENGER_PORT
+              value: '8080'
+            - name: RACECAR_MAX_FETCH_QUEUE_SIZE
+              value: '5'
+            - name: RACECAR_OFFSET_COMMIT_INTERVAL
+              value: '5'
+          imagePullPolicy: IfNotPresent
+          name: compliance-inventory-events-consumer
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1200Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - compliance-inventory-events-consumer
+        from:
+          kind: ImageStreamTag
+          name: 'compliance-backend:latest'
+          namespace: buildfactory
+      type: ImageChange
+    - type: ConfigChange
+


### PR DESCRIPTION


Currently the job that's deleting hosts once we see the event coming from the inventory is not checking whether the Host ID is in the compliance DB. This throws an exception and causes the job to retry 3 times and prints the stacktrace to the logs.

 

We can avoid it by just rescuing for ActiveRecord::RecordNotFound:
