### PR TITLE
RHICOMPL-397 - Remove systems count from rules API

### DIFF
--- a/app/serializers/rule_serializer.rb
+++ b/app/serializers/rule_serializer.rb
@@ -5,10 +5,4 @@ class RuleSerializer
   include FastJsonapi::ObjectSerializer
   attributes :created_at, :updated_at, :ref_id, :title, :rationale,
              :description, :severity
-  attributes :total_systems_count do |rule|
-    rule.hosts.count {}
-  end
-  attributes :affected_systems_count do |rule|
-    rule.hosts.count { |host| rule.compliant?(host) }
-  end
 end


### PR DESCRIPTION
Currently the API is taking very long to return the number of hosts that
are compliant or not with each rule. This info is not directly relevant
to our main consumer of the Rules API.

In fact, that info is taking a long time to compute, we've seen
responses of 15s+ timing out. This causes problems in the Remediations
app, which relies on this API to show the rules.

I advocate for just removing this info and the response becomes just as
simple as

1. Checking the user is registered and has a policy with the rule
2. Returning the rule

On average this is taking 60ms total.