### PR TITLE
RHICOMPL-216 - Show only pass/fail results

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -22,14 +22,13 @@ module Types
     def rules(args = {})
       selected_columns = args[:lookahead].selections.map(&:name) &
                          ::Rule.column_names.map(&:to_sym)
-      rules = object.rules.select(selected_columns)
-
+      rules = object.rules.select(selected_columns << :id).where(
+        id: RuleResult.selected.pluck(:rule_id)
+      )
       rules = rules.with_identifier(args[:identifier]) if args.dig(:identifier)
       rules = rules.with_references(args[:references]) if args.dig(:references)
-
       rules = lookahead_includes(args[:lookahead], rules,
                                  identifier: :rule_identifier)
-
       rules
     end
     # rubocop:enable AbcSize

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -56,10 +56,8 @@ module Types
       ::Rails.cache.fetch("#{object.id}/failed_rule_objects_result",
                           expires_in: 1.week) do
         ::Rule.where(
-          id: ::RuleResult.includes(:rule).where(
-            host: object,
-            result: %w[error fail notchecked]
-          ).pluck(:rule_id).uniq
+          id: ::RuleResult.failed.for_system(object.id)
+              .includes(:rule).pluck(:rule_id).uniq
         )
       end
     end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -53,8 +53,8 @@ class Rule < ApplicationRecord
                     ORDER BY end_time DESC, created_at DESC
              )
           FROM rule_results rr2
-          WHERE rr2.host_id = ? AND rr2.rule_id = ?
-       ) rule_results WHERE RANK = 1', host.id, id]
+          WHERE rr2.host_id = ? AND rr2.result IN (?) AND rr2.rule_id = ?
+       ) rule_results WHERE RANK = 1', host.id, RuleResult::SELECTED, id]
       ).last
       return false if latest_result.blank?
 

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -10,4 +10,11 @@ class RuleResult < ApplicationRecord
 
   validates :host, presence: true
   validates :rule, presence: true
+
+  SELECTED = %w[pass fail notapplicable error unknown].freeze
+  FAIL = %w[fail error unknown notchecked].freeze
+
+  scope :selected, -> { where(result: SELECTED) }
+  scope :failed, -> { where(result: FAIL) }
+  scope :for_system, ->(host_id) { where(host_id: host_id) }
 end

--- a/test/graphql/queries/rule_query_test.rb
+++ b/test/graphql/queries/rule_query_test.rb
@@ -9,6 +9,7 @@ class RuleQueryTest < ActiveSupport::TestCase
     profiles(:one).update rules: [rules(:one)]
     rules(:one).update rule_identifier: rule_identifiers(:one)
     rules(:one).update rule_references: [rule_references(:one)]
+    rule_results(:one).update rule: rules(:one), host: hosts(:one)
   end
 
   test 'rules are filtered by identifier' do

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -25,10 +25,10 @@ class ProfileTest < ActiveSupport::TestCase
     assert profiles(:one).compliant?(hosts(:one))
   end
 
-  test 'host is not compliant if some rules are "fail" or "notselected"' do
+  test 'host is not compliant if some rules are "fail" or "error"' do
     RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass')
     RuleResult.create(rule: rules(:two), host: hosts(:one),
-                      result: 'notchecked')
+                      result: 'error')
     assert_not profiles(:one).compliant?(hosts(:one))
 
     RuleResult.find_by(rule: rules(:two), host: hosts(:one))
@@ -56,7 +56,7 @@ class ProfileTest < ActiveSupport::TestCase
     setup do
       RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass')
       RuleResult.create(rule: rules(:two), host: hosts(:one),
-                        result: 'notchecked')
+                        result: 'fail')
     end
 
     should 'host is compliant if 50% of rules pass with a threshold of 50' do


### PR DESCRIPTION
Moved from https://github.com/RedHatInsights/compliance-backend/pull/225 

- This version does not rely on default_scope
- It should be followed by a PR that stops parsing irrelevant results (notselected)
- The response time is considerably faster as we cut down results by 90%
