### PR TITLE
Fixes 264: Only import new rule references

### DIFF
--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -35,14 +35,17 @@ module XCCDFReport
         end
       end
 
-      def save_rule_references
+      def rule_references
         return @rule_references if @rule_references
 
         @rule_references = []
         new_rules.map do |rule|
           @rule_references << RuleReference.from_oscap_objects(rule.references)
         end
-        RuleReference.import(@rule_references.flatten,
+      end
+
+      def save_rule_references
+        RuleReference.import(new_rule_references,
                              columns: %i[href label],
                              ignore: true)
       end
@@ -63,6 +66,12 @@ module XCCDFReport
       end
 
       private
+
+      def new_rule_references
+        rule_references.flatten.keep_if do |rule|
+          rule.id.nil?
+        end
+      end
 
       def new_profiles
         @new_profiles ||= Profile.where(ref_id: @oscap_parser.profiles.keys)

--- a/test/services/concerns/xccdf_report/rules_test.rb
+++ b/test/services/concerns/xccdf_report/rules_test.rb
@@ -40,4 +40,24 @@ class RulesTest < ActiveSupport::TestCase
 
     assert_includes rule.profiles, profile
   end
+
+  test 'only new rule references are saved' do
+    stubs(:new_rules).returns(
+      [OpenStruct.new(references: [{ label: 'foo', href: '' }])]
+    )
+
+    assert_difference('RuleReference.count', 1) do
+      save_rule_references
+    end
+
+    @rule_references = nil # un-cache it from ||=
+    stubs(:new_rules).returns(
+      [OpenStruct.new(references: [{ label: 'foo', href: '' },
+                                   { label: 'bar', href: '' }])]
+    )
+
+    assert_difference('RuleReference.count', 1) do
+      save_rule_references
+    end
+  end
 end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -112,6 +112,7 @@ class XCCDFReportParserTest < ActiveSupport::TestCase
 
   context 'rule results' do
     should 'save them, associate them with a rule and a host' do
+      @report_parser.stubs(:save_rule_references)
       assert_difference('RuleResult.count', 367) do
         rule_results = @report_parser.save_all
         assert_equal @report_parser.report_host,


### PR DESCRIPTION
Without the relevant code change, the test fails:

```
ERROR["test_only_new_rule_references_are_saved", #<Minitest::Reporters::Suite:0x000055d2bc8ac048 @name="RulesTest">, 1.3665143339894712]
 test_only_new_rule_references_are_saved#RulesTest (1.37s)
ActiveRecord::NotNullViolation:         ActiveRecord::NotNullViolation: PG::NotNullViolation: ERROR:  null value in column "id" violates not-null constraint
        DETAIL:  Failing row contains (null, , bar).
        : INSERT INTO "rule_references" ("id","href","label") VALUES ('18c74014-06a4-496f-a1f6-63092788d2b5','','foo'),(NULL,'','bar') ON CONFLICT DO NOTHING  RETURNING "id"
            app/services/concerns/xccdf_report/rules.rb:48:in `save_rule_references'
            test/services/concerns/xccdf_report/rules_test.rb:60:in `block (2 levels) in <class:RulesTest>'
            test/services/concerns/xccdf_report/rules_test.rb:59:in `block in <class:RulesTest>'
``` 

Signed-off-by: Andrew Kofink <akofink@redhat.com>