### PR TITLE
Allow an environment variable for the test DB

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,19 +14,10 @@ default: &default
 
 test:
   <<: *default
-  # use this config with docker-compose
-  #host: db
-  #username: postgres
-  #password:
-  #database: compliance_test
+  database: <%= ENV['POSTGRESQL_TEST_DATABASE'] || ENV['POSTGRESQL_DATABASE'] %>
 
 production:
   <<: *default
 
 development:
   <<: *default
-  # use this config with docker-compose
-  #host: db
-  #username: postgres
-  #password:
-  #database: compliance_dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - DATABASE_SERVICE_NAME=postgres
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
       - POSTGRESQL_USER=postgres
       - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
     ports:
@@ -36,6 +37,7 @@ services:
       - DATABASE_SERVICE_NAME=postgres
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
       - POSTGRESQL_USER=postgres
       - KAFKAMQ=kafka:29092
     depends_on:
@@ -73,6 +75,7 @@ services:
       - DATABASE_SERVICE_NAME=postgres
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
       - POSTGRESQL_USER=postgres
   redis:
     image: redis:latest


### PR DESCRIPTION
- Update docker-compose with the environment variable

I've been getting these kinds of messages with the commented version of the database.yml in master: 

```
ActiveRecord::EnvironmentMismatchError: You are attempting to modify a database that was last run in `test` environment.                                                                                           
You are running in `development` environment. If you are sure you want to continue, first set the environment using:                                                                                               
                                                                                                                                                                                                                   
        bin/rails db:environment:set RAILS_ENV=development
```

This allows passing another environment variable to specify a separate test database, but it is not required.

Signed-off-by: Andrew Kofink <akofink@redhat.com>