### PR TITLE
Relay GraphQL (pagination)

### DIFF
--- a/app/graphql/connections/base_connection.rb
+++ b/app/graphql/connections/base_connection.rb
@@ -1,0 +1,9 @@
+module Connections
+  class BaseConnection < GraphQL::Types::Relay::BaseConnection
+    field :total_count, Integer, null: false
+
+    def total_count
+      object.nodes.size
+    end
+  end
+end

--- a/app/graphql/connections/base_connection.rb
+++ b/app/graphql/connections/base_connection.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 module Connections
+  # Contains fields and methods related with GraphQL connection fields
   class BaseConnection < GraphQL::Types::Relay::BaseConnection
     field :total_count, Integer, null: false
 
     def total_count
-      object.nodes.size
+      object.nodes.count
     end
   end
 end

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class BaseResolver < GraphQL::Schema::Resolver
+  end
+end

--- a/app/graphql/resolvers/concerns/collection.rb
+++ b/app/graphql/resolvers/concerns/collection.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module Concerns
+    # Module for Collection GraphQL fields, contains usual pagination options
+    module Collection
+      extend ActiveSupport::Concern
+
+      included do
+        type ["Types::#{self::MODEL_CLASS}".safe_constantize], null: false
+        argument :search, String, 'Search query', required: false
+        argument :limit, Integer, 'Pagination limit', required: false
+        argument :offset, Integer, 'Pagination offset', required: false
+      end
+
+      def resolve(**kwargs)
+        filters = filter_list(**kwargs)
+        base_scope = authorized_scope
+        filters.reduce(base_scope) { |scope, filter| filter.call(scope) }
+      end
+
+      private
+
+      def filter_list(search: nil, offset: nil, limit: nil)
+        filters = []
+        filters << search_filter(search: search) if search.present?
+
+        if offset.present? || limit.present?
+          filters << pagination_filter(offset: offset, limit: limit)
+        end
+
+        filters
+      end
+
+      def pagination_filter(offset:, limit:)
+        lambda do |scope|
+          begin
+            scope.paginate(page: offset, per_page: limit)
+          rescue ScopedSearch::QueryNotSupported => e
+            raise GraphQL::ExecutionError, e.message
+          end
+        end
+      end
+
+      def search_filter(search:)
+        lambda do |scope|
+          begin
+            scope.search_for(search)
+          rescue ScopedSearch::QueryNotSupported => e
+            raise GraphQL::ExecutionError, e.message
+          end
+        end
+      end
+
+      def model_class
+        self.class::MODEL_CLASS
+      end
+
+      def authorized_scope
+        Pundit.policy_scope(context[:current_user], model_class)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/concerns/record.rb
+++ b/app/graphql/resolvers/concerns/record.rb
@@ -1,0 +1,17 @@
+module Resolvers
+  module Concerns
+    module Record
+      extend ActiveSupport::Concern
+
+      included do
+        type "Types::#{self::MODEL_CLASS}".safe_constantize, null: false
+
+        argument :id, String, 'Global ID for Record', required: true
+      end
+
+      def resolve(id:)
+        RecordLoader.for(self.class::MODEL_CLASS).load_by_global_id(id)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/concerns/record.rb
+++ b/app/graphql/resolvers/concerns/record.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module Resolvers
   module Concerns
+    # Contains fields and methods related with GraphQL Relay record field
     module Record
       extend ActiveSupport::Concern
 
@@ -10,7 +13,7 @@ module Resolvers
       end
 
       def resolve(id:)
-        RecordLoader.for(self.class::MODEL_CLASS).load_by_global_id(id)
+        ::RecordLoader.for(self.class::MODEL_CLASS).load_by_global_id(id)
       end
     end
   end

