### PR TITLE
Parse rule identifiers

### DIFF
--- a/app/models/concerns/openscap_parser_derived.rb
+++ b/app/models/concerns/openscap_parser_derived.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Methods that are shared between models created from XCCDF types
+module OpenscapParserDerived
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :op_source
+  end
+end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -5,6 +5,7 @@
 class Rule < ApplicationRecord
   extend FriendlyId
   friendly_id :ref_id, use: :slugged
+  include OpenscapParserDerived
 
   has_many :profile_rules, dependent: :delete_all
   has_many :profiles, through: :profile_rules, source: :profile
@@ -40,6 +41,8 @@ class Rule < ApplicationRecord
   def self.from_openscap_parser(op_rule, benchmark_id: nil)
     rule = find_or_initialize_by(ref_id: op_rule.id,
                                  benchmark_id: benchmark_id)
+
+    rule.op_source = op_rule
 
     rule.assign_attributes(title: op_rule.title,
                            description: op_rule.description,

--- a/app/models/rule_identifier.rb
+++ b/app/models/rule_identifier.rb
@@ -7,10 +7,11 @@ class RuleIdentifier < ApplicationRecord
   validates :label, presence: true
   validates :system, presence: true
 
-  def self.from_openscap_parser(op_rule_identifier)
+  def self.from_openscap_parser(op_rule_identifier, rule_id)
     if op_rule_identifier.label # rubocop:disable Style/GuardClause
-      new(label: op_rule_identifier.label,
-          system: op_rule_identifier.system)
+      find_or_initialize_by(label: op_rule_identifier.label,
+                            system: op_rule_identifier.system,
+                            rule_id: rule_id)
     end
   end
 end

--- a/app/services/concerns/xccdf/rule_identifiers.rb
+++ b/app/services/concerns/xccdf/rule_identifiers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Xccdf
+  # Methods related to saving rule identifiers
+  module RuleIdentifiers
+    extend ActiveSupport::Concern
+
+    included do
+      def save_rule_identifiers
+        @rule_identifiers ||= @new_rules.map do |rule|
+          ::RuleIdentifier.from_openscap_parser(rule.op_source.identifier,
+                                                rule.id)
+        end.compact
+
+        ::RuleIdentifier.import!(new_rule_identifiers, ignore: true)
+      end
+
+      private
+
+      def new_rule_identifiers
+        @new_rule_identifiers ||= @rule_identifiers.select(&:new_record?)
+      end
+    end
+  end
+end

--- a/app/services/concerns/xccdf/rule_references.rb
+++ b/app/services/concerns/xccdf/rule_references.rb
@@ -11,22 +11,13 @@ module Xccdf
           ::RuleReference.from_openscap_parser(op_reference)
         end
 
-        ::RuleReference.import!(@rule_references.select(&:new_record?),
-                                ignore: true)
-      end
-
-      def associate_rule_references
-        # new_rules.map(&:id) == new_rule_records.pluck(:ref_id)
-        new_rule_records.zip(new_rules).each do |rule_record, op_rule|
-          references = ::RuleReference.find_from_oscap(op_rule.references)
-          rule_record.rule_references = references
-        end
+        ::RuleReference.import!(new_rule_references, ignore: true)
       end
 
       private
 
       def new_rule_references
-        @new_rule_references ||= rule_references.reject(&:persisted?)
+        @new_rule_references ||= @rule_references.select(&:new_record?)
       end
     end
   end

--- a/app/services/concerns/xccdf/rules.rb
+++ b/app/services/concerns/xccdf/rules.rb
@@ -11,7 +11,13 @@ module Xccdf
           ::Rule.from_openscap_parser(op_rule, benchmark_id: @benchmark&.id)
         end
 
-        ::Rule.import!(@rules.select(&:new_record?), ignore: true)
+        ::Rule.import!(new_rules, ignore: true)
+      end
+
+      private
+
+      def new_rules
+        @new_rules ||= @rules.select(&:new_record?)
       end
     end
   end

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -9,6 +9,7 @@ module Xccdf
       include ::Xccdf::Benchmarks
       include ::Xccdf::Profiles
       include ::Xccdf::Rules
+      include ::Xccdf::RuleIdentifiers
       include ::Xccdf::ProfileRules
       include ::Xccdf::RuleReferences
       include ::Xccdf::RuleReferencesRules
@@ -19,6 +20,7 @@ module Xccdf
         save_benchmark
         save_profiles
         save_rules
+        save_rule_identifiers
         save_profile_rules
         save_rule_references
         save_rule_references_rules

--- a/test/models/rule_identifier_test.rb
+++ b/test/models/rule_identifier_test.rb
@@ -13,11 +13,12 @@ class RuleIdentifierTest < ActiveSupport::TestCase
 
   test 'builds a RuleIdentifier from_openscap_parser' \
     'OpenscapParser::RuleIdentifier' do
-    rule_identifier = RuleIdentifier.from_openscap_parser(OP_RULE_IDENTIFIER)
+    rule_identifier = RuleIdentifier.from_openscap_parser(OP_RULE_IDENTIFIER,
+                                                          rules(:one).id)
     assert_equal OP_RULE_IDENTIFIER.system, rule_identifier.system
     assert_equal OP_RULE_IDENTIFIER.label, rule_identifier.label
-    rule_identifier.rule = rules(:one)
     assert rule_identifier.save
-    assert_nil RuleIdentifier.from_openscap_parser(OP_RULE_IDENTIFIER).id
+    assert_equal rule_identifier.id, RuleIdentifier
+      .from_openscap_parser(OP_RULE_IDENTIFIER, rules(:one).id).id
   end
 end

--- a/test/services/concerns/xccdf/rule_identifiers_test.rb
+++ b/test/services/concerns/xccdf/rule_identifiers_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/rule_identifiers'
+
+# A class to test saving RuleReferences from OpenscapParser
+class RuleReferencesTest < ActiveSupport::TestCase
+  class MockParser
+    attr_accessor :new_rules
+
+    include Xccdf::RuleIdentifiers
+  end
+
+  test 'identifiers of new rules are saved' do
+    parser = MockParser.new
+    rule = rules(:one)
+    rule.op_source = OpenStruct.new(
+      identifier: OpenStruct.new(
+        label: 'foo label',
+        system: 'http://123.foo'
+      )
+    )
+
+    parser.new_rules = [rule]
+
+    assert_difference('RuleIdentifier.count', 1) do
+      parser.save_rule_identifiers
+    end
+
+    assert_no_difference('RuleReference.count') do
+      parser.save_rule_identifiers
+    end
+  end
+end


### PR DESCRIPTION
No rule identifiers were being parsed. This now adds rule identifier parsing from benchmark files and results files.