### PR TITLE
Refactor xccdf, pull out rule_references

### DIFF
--- a/app/models/rule_reference.rb
+++ b/app/models/rule_reference.rb
@@ -14,9 +14,9 @@ class RuleReference < ApplicationRecord
                     }
   validates :href, presence: true, allow_blank: true
 
-  def self.from_oscap_objects(oscap_references)
-    oscap_references.map do |oscap_reference|
-      find_or_initialize_by(oscap_reference)
+  def self.find_from_oscap(oscap_references)
+    oscap_references.inject(where('1=0')) do |rel, reference|
+      rel.or(where(reference))
     end
   end
 end

--- a/app/services/concerns/xccdf_report/profiles.rb
+++ b/app/services/concerns/xccdf_report/profiles.rb
@@ -8,17 +8,17 @@ module XCCDFReport
 
     included do
       def save_profiles
-        created = []
-        # Only save profiles with an associated TestResult. Otherwise there
-        # could be profiles saved w/o results.
-        @oscap_parser.profiles.each do |ref_id, name|
+        @oscap_parser.profiles.map do |ref_id, name|
           profile = Profile.find_or_initialize_by(name: name, ref_id: ref_id,
                                                   account_id: @account.id)
-          profile.description = @oscap_parser.description
-          profile.save
-          created << profile
+          unless profile.persisted?
+            profile.update!(
+              description: @oscap_parser.description
+            )
+          end
+
+          profile
         end
-        created
       end
 
       def host_new_profiles

--- a/app/services/concerns/xccdf_report/rule_references.rb
+++ b/app/services/concerns/xccdf_report/rule_references.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module XCCDFReport
+  # Methods related to saving rule references and finding which rules
+  # they belong to
+  module RuleReferences
+    extend ActiveSupport::Concern
+
+    included do
+      def rule_references
+        @rule_references ||= new_rules.map do |rule|
+          RuleReference.from_oscap_objects(rule.references)
+        end
+      end
+
+      def save_rule_references
+        RuleReference.import(new_rule_references,
+                             columns: %i[href label],
+                             ignore: true)
+      end
+
+      def associate_rule_references(new_rules)
+        new_rules.zip(@rule_references || []).each do |rule, references|
+          rule.update(rule_references: references) if references.present?
+        end
+      end
+
+      private
+
+      def new_rule_references
+        rule_references.flatten.keep_if do |rule|
+          rule.id.nil?
+        end
+      end
+    end
+  end
+end

--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -35,21 +35,6 @@ module XCCDFReport
         end
       end
 
-      def rule_references
-        return @rule_references if @rule_references
-
-        @rule_references = []
-        new_rules.map do |rule|
-          @rule_references << RuleReference.from_oscap_objects(rule.references)
-        end
-      end
-
-      def save_rule_references
-        RuleReference.import(new_rule_references,
-                             columns: %i[href label],
-                             ignore: true)
-      end
-
       def save_rules
         add_profiles_to_old_rules(rules_already_saved, new_profiles)
         rule_import = Rule.import!(new_rule_records, recursive: true)
@@ -57,20 +42,7 @@ module XCCDFReport
         rule_import
       end
 
-      def associate_rule_references(rules)
-        @rule_references ||= []
-        rules.zip(@rule_references).each do |rule, references|
-          rule.update(rule_references: references) if references.present?
-        end
-      end
-
       private
-
-      def new_rule_references
-        rule_references.flatten.keep_if do |rule|
-          rule.id.nil?
-        end
-      end
 
       def new_profiles
         @new_profiles ||= Profile.where(ref_id: @oscap_parser.profiles.keys,

--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -29,8 +29,10 @@ module XCCDFReport
       end
 
       def new_rules
+        return @new_rules if @new_rules
+
         ref_ids = rules_already_saved.pluck(:ref_id)
-        @oscap_parser.rule_objects.reject do |rule|
+        @new_rules = @oscap_parser.rule_objects.reject do |rule|
           ref_ids.include? rule.id
         end
       end
@@ -38,7 +40,7 @@ module XCCDFReport
       def save_rules
         add_profiles_to_old_rules(rules_already_saved, new_profiles)
         rule_import = Rule.import!(new_rule_records, recursive: true)
-        associate_rule_references(new_rule_records)
+        associate_rule_references
         rule_import
       end
 

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -13,6 +13,7 @@ class EmptyMetadataError < StandardError; end
 class XCCDFReportParser
   include ::XCCDFReport::Profiles
   include ::XCCDFReport::Rules
+  include ::XCCDFReport::RuleReferences
 
   attr_reader :report_path, :oscap_parser
 

--- a/test/services/concerns/xccdf_report/profiles_test.rb
+++ b/test/services/concerns/xccdf_report/profiles_test.rb
@@ -15,20 +15,21 @@ class ProfilesTest < ActiveSupport::TestCase
   include XCCDFReport::Profiles
 
   setup do
-    @account = OpenStruct.new(id: 1)
-    @host = OpenStruct.new(id: 2)
+    @account = accounts(:test)
+    @host = hosts(:one)
     @oscap_parser = OpenscapParser::Base.new(
       file_fixture('xccdf_report.xml').read
     )
   end
 
   test 'save_profiles' do
-    before = Profile.count
-    save_profiles
-    now = Profile.count
-    assert_equal before + 1, now
-    save_profiles
-    assert_equal now, Profile.count
+    assert_difference('Profile.count', 1) do
+      save_profiles
+    end
+
+    assert_no_difference('Profile.count') do
+      save_profiles
+    end
   end
 
   test 'host_new_profiles' do

--- a/test/services/concerns/xccdf_report/rule_references_test.rb
+++ b/test/services/concerns/xccdf_report/rule_references_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf_report/rule_references'
+
+class RulesTest < ActiveSupport::TestCase
+  include XCCDFReport::RuleReferences
+
+  test 'only new rule references are saved' do
+    stubs(:new_rules).returns(
+      [OpenStruct.new(references: [{ label: 'foo', href: '' }])]
+    )
+
+    assert_difference('RuleReference.count', 1) do
+      save_rule_references
+    end
+
+    @rule_references = nil # un-cache it from ||=
+    stubs(:new_rules).returns(
+      [OpenStruct.new(references: [{ label: 'foo', href: '' },
+                                   { label: 'bar', href: '' }])]
+    )
+
+    assert_difference('RuleReference.count', 1) do
+      save_rule_references
+    end
+  end
+end

--- a/test/services/concerns/xccdf_report/rules_test.rb
+++ b/test/services/concerns/xccdf_report/rules_test.rb
@@ -42,24 +42,4 @@ class RulesTest < ActiveSupport::TestCase
 
     assert_includes rule.profiles, profile
   end
-
-  test 'only new rule references are saved' do
-    stubs(:new_rules).returns(
-      [OpenStruct.new(references: [{ label: 'foo', href: '' }])]
-    )
-
-    assert_difference('RuleReference.count', 1) do
-      save_rule_references
-    end
-
-    @rule_references = nil # un-cache it from ||=
-    stubs(:new_rules).returns(
-      [OpenStruct.new(references: [{ label: 'foo', href: '' },
-                                   { label: 'bar', href: '' }])]
-    )
-
-    assert_difference('RuleReference.count', 1) do
-      save_rule_references
-    end
-  end
 end


### PR DESCRIPTION
This is almost all refactoring. The only functionality change should be that saving a profile raises an exception if saving fails for some reason (i.e. model validation failure).

Built on top of https://github.com/RedHatInsights/compliance-backend/pull/195