--- a/app/graphql/resolvers/generic.rb
+++ b/app/graphql/resolvers/generic.rb
@@ -1,0 +1,27 @@
+module Resolvers
+  class Generic
+    def initialize(type)
+      @type = type
+    end
+
+    def self.for(type)
+      new(type)
+    end
+
+    def collection
+      return unless model_class
+      base_class.include(Resolvers::Concerns::Collection)
+    end
+
+    private
+
+    attr_reader :type
+    delegate :model_class, to: :type
+
+    def base_class
+      Class.new(Resolvers::BaseResolver).tap do |c|
+        c.const_set('MODEL_CLASS', model_class)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/generic.rb
+++ b/app/graphql/resolvers/generic.rb
@@ -1,5 +1,10 @@
+# frozen_string_literal: true
+
 module Resolvers
+  # Base class for resolvers
   class Generic
+    attr_reader :type
+
     def initialize(type)
       @type = type
     end
@@ -8,14 +13,20 @@ module Resolvers
       new(type)
     end
 
+    def record
+      return unless model_class
+
+      base_class.include(Resolvers::Concerns::Record)
+    end
+
     def collection
       return unless model_class
+
       base_class.include(Resolvers::Concerns::Collection)
     end
 
     private
 
-    attr_reader :type
     delegate :model_class, to: :type
 
     def base_class

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1,23 +1,105 @@
 """
 A Business Objective registered in Insights Compliance
 """
