### PR TITLE
Ensure rule results are associated by ref_id to rules

### DIFF
--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -58,10 +58,11 @@ class XCCDFReportParser
 
   def save_rule_results
     RuleResult.import!(
-      rule_results_rule_ids.zip(@oscap_parser.rule_results.map(&:result))
-      .each_with_object([]) do |rule_result, rule_results|
+      @oscap_parser.rule_results.each_with_object([]) do |rule_result, rule_results|
         rule_results << RuleResult.new(
-          host: @host, rule_id: rule_result[0], result: rule_result[1],
+          host: @host,
+          rule_id: rule_results_rule_ids[rule_result.id],
+          result: rule_result.result,
           start_time: @oscap_parser.start_time.in_time_zone,
           end_time: @oscap_parser.end_time.in_time_zone
         )
@@ -79,8 +80,8 @@ class XCCDFReportParser
   end
 
   def rule_results_rule_ids
-    @rule_results_rule_ids ||= Rule.select(:id).where(
+    @rule_results_rule_ids ||= Rule.where(
       ref_id: @oscap_parser.rule_results.map(&:id)
-    ).pluck(:id)
+    ).pluck(:ref_id, :id).to_h
   end
 end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -104,6 +104,9 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
         rule_names = RuleResult.where(id: rule_results.ids).map(&:rule)
                                .pluck(:ref_id)
         assert rule_names.include?(@report_parser.oscap_parser.rule_ids.sample)
+        @report_parser.oscap_parser.rule_results.each do |rule_result|
+          assert_equal rule_result.result, RuleResult.joins(:rule).find_by(rules: {ref_id: rule_result.id}).result
+        end
       end
     end
   end


### PR DESCRIPTION
The existing `zip` implementation pairs xml rule_results with database RuleResult objects in undefined order. This implementation creates a hash of database RuleResults by `{<ref_id> => <id>}` and uses xml rule_results.id to index into the hash.

This new implementation should not significantly increase runtime of a parse (locally measured: 23.638 sec initial, ~ 1.685 sec subsequent).

Signed-off-by: Andrew Kofink <akofink@redhat.com>