### PR TITLE
Fixes #236: Remove slug/friendly_id from profiles

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,7 +7,7 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    profile = Profile.friendly.find(params[:id])
+    profile = Profile.find(params[:id])
     authorize profile
     render json: ProfileSerializer.new(profile)
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,9 +2,7 @@
 
 # OpenSCAP profile
 class Profile < ApplicationRecord
-  extend FriendlyId
   scoped_search on: %i[id name ref_id account_id compliance_threshold]
-  friendly_id :ref_id, use: :slugged
 
   has_many :profile_rules, dependent: :delete_all
   has_many :rules, through: :profile_rules, source: :rule

--- a/db/migrate/20190829162229_remove_slug_from_profiles.rb
+++ b/db/migrate/20190829162229_remove_slug_from_profiles.rb
@@ -1,0 +1,5 @@
+class RemoveSlugFromProfiles < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :profiles, :slug
+  end
+end


### PR DESCRIPTION
Profile ref_id is not globally unique. Profiles are unique by ref_id,
account_id, and name, but that doesn't work well for a friendly ID.

https://projects.engineering.redhat.com/browse/RHICOMPL-236

Signed-off-by: Andrew Kofink <akofink@redhat.com>