### PR TITLE
Handle small report uploads which return StringIO

### DIFF
--- a/app/services/safe_downloader.rb
+++ b/app/services/safe_downloader.rb
@@ -28,7 +28,7 @@ class SafeDownloader
       downloaded_file = open_url(encode_url(url), create_options(max_size))
       raise EmptyReportError if downloaded_file.size.zero?
 
-      IO.read(downloaded_file)
+      report_contents(downloaded_file)
     rescue *DOWNLOAD_ERRORS => e
       raise DownloadError if e.instance_of?(RuntimeError) &&
                              e.message !~ /redirection/
@@ -37,6 +37,15 @@ class SafeDownloader
     end
 
     private
+
+    def report_contents(downloaded_file)
+      case downloaded_file
+      when StringIO
+        downloaded_file.string
+      else
+        IO.read(downloaded_file)
+      end
+    end
 
     def open_url(url, options)
       url.open(options)

--- a/test/services/safe_downloader_test.rb
+++ b/test/services/safe_downloader_test.rb
@@ -7,9 +7,20 @@ class SafeDownloaderTest < ActiveSupport::TestCase
     @url = 'http://example.com'
   end
 
-  test 'download success' do
-    URI::HTTP.any_instance.expects(:open).returns(StringIO.new('a'))
-    IO.expects(:read)
+  test 'download success with small file' do
+    strio = StringIO.new('a')
+    URI::HTTP.any_instance.expects(:open).returns(strio)
+    IO.expects(:read).never
+    strio.expects(:string)
+
+    SafeDownloader.download(@url)
+  end
+
+  test 'download success with large file' do
+    tempfile = Tempfile.new
+    tempfile.write('foo')
+    URI::HTTP.any_instance.expects(:open).returns(tempfile)
+    IO.expects(:read).with(tempfile)
 
     SafeDownloader.download(@url)
   end


### PR DESCRIPTION
`URI(...).read` returns a `StringIO` for files < 10Kb and a Tempfile otherwise. We need to handle the `StringIO` case.