### PR TITLE
Fix and add tests for exception_notifier

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
   include ActionController::Helpers
   include Pundit
   include Authentication
-  include ExceptionNotifier
+  include ExceptionNotifierCustomData
   include Metadata
   include Pagination
   include Search

--- a/app/controllers/concerns/exception_notifier_custom_data.rb
+++ b/app/controllers/concerns/exception_notifier_custom_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Module to add any info to ExceptionNotifier
-module ExceptionNotifier
+module ExceptionNotifierCustomData
   extend ActiveSupport::Concern
 
   included do

--- a/test/controllers/concerns/exception_notifier_custom_data_test.rb
+++ b/test/controllers/concerns/exception_notifier_custom_data_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'exception_notifier_custom_data'
+
+# This class tests a "dummy" controller for the exception notifier.
+class MocksController < ActionController::API
+  include ExceptionNotifierCustomData
+
+  def index; end
+
+  def current_user
+    :current_user
+  end
+end
+
+class ExceptionNotifierCustomDataTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.application.routes.draw { resources :mocks }
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+  end
+
+  test 'adds exception_data to request env' do
+    get mocks_path
+    assert_response :success
+    assert_equal(
+      :current_user,
+      response.request.env.dig(
+        'exception_notifier.exception_data', :current_user
+      )
+    )
+  end
+end


### PR DESCRIPTION
We were overwriting the `ExceptionNotifier` constant, defined in [the gem](https://github.com/smartinez87/exception_notification/blob/master/lib/exception_notifier.rb#L7). Maybe this will start notifying us via Slack.

This should also finally close https://projects.engineering.redhat.com/browse/RHICOMPL-21