### PR TITLE
INSIGHTSQA-1564 - Uncomment cancelPriorBuilds call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
 @Library("github.com/RedHatInsights/insights-pipeline-lib") _
 
 node {
-    //cancelPriorBuilds()
+    cancelPriorBuilds()
 
     runIfMasterOrPullReq {
         runStages()


### PR DESCRIPTION
Reverting back changes from #224 as of RedHatInsights/insights-pipeline-lib#43  'cancelPriorBuilds' can be called more than once.