### PR TITLE
Use type collector not collector with prometheus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - .:/app:z
     ports:
       - '9394:9394'
-    command: bundle exec prometheus_exporter -c lib/graphql_collector.rb
+    command: bundle exec prometheus_exporter -a lib/graphql_collector.rb
   sidekiq:
     image: compliance-backend-rails
     restart: on-failure


### PR DESCRIPTION
This change fixes the following errors in devel:

```
Attaching to compliance-backend_prometheus_1
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>5.679999594576657e-05, "platform_key"=>"__Schema.queryType", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>2.43279937421903e-05, "platform_key"=>"__Field.type", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>2.346000110264868e-05, "platform_key"=>"__Type.ofType", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>5.343199882190675e-05, "platform_key"=>"__Field.args", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.001320823997957632, "platform_key"=>"Query.system", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>6.63116837599955, "platform_key"=>"Profile.rules", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.001332247004029341, "platform_key"=>"Rule.references", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.007206014997791499, "platform_key"=>"Rule.references", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.005436313003883697, "platform_key"=>"Rule.references", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.0001367219956591725, "platform_key"=>"Rule.identifier", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.0001967330026673153, "platform_key"=>"Rule.identifier", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.0001855099981185049, "platform_key"=>"Rule.identifier", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.0004440129996510223, "platform_key"=>"Rule.references", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.0004634979995898902, "platform_key"=>"Rule.references", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.0001831010013120249, "platform_key"=>"Rule.identifier", "key"=>"execute_field"}
prometheus_1        | failed to register metric {"type"=>"graphql", "duration"=>0.0002300990017829463, "platform_key"=>"Rule.identifier", "key"=>"execute_field"}
prometheus_1        | 2019-08-28 13:23:21 +0000 Starting prometheus exporter on port 9394
```

From https://graphql-ruby.org/queries/tracing#prometheus

Signed-off-by: Andrew Kofink <akofink@redhat.com>