### PR TITLE
Do not instantiate unnecessary objects in graphql

### DIFF
--- a/app/graphql/types/rule.rb
+++ b/app/graphql/types/rule.rb
@@ -14,13 +14,22 @@ module Types
     field :severity, String, null: false
     field :profiles, [::Types::Profile], null: true
     field :identifier, ::Types::RuleIdentifier, null: true
-    field :references, [::Types::RuleReference], null: true
+    field :references, [::Types::RuleReference], null: true,
+                                                 extras: [:lookahead]
     field :compliant, Boolean, null: false do
       argument :system_id, String, 'Is a system compliant?', required: true
     end
 
     def compliant(system_id:)
       object.compliant?(Host.find(system_id))
+    end
+
+    def references(lookahead:)
+      selected_columns = lookahead.selections.map(&:name) &
+                         ::RuleReference.column_names.map(&:to_sym)
+      object.references.pluck(selected_columns).map do |reference|
+        selected_columns.zip([reference].flatten).to_h
+      end
     end
   end
 end

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -41,7 +41,7 @@ module Types
     end
 
     def profile_names
-      object.profiles.map(&:name).join(', ')
+      object.profiles.pluck(:name).join(', ')
     end
 
     def rules_passed(args = {})
@@ -67,8 +67,7 @@ module Types
     def last_scanned(args = {})
       if args[:profile_id].present?
         rule_ids = ::Profile.find(args[:profile_id]).rules.pluck(:id)
-        rule_results = ::RuleResult.where(rule_id: rule_ids,
-                                          host: object.id)
+        rule_results = object.rule_results.where(rule_id: rule_ids)
       else
         rule_results = object.rule_results
       end


### PR DESCRIPTION
From the system details graphql request:

Before:

```
Completed 200 OK in 20178ms (Views: 281.5ms | ActiveRecord: 909.9ms)
```

After:

```
Completed 200 OK in 12679ms (Views: 320.2ms | ActiveRecord: 2061.4ms)
```

At this point, I think the bulk of the time is spent creating/serializing objects rather than SQL execution. This PR trades higher SQL time for creating less objects (essentially via `pluck`). It is about a 7 second improvement in response time, but we're still at around 13 seconds total for this response. :man_shrugging: 

Signed-off-by: Andrew Kofink <akofink@redhat.com>