### PR TITLE
RHICOMPL-178 - Optimize Rule results policy fetching

### DIFF
--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -12,9 +12,11 @@ module Metadata
       response.headers['Content-Type'] = 'application/vnd.api+json'
     end
 
-    def metadata(opts)
+    def metadata(opts = {})
+      opts[:total] ||= policy_scope(resource).count
       options = {}
-      options[:meta] = { total: opts[:total], search: params[:search] }
+      options[:meta] = { total: opts[:total], search: params[:search],
+                         limit: pagination_limit, offset: pagination_offset }
       options[:links] = links(opts[:total])
       options
     end

--- a/app/controllers/concerns/search.rb
+++ b/app/controllers/concerns/search.rb
@@ -6,11 +6,9 @@ module Search
 
   included do
     def scope_search
-      return policy_scope(resource) unless params[:search]
-
-      policy_scope(resource).search_for(params[:search])
-                            .paginate(page: pagination_offset,
-                                      per_page: pagination_limit)
+      result = policy_scope(resource)
+      result = result.search_for(params[:search]) if params[:search].present?
+      result.paginate(page: pagination_offset, per_page: pagination_limit)
     end
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,11 +3,7 @@
 # API for Profiles
 class ProfilesController < ApplicationController
   def index
-    profiles = scope_search.sort_by(&:score)
-    render json: ProfileSerializer.new(
-      profiles,
-      metadata(total: profiles.count)
-    )
+    render json: ProfileSerializer.new(scope_search.sort_by(&:score), metadata)
   end
 
   def show

--- a/app/controllers/rule_results_controller.rb
+++ b/app/controllers/rule_results_controller.rb
@@ -3,9 +3,7 @@
 # API for RuleResults
 class RuleResultsController < ApplicationController
   def index
-    render json: RuleResultSerializer.new(
-      scope_search, metadata(total: scope_search.count)
-    )
+    render json: RuleResultSerializer.new(scope_search, metadata)
   end
 
   private

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -3,10 +3,7 @@
 # REST API for Rules
 class RulesController < ApplicationController
   def index
-    render json: RuleSerializer.new(
-      scope_search,
-      metadata(total: scope_search.count)
-    )
+    render json: RuleSerializer.new(scope_search, metadata)
   end
 
   def show

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -8,9 +8,7 @@ class SystemsController < ApplicationController
   def index
     respond_to do |format|
       format.any do
-        render json: HostSerializer.new(
-          scope_search, metadata(total: scope_search.count)
-        )
+        render json: HostSerializer.new(scope_search, metadata)
       end
       format.csv do
         csv_response(*csv_params)

--- a/app/policies/rule_result_policy.rb
+++ b/app/policies/rule_result_policy.rb
@@ -13,7 +13,8 @@ class RuleResultPolicy < ApplicationPolicy
   # Only show RuleResults belonging to hosts visible by the current user
   class Scope < ::ApplicationPolicy::Scope
     def resolve
-      scope.select { |rule_result| Pundit.policy(user, rule_result.host) }
+      available_hosts = HostPolicy::Scope.new(user, Host).resolve.pluck(:id)
+      scope.where(host_id: available_hosts)
     end
   end
 end

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -88,5 +88,12 @@ class MetadataTest < ActionDispatch::IntegrationTest
       assert_match(/limit=1/, json_body['links']['last'])
       assert_match(/offset=#{Profile.count}/, json_body['links']['last'])
     end
+
+    should 'return passed limit and offset' do
+      get profiles_url, params: { limit: 1, offset: 2 }
+      assert_response :success
+      assert_equal(1, json_body['meta']['limit'])
+      assert_equal(2, json_body['meta']['offset'])
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the policy method to retrieve rule_results on
api/compliance/rule_results. Before this PR, the policy
was iterating on all of the rule_results, which was incredibly
slow.

Aside from that, output was not paginated unless 'search' was
passed. Fixing the pagination forced me to change other controllers to
match it, as a side effect all other endpoints pagination are
now fixed.
