### PR TITLE
Require query, mutation in graphql schema

### DIFF
--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -2,6 +2,8 @@
 
 require 'prometheus_exporter/client' unless Rails.env.test?
 require 'compliance_timeout'
+require_relative 'types/query'
+require_relative 'types/mutation'
 
 # Definition for the GraphQL schema - read the
 # GraphQL-ruby documentation to find out what to add or


### PR DESCRIPTION
Fixes the following issue after hot-reloading:

```
Completed 500 Internal Server Error in 110ms (ActiveRecord: 15.4ms)

NameError (uninitialized constant Schema::Types):
  
app/graphql/schema.rb:12:in `<class:Schema>'
app/graphql/schema.rb:9:in `<top (required)>'
app/controllers/graphql_controller.rb:8:in `query'
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>