### PR TITLE
Disable prometheus exporter in test environment

### DIFF
--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'prometheus_exporter/client'
+require 'prometheus_exporter/client' unless Rails.env.test?
 
 # Definition for the GraphQL schema - read the
 # GraphQL-ruby documentation to find out what to add or
 # remove here.
 class Schema < GraphQL::Schema
-  use GraphQL::Tracing::PrometheusTracing
+  use GraphQL::Tracing::PrometheusTracing unless Rails.env.test?
   query Types::Query
   mutation Types::Mutation
 end


### PR DESCRIPTION
This allows easier debugging while writing tests, as it disables prometheus error messages like this:

```
Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9394
Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9394
Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9394
Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9394
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>