### PR TITLE
Allow payload_id or request_id as the message ID

### DIFF
--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -23,6 +23,7 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
       @consumer.expects(:validation_message).returns('success')
       @consumer.expects(:produce).with(
         {
+          'payload_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'request_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'service': 'compliance',
           'validation': 'success'


### PR DESCRIPTION
We want to be backwards compatible here because messages can hang around after new code is deployed.

Related to https://github.com/RedHatInsights/compliance-backend/pull/147 