### PR TITLE
Only use rubocop in test/dev env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,8 @@ group :development, :test do
   gem 'pry-remote'
   gem 'rspec-rails'
   gem 'rswag-specs'
+  gem 'rubocop', require: false
+  gem 'rubocop-rails', require: false
   gem 'shoulda-context'
   gem 'shoulda-matchers'
   gem 'dotenv-rails'
@@ -93,8 +95,6 @@ group :development do
   gem 'bullet'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'pry-rails'
-  gem 'rubocop', require: false
-  gem 'rubocop-rails', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -12,5 +12,7 @@ namespace :test do
   end
 end
 
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new
+unless Rails.env.production?
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,55 +1,57 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-SimpleCov.start 'rails' do
-  # don't test the schema!
-  # https://github.com/rmosolgo/graphql-ruby/blob/master/guides/schema/
-  # testing.md#dont-test-the-schema
-  add_filter 'app/models/schema.rb'
-  # these just contain the description of the attributes of the
-  # API responses, no code (https://github.com/Netflix/fast_jsonapi)
-  add_filter 'app/serializers'
-  # empty class that has to be there for prometheus integration
-  add_filter 'lib/graphql_collector.rb'
-end
-
-if ENV['CODECOV_TOKEN']
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
-
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
-require 'rails/test_help'
-
-require 'minitest/reporters'
-require 'minitest/mock'
-require 'mocha/minitest'
-
-Minitest::Reporters.use!(
-  Minitest::Reporters::ProgressReporter.new,
-  ENV,
-  Minitest.backtrace_filter
-)
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :minitest_5
-    with.library :rails
+unless Rails.env.production?
+  require 'simplecov'
+  SimpleCov.start 'rails' do
+    # don't test the schema!
+    # https://github.com/rmosolgo/graphql-ruby/blob/master/guides/schema/
+    # testing.md#dont-test-the-schema
+    add_filter 'app/models/schema.rb'
+    # these just contain the description of the attributes of the
+    # API responses, no code (https://github.com/Netflix/fast_jsonapi)
+    add_filter 'app/serializers'
+    # empty class that has to be there for prometheus integration
+    add_filter 'lib/graphql_collector.rb'
   end
-end
 
-module ActiveSupport
-  class TestCase
-    fixtures :all
-    self.use_transactional_tests = true
+  if ENV['CODECOV_TOKEN']
+    require 'codecov'
+    SimpleCov.formatter = SimpleCov::Formatter::Codecov
   end
-end
 
-module ActionDispatch
-  class IntegrationTest
-    def json_body
-      JSON.parse(response.body)
+  ENV['RAILS_ENV'] ||= 'test'
+  require_relative '../config/environment'
+  require 'rails/test_help'
+
+  require 'minitest/reporters'
+  require 'minitest/mock'
+  require 'mocha/minitest'
+
+  Minitest::Reporters.use!(
+    Minitest::Reporters::ProgressReporter.new,
+    ENV,
+    Minitest.backtrace_filter
+  )
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :minitest_5
+      with.library :rails
+    end
+  end
+
+  module ActiveSupport
+    class TestCase
+      fixtures :all
+      self.use_transactional_tests = true
+    end
+  end
+
+  module ActionDispatch
+    class IntegrationTest
+      def json_body
+        JSON.parse(response.body)
+      end
     end
   end
 end


### PR DESCRIPTION
- Moved rubocop to the dev, test group in the gemfile instead of just development.
- Don't require rubocop or create a rake task for it unless dev/test

Signed-off-by: Andrew Kofink <akofink@redhat.com>