### PR TITLE
Remove unnecessary includes in graphql

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -25,7 +25,6 @@ module Types
       rules = rules.with_references(args[:references]) if args.dig(:references)
 
       rules = lookahead_includes(args[:lookahead], rules,
-                                 compliant: :rule_results,
                                  identifier: :rule_identifier,
                                  references: :rule_references)
 


### PR DESCRIPTION
After merging #210, I noticed the following:

```
user: root
POST /api/compliance/graphql
AVOID eager loading detected
  Rule => [:rule_results]
  Remove from your finder: :includes => [:rule_results]
Call stack
```

It seems we used one too many includes!

Signed-off-by: Andrew Kofink <akofink@redhat.com>