### PR TITLE
Include name in profile uniqueness scope

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,7 +16,7 @@ class Profile < ApplicationRecord
   belongs_to :account, optional: true
   belongs_to :business_objective, optional: true
 
-  validates :ref_id, uniqueness: { scope: :account_id }, presence: true
+  validates :ref_id, uniqueness: { scope: %i[account_id name] }, presence: true
   validates :name, presence: true
   validates :compliance_threshold, numericality: true
 

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class ProfileTest < ActiveSupport::TestCase
-  should validate_uniqueness_of(:ref_id).scoped_to(:account_id)
+  should validate_uniqueness_of(:ref_id).scoped_to(%i[account_id name])
   should validate_presence_of :ref_id
   should validate_presence_of :name
   should belong_to(:business_objective).optional


### PR DESCRIPTION
We `find_or_initialize_by` `ref_id`, `name`, and `account_id` in the
[`XCCDFReport::Profiles`](https://github.com/RedHatInsights/compliance-backend/blob/master/app/services/concerns/xccdf_report/profiles.rb#L15) module, so profiles should be unique by those
three attributes.

Easy way to test: upload the standard profile for RHEL7 (`ref_id=xccdf_org.ssgproject.content_profile_standard`) and then another for RHEL8 (`ref_id=xccdf_org.ssgproject.content_profile_standard`). The only difference is the name (i.e. "Standard System Security Profile for Red Hat Enterprise Linux 7").

Signed-off-by: Andrew Kofink <akofink@redhat.com>