### PR TITLE
Reduce SQL statements in associate_rule_references

### DIFF
--- a/app/services/concerns/xccdf_report/rule_references.rb
+++ b/app/services/concerns/xccdf_report/rule_references.rb
@@ -24,7 +24,7 @@ module XCCDFReport
         # new_rules.map(&:id) == new_rule_records.pluck(:ref_id)
         new_rule_records.zip(new_rules).each do |rule_record, oscap_rule|
           references = RuleReference.find_from_oscap(oscap_rule.references)
-          rule_record.update(rule_references: references)
+          rule_record.rule_references = references
         end
       end
 

--- a/app/services/concerns/xccdf_report/rules.rb
+++ b/app/services/concerns/xccdf_report/rules.rb
@@ -39,9 +39,8 @@ module XCCDFReport
 
       def save_rules
         add_profiles_to_old_rules(rules_already_saved, new_profiles)
-        rule_import = Rule.import!(new_rule_records, recursive: true)
         associate_rule_references
-        rule_import
+        Rule.import!(new_rule_records, recursive: true)
       end
 
       private


### PR DESCRIPTION
This changes from <# of new rules> updates for rule references to 1 update. It shaves about 13 seconds off the initial import, from ~85 seconds to ~72 seconds.

Signed-off-by: Andrew Kofink <akofink@redhat.com>