### PR TITLE
Add a util container to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,11 @@ services:
       - MALLOC_ARENA_MAX=2
   redis:
     image: redis:latest
+  util:
+    image: compliance-backend-rails
+    volumes:
+      - .:/app:z
+    entrypoint: bash -c 'sleep infinity'
 networks:
   default:
     external:


### PR DESCRIPTION
This allows running the rails console or rake tasks without waiting for
one of the services to come up. This is very important for migrations,
which disallow some services from coming up in the first place.

For example:

`docker-compose exec util bundle update`
`docker-compose exec util bundle exec rake db:migrate`

Signed-off-by: Andrew Kofink <akofink@redhat.com>