### PR TITLE
Add a concurrency variable for Sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+---
+:concurrency: <%= ENV["SIDEKIQ_CONCURRENCY"] || ENV["POSTGRESQL_MAX_CONNECTIONS"] || 10 %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev
       - POSTGRESQL_USER=postgres
+      - SIDEKIQ_CONCURRENCY=5
   redis:
     image: redis:latest
 


### PR DESCRIPTION
Fixes the following issue:

```
WARN: ActiveRecord::ConnectionTimeoutError: could not obtain a connection from the pool within 5.000 seconds (waited 5.002 seconds); all pooled connections were in use
```

The default is 10, which I've kept if no environment variable is set, or the max database connections if that's set. Alternatively, you may specify an environment variable separate from the database variable if you so desire.

I noticed there is a mismatch in both CI and production between the max DB connections and the number of sidekiq threads. This PR should also fix the issue in both without updating the deployment config. It should also help sidekiq scale better to more pods.

Fixes https://projects.engineering.redhat.com/browse/RHICOMPL-337

Signed-off-by: Andrew Kofink <akofink@redhat.com>