### PR TITLE
Ease the use of local gems in devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 
 brakeman_output.markdown
+
+Gemfile.local

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - 'test/fixtures/**/*'
     - 'Rakefile'
     - 'Gemfile'
+    - 'vendor/**/*'
 
 Rails:
   Enabled: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y qt5-default libqt5webkit5-dev \
       gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x libopenscap-dev \
       postgresql-client
 
+COPY vendor/ ./vendor
 COPY Gemfile* ./
 COPY entrypoint.sh ./
 

--- a/Gemfile
+++ b/Gemfile
@@ -101,3 +101,9 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+group :development, :test do
+  # load local gemfile
+  local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
+  self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
+end

--- a/Gemfile.local.example
+++ b/Gemfile.local.example
@@ -1,0 +1,1 @@
+ gem 'openscap_parser', path: 'vendor/openscap_parser'


### PR DESCRIPTION
To use (i.e.) local openscap_parser with this PR:

1. `cp <gem repo> vendor/`
1. `cp Gemfile.local.example Gemfile.local`
1. comment out the existing gem (i.e. openscap_parser) in the Gemfile
1. Run `bundle update <gem>` or rebuild the container image

Signed-off-by: Andrew Kofink <akofink@redhat.com>