### PR TITLE
Fixes 323: Include associations in graphql query

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module Types
+  # Definition of the BaseObject type in GraphQL
   class BaseObject < GraphQL::Schema::Object
+    protected
+
+    def lookahead_includes(lookahead, object, selects_includes)
+      selects_includes.each do |selects, includes|
+        object = object.includes(includes) if lookahead.selects?(selects)
+      end
+
+      object
+    end
   end
 end

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -11,7 +11,7 @@ module Types
     field :description, String, null: true
     field :ref_id, String, null: false
     field :compliance_threshold, Float, null: false
-    field :rules, [::Types::Rule], null: true do
+    field :rules, [::Types::Rule], null: true, extras: [:lookahead] do
       argument :identifier, String,
                'Rule identifier to filter by', required: false
       argument :references, [String],
@@ -23,6 +23,11 @@ module Types
 
       rules = rules.with_identifier(args[:identifier]) if args.dig(:identifier)
       rules = rules.with_references(args[:references]) if args.dig(:references)
+
+      rules = lookahead_includes(args[:lookahead], rules,
+                                 compliant: :rule_results,
+                                 identifier: :rule_identifier,
+                                 references: :rule_references)
 
       rules
     end


### PR DESCRIPTION
The following is the system details graphql query with the standard RHEL7 profile for this system:

Before: 

```
Completed 200 OK in 24344ms (Views: 302.9ms | ActiveRecord: 2026.4ms)


user: root
POST /api/compliance/graphql
USE eager loading detected
  Rule => [:rule_identifier]
  Add to your finder: :includes => [:rule_identifier]
Call stack
  /app/app/controllers/graphql_controller.rb:8:in `query'


user: root
POST /api/compliance/graphql
USE eager loading detected
  Rule => [:rule_references_rules]
  Add to your finder: :includes => [:rule_references_rules]
Call stack
  /app/app/controllers/graphql_controller.rb:8:in `query'


user: root
POST /api/compliance/graphql
USE eager loading detected
  Rule => [:rule_references]
  Add to your finder: :includes => [:rule_references]
Call stack
  /app/app/controllers/graphql_controller.rb:8:in `query'
```

After:

```
Completed 200 OK in 17949ms (Views: 340.4ms | ActiveRecord: 888.1ms)
```

It uses the [lookahead feature of graphql-ruby](https://graphql-ruby.org/queries/lookahead.html).

Signed-off-by: Andrew Kofink <akofink@redhat.com>