-type BusinessObjective {
+type BusinessObjective implements Node {
+  globalId: ID!
   id: ID!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   title: String!
 }
 
 """
 The mutation root of this schema
 """
-type Mutation {
+type Mutation implements Node {
   createBusinessObjective(input: createBusinessObjectiveInput!): createBusinessObjectivePayload
+  globalId: ID!
+
+  """
+  ID of the object.
+  """
+  id: ID!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   updateProfile(input: UpdateProfileInput!): UpdateProfilePayload
+}
+
+"""
+An object with an ID.
+"""
+interface Node {
+  """
+  ID of the object.
+  """
+  id: ID!
+}
+
+"""
+Information about pagination in a connection.
+"""
+type PageInfo {
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+
+  """
+  When paginating forwards, are there more items?
+  """
+  hasNextPage: Boolean!
+
+  """
+  When paginating backwards, are there more items?
+  """
+  hasPreviousPage: Boolean!
+
+  """
+  When paginating backwards, the cursor to continue.
+  """
+  startCursor: String
 }
 
 """
 A Profile registered in Insights Compliance
 """
-type Profile {
+type Profile implements Node {
   businessObjective: BusinessObjective
   businessObjectiveId: ID
   complianceThreshold: Float!
@@ -25,19 +107,40 @@ type Profile {
     """
     Is a system compliant?
     """
-    systemId: String!
+    systemId: String
   ): Boolean!
   compliantHostCount: Int!
   description: String
+  globalId: ID!
   hosts: [System!]
   id: ID!
   lastScanned(
     """
     Last time this profile was scanned for a system
     """
-    systemId: String!
+    systemId: String
   ): String!
   name: String!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   refId: String!
   rules(
     """
@@ -59,21 +162,57 @@ type Profile {
     """
     Rules failed for a system and a profile
     """
-    systemId: String!
+    systemId: String
   ): Int!
   rulesPassed(
     """
     Rules passed for a system and a profile
     """
-    systemId: String!
+    systemId: String
   ): Int!
   totalHostCount: Int!
 }
 
 """
+The connection type for Profile.
+"""
+type ProfileConnection {
+  """
+  A list of edges.
+  """
+  edges: [ProfileEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Profile]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type ProfileEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Profile
+}
+
+"""
 The root of all queries
 """
-type Query {
+type Query implements Node {
   """
   All image streams visible by the user
   """
@@ -118,18 +257,116 @@ type Query {
   All business objectives visible by the user
   """
   businessObjectives: [BusinessObjective!]
+  globalId: ID!
+
+  """
+  ID of the object.
+  """
+  id: ID!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   profile(id: String!): Profile
+  profiles(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Pagination limit
+    """
+    limit: Int
+
+    """
+    Pagination offset
+    """
+    offset: Int
+
+    """
+    Search query
+    """
+    search: String
+  ): ProfileConnection!
 
   """
   Details for a system
   """
   system(id: String!): System
+  systems(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Pagination limit
+    """
+    limit: Int
+
+    """
+    Pagination offset
+    """
+    offset: Int
+
+    """
+    Search query
+    """
+    search: String
+  ): SystemConnection!
 }
 
 """
 A Rule registered in Insights Compliance
 """
-type Rule {
+type Rule implements Node {
   compliant(
     """
     Is a system compliant?
@@ -137,8 +374,29 @@ type Rule {
     systemId: String!
   ): Boolean!
   description: String
+  globalId: ID!
   id: ID!
   identifier: RuleIdentifier
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   profiles: [Profile!]
   rationale: String
   refId: String!
@@ -151,9 +409,30 @@ type Rule {
 """
 A Rule Identifier
 """
-type RuleIdentifier {
+type RuleIdentifier implements Node {
+  globalId: ID!
   id: ID!
   label: String!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   rule: Rule
   system: String!
 }
@@ -161,23 +440,45 @@ type RuleIdentifier {
 """
 An OpenSCAP Rule Reference
 """
-type RuleReference {
+type RuleReference implements Node {
+  globalId: ID!
   href: String!
   id: ID!
   label: String!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   rules: [Rule!]
 }
 
 """
 A System registered in Insights Compliance
 """
-type System {
+type System implements Node {
   compliant(
     """
     Filter results by profile ID
     """
     profileId: String
   ): Boolean!
+  globalId: ID!
   id: ID!
   lastScanned(
     """
@@ -186,6 +487,26 @@ type System {
     profileId: String
   ): String
   name: String!
+
+  """
+  Fetches an object given its ID.
+  """
+  node(
+    """
+    ID of the object.
+    """
+    id: ID!
+  ): Node
+
+  """
+  Fetches a list of objects given a list of IDs.
+  """
+  nodes(
+    """
+    IDs of the objects.
+    """
+    ids: [ID!]!
+  ): [Node]!
   profileNames: String!
   profiles: [Profile!]
 
@@ -205,6 +526,42 @@ type System {
     """
     profileId: String
   ): Int!
+}
+
+"""
+The connection type for System.
+"""
+type SystemConnection {
+  """
+  A list of edges.
+  """
+  edges: [SystemEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [System]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type SystemEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: System
 }
 
 """

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -15,7 +15,7 @@ module Types
         if new_model_class
           @model_class = new_model_class
         else
-          @model_class ||= "::#{self.to_s.demodulize}".safe_constantize
+          @model_class ||= "::#{to_s.demodulize}".safe_constantize
         end
       end
     end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -2,7 +2,24 @@
 
 module Types
   # Definition of the BaseObject type in GraphQL
-  class BaseObject < GraphQL::Schema::Object
+  class BaseObject < GraphQL::Types::Relay::BaseObject
+    implements GraphQL::Relay::Node.interface
+    connection_type_class Connections::BaseConnection
+
+    global_id_field :global_id
+    field :node, field: GraphQL::Relay::Node.field
+    field :nodes, field: GraphQL::Relay::Node.plural_field
+
+    class << self
+      def model_class(new_model_class = nil)
+        if new_model_class
+          @model_class = new_model_class
+        else
+          @model_class ||= "::#{self.to_s.demodulize}".safe_constantize
+        end
+      end
+    end
+
     protected
 
     def lookahead_includes(lookahead, object, selects_includes)

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -41,22 +41,22 @@ module Types
     field :total_host_count, Int, null: false
 
     field :compliant, Boolean, null: false do
-      argument :system_id, String, 'Is a system compliant?', required: true
+      argument :system_id, String, 'Is a system compliant?', required: false
     end
 
     field :rules_passed, Int, null: false do
       argument :system_id, String,
-               'Rules passed for a system and a profile', required: true
+               'Rules passed for a system and a profile', required: false
     end
 
     field :rules_failed, Int, null: false do
       argument :system_id, String,
-               'Rules failed for a system and a profile', required: true
+               'Rules failed for a system and a profile', required: false
     end
 
     field :last_scanned, String, null: false do
       argument :system_id, String,
-               'Last time this profile was scanned for a system', required: true
+               'Last time this profile was scanned for a system', required: false
     end
 
     field :compliant_host_count, Int, null: false
@@ -68,19 +68,23 @@ module Types
       object.hosts.count
     end
 
-    def compliant(system_id:)
+    def compliant(args={})
+      system_id = args[:system_id] || context[:parent_system_id]
       object.compliant?(Host.find(system_id))
     end
 
-    def rules_passed(system_id:)
+    def rules_passed(args={})
+      system_id = args[:system_id] || context[:parent_system_id]
       Host.find(system_id).rules_passed(object)
     end
 
-    def rules_failed(system_id:)
+    def rules_failed(args={})
+      system_id = args[:system_id] || context[:parent_system_id]
       Host.find(system_id).rules_failed(object)
     end
 
-    def last_scanned(system_id:)
+    def last_scanned(args={})
+      system_id = args[:system_id] || context[:parent_system_id]
       rule_ids = object.rules.pluck(:id)
       rule_results = RuleResult.where(
         rule_id: rule_ids,

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -12,12 +12,14 @@ module Types
       end
 
       def collection_field(name, type)
-        field name, type.connection_type, resolver: Resolvers::Generic.for(type).collection
+        field name, type.connection_type,
+              null: false, resolver: Resolvers::Generic.for(type).collection
       end
     end
 
     collection_field :systems, Types::System
     collection_field :profiles, Types::Profile
+    record_field :profile, Types::Profile
 
     field :all_systems, [Types::System], null: true do
       description 'All systems visible by the user'

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -6,6 +6,19 @@ module Types
     graphql_name 'Query'
     description 'The root of all queries'
 
+    class << self
+      def record_field(name, type)
+        field name, type, resolver: Resolvers::Generic.for(type).record
+      end
+
+      def collection_field(name, type)
+        field name, type.connection_type, resolver: Resolvers::Generic.for(type).collection
+      end
+    end
+
+    collection_field :systems, Types::System
+    collection_field :profiles, Types::Profile
+
     field :all_systems, [Types::System], null: true do
       description 'All systems visible by the user'
       argument :search, String, 'Search query', required: false

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -8,7 +8,7 @@ module Types
 
     field :id, ID, null: false
     field :name, String, null: false
-    field :profiles, [::Types::Profile], null: true
+    field :profiles, [::Types::Profile], null: true, extras: [:lookahead]
     field :compliant, Boolean, null: false do
       argument :profile_id, String, 'Filter results by profile ID',
                required: false
@@ -28,6 +28,13 @@ module Types
     field :last_scanned, String, null: true do
       argument :profile_id, String, 'Filter results by profile ID',
                required: false
+    end
+
+    def profiles(lookahead:)
+      if [:rulesPassed, :rulesFailed, :compliant, :lastScanned].any? { |option| lookahead.selects?(option) }
+        context[:parent_system_id] = object.id
+      end
+      object.profiles
     end
 
     def compliant(args = {})

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -3,6 +3,7 @@
 module Types
   # Definition of the System GraphQL type
   class System < Types::BaseObject
+    model_class ::Host
     graphql_name 'System'
     description 'A System registered in Insights Compliance'
 
@@ -31,9 +32,7 @@ module Types
     end
 
     def profiles(lookahead:)
-      if [:rulesPassed, :rulesFailed, :compliant, :lastScanned].any? { |option| lookahead.selects?(option) }
-        context[:parent_system_id] = object.id
-      end
+      context_parent(lookahead)
       object.profiles
     end
 
@@ -78,6 +77,15 @@ module Types
       end
 
       rule_results.maximum(:end_time)&.iso8601 || 'Never'
+    end
+
+    private
+
+    def context_parent(lookahead)
+      profile_fields = %i[rulesPassed rulesFailed compliant lastScanned]
+      return unless profile_fields.any? { |field| lookahead.selects?(field) }
+
+      context[:parent_system_id] = object.id
     end
   end
 end


### PR DESCRIPTION
This allows to query connections so that:

```
{
    systems(first: 10, after: "MQ", search: "example") {
        totalCount
        pageInfo {
            startCursor
            endCursor
            hasNextPage
            hasPreviousPage
        },
        edges {
          cursor
          node {
            id
            name
          }
        }
    }
}
```

```
{
  "data": {
    "systems": {
      "totalCount": 200,
      "pageInfo": {
        "startCursor": "Mg",
        "endCursor": "MTE",
        "hasNextPage": true,
        "hasPreviousPage": false
      },
      "edges": [
        {
          "cursor": "Mg",
          "node": {
            "id": "QmFzZU9iamVjdC0wM2YwYTlhNS1jN2U2LTRhZTItOTIyYS00ZWNkMTE5ZmY3NmU=",
            "name": "example-1"
          }
        },
        {
          "cursor": "Mw",
          "node": {
            "id": "QmFzZU9iamVjdC0xOWI0NDk0ZS1jYWQxLTQ1NDEtYmQ4ZS0yMzIyOGU1YWU3NGM=",
            "name": "example-2"
          }
        },
        {
          "cursor": "NA",
          "node": {
            "id": "QmFzZU9iamVjdC0zMjE3OWFmOS03NmEwLTRjZmQtOTJjZC0wM2Y5ODZmYjE0OGM=",
            "name": "example-3"
          }
        },
        {
          "cursor": "NQ",
          "node": {
            "id": "QmFzZU9iamVjdC1mMTczZThjMy02MjRkLTQzZDEtOTQ0ZC1jYjFlN2YwN2MwMWM=",
            "name": "example-4"
          }
        },
        {
          "cursor": "Ng",
          "node": {
            "id": "QmFzZU9iamVjdC1jNjUzOTRiMS1iMjE2LTQwYWEtODNiZS1kZjMzOGNjNzg4Yjk=",
            "name": "example-5"
          }
        },
        {
          "cursor": "Nw",
          "node": {
            "id": "QmFzZU9iamVjdC1mNmRmZjhjYy04Y2MxLTQxNjktYTI4Mi1kNTYxMGJlZGM3MzY=",
            "name": "example-6"
          }
        },
        {
          "cursor": "OA",
          "node": {
            "id": "QmFzZU9iamVjdC0xMjViMmZhMC03Y2RlLTQ0MWMtYWY2OS0yNGRiODRjZTdkMzg=",
            "name": "example-7"
          }
        },
        {
          "cursor": "OQ",
          "node": {
            "id": "QmFzZU9iamVjdC1iZTgxZWQ1OC0wZDVjLTQxNDctODUzYy1hYTVlYTQ0ODgzYTg=",
            "name": "example-8"
          }
        },
        {
          "cursor": "MTA",
          "node": {
            "id": "QmFzZU9iamVjdC1lOWFjOGY1YS04Yzc1LTQ2ZGMtYjJkZi04OTc5MzA1OGU4NGM=",
            "name": "example-9"
          }
        },
        {
          "cursor": "MTE",
          "node": {
            "id": "QmFzZU9iamVjdC0zNzVjNjkwZi1jOWUwLTQxOTctYTYyNy0zZDFkMjk0NDFlMWU=",
            "name": "example-10"
          }
        }
      ]
    }
  }
}
```

This is missing tests, especially for authorization scopes