### PR TITLE
RHICOMPL-363 - Make uniqueness constraint for profile account_id and name

### DIFF
--- a/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
+++ b/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintToProfileByAccount < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:profiles , %i[account_id ref_id benchmark_id], unique: true)
+  end
+end

--- a/test/services/xccdf_report_migration_test.rb
+++ b/test/services/xccdf_report_migration_test.rb
@@ -49,7 +49,7 @@ class XCCDFReportMigrationTest < ActiveSupport::TestCase
     conflict_profile = Profile.create!(
       account: accounts(:test),
       hosts: [hosts(:one)],
-      name: 'footitle',
+      name: 'footitle2',
       benchmark: benchmarks(:one),
       ref_id: "xccdf_org.ssgproject.content_profile_#{@profile.ref_id}"
     )


### PR DESCRIPTION
Currently if many threads start to upload reports with the same profile
for the first time to an account, it could happen that 6 sidekiq pods
(at the moment these are 6 threads but it could change) start processing
the report at the same time.

Since all data is saved on the database at once, the Rails uniqueness
constraints may NOT apply in this case of concurrent parsing. It will
end with multiple profiles with the same ref_id, name and account_id
which is not what is expected.

This PR introduces a DB constraint so that when this happens, only 1 of
the jobs will actually save the profile, the first one to finish
parsing. The rest of them will likely fail - which is EXPECTED. As the
job is going to retry 3 times, it will retry the parsing and the 2nd
time `Profile.find_or_initialize` will find the pre-existing profile, so
it's eventually consistent.