### PR TITLE
Sort rule references by label by default

### DIFF
--- a/app/models/rule_reference.rb
+++ b/app/models/rule_reference.rb
@@ -2,6 +2,7 @@
 
 # Models rule references
 class RuleReference < ApplicationRecord
+  default_scope { order(:label) }
   scoped_search on: %i[href label]
   has_many :rule_references_rules, dependent: :delete_all
   has_many :rules, through: :rule_references_rules


### PR DESCRIPTION
It's hard to imagine we'd ever want to sort by `id` or `href`.

```rb
RuleReference(id: uuid, href: string, label: string)
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>