### PR TITLE
Fail for missing Account in import_remediations

### DIFF
--- a/lib/tasks/import_remediations.rake
+++ b/lib/tasks/import_remediations.rake
@@ -15,7 +15,7 @@ task import_remediations: :environment do
   start_time = Time.now.utc
   puts "Starting import_remediations job at #{start_time}"
   RemediationsAPI.new(
-    Account.find_by(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
+    Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
   ).import_remediations
   end_time = Time.now.utc
   duration = end_time - start_time


### PR DESCRIPTION
```
# Before
$ bundle exec rake import_remediations JOBS_ACCOUNT_NUMBER=1212
Starting import_remediations job at 2019-09-19 18:22:56 UTC
rake aborted!
NoMethodError: undefined method `fake_identity_header' for nil:NilClass
/app/app/services/remediations_api.rb:8:in `initialize'
/app/lib/tasks/import_remediations.rake:17:in `new'
/app/lib/tasks/import_remediations.rake:17:in `block in <top (required)>'
/usr/local/bundle/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:30:in `block in <main>'
/usr/local/bin/bundle:22:in `<main>'
Tasks: TOP => import_remediations
(See full trace by running task with --trace)

# After
$ bundle exec rake import_remediations JOBS_ACCOUNT_NUMBER=1212
Starting import_remediations job at 2019-09-19 18:26:02 UTC
rake aborted!
ActiveRecord::RecordNotFound: Couldn't find Account
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/core.rb:217:in `find_by!'
/app/lib/tasks/import_remediations.rake:18:in `block in <top (required)>'
/usr/local/bundle/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:30:in `block in <main>'
/usr/local/bin/bundle:22:in `<main>'
Tasks: TOP => import_remediations
(See full trace by running task with --trace)
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>