### PR TITLE
Rescue SafeDownloader when downloaded file is empty

### DIFF
--- a/test/services/safe_downloader_test.rb
+++ b/test/services/safe_downloader_test.rb
@@ -8,10 +8,17 @@ class SafeDownloaderTest < ActiveSupport::TestCase
   end
 
   test 'download success' do
-    URI::HTTP.any_instance.expects(:open)
+    URI::HTTP.any_instance.expects(:open).returns(StringIO.new('a'))
     IO.expects(:read)
 
     SafeDownloader.download(@url)
+  end
+
+  test 'download with empty file fails' do
+    URI::HTTP.any_instance.expects(:open).returns(StringIO.new)
+    assert_raises(SafeDownloader::DownloadError) do
+      SafeDownloader.download(@url)
+    end
   end
 
   test 'download with url parse failure' do


### PR DESCRIPTION
If the file download fails because the file is empty, the message will
be pushed back to kafka and we will consume it endlessly, effectively
turning one of the 2 consumers idle. Instead we should just rescue that
case and invalidate that payload.