### PR TITLE
[RHICOMPL-412] - Improve parsing performance by searching pre-existing rules in bulk

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -38,18 +38,27 @@ class Rule < ApplicationRecord
     joins(:profile_rules).where.not(profile_rules: { profile_id: nil }).distinct
   }
 
-  def self.from_openscap_parser(op_rule, benchmark_id: nil)
-    rule = find_or_initialize_by(ref_id: op_rule.id,
-                                 benchmark_id: benchmark_id)
+  class << self
+    def from_openscap_parser(op_rule, benchmark_id: nil)
+      rule = find_or_initialize_by(ref_id: op_rule.id,
+                                   benchmark_id: benchmark_id)
 
-    rule.op_source = op_rule
+      rule.op_source = op_rule
 
-    rule.assign_attributes(title: op_rule.title,
-                           description: op_rule.description,
-                           rationale: op_rule.rationale,
-                           severity: op_rule.severity)
+      rule.assign_attributes(title: op_rule.title,
+                             description: op_rule.description,
+                             rationale: op_rule.rationale,
+                             severity: op_rule.severity)
 
-    rule
+      rule
+    end
+
+    def new_from_openscap_parser(op_rules, benchmark_id: nil)
+      preexisting_rules = ::Rule.where(
+        ref_id: op_rules.map(&:id), benchmark_id: benchmark_id
+      ).pluck(:ref_id)
+      op_rules.reject { |rule| preexisting_rules.include?(rule.id) }
+    end
   end
 
   # Disabling MethodLength because it measures things wrong

--- a/app/models/rule_identifier.rb
+++ b/app/models/rule_identifier.rb
@@ -7,11 +7,20 @@ class RuleIdentifier < ApplicationRecord
   validates :label, presence: true
   validates :system, presence: true
 
-  def self.from_openscap_parser(op_rule_identifier, rule_id)
-    if op_rule_identifier.label # rubocop:disable Style/GuardClause
-      find_or_initialize_by(label: op_rule_identifier.label,
-                            system: op_rule_identifier.system,
-                            rule_id: rule_id)
+  class << self
+    def from_openscap_parser(op_rule_identifier, rule_id)
+      if op_rule_identifier.label # rubocop:disable Style/GuardClause
+        find_or_initialize_by(label: op_rule_identifier.label,
+                              system: op_rule_identifier.system,
+                              rule_id: rule_id)
+      end
+    end
+
+    def preexisting_from_oscap_parser(new_rules)
+      ::RuleIdentifier.where(
+        label: new_rules.map { |r| r.op_source.identifier.label },
+        rule_id: new_rules.map(&:id)
+      )
     end
   end
 end

--- a/app/models/rule_reference.rb
+++ b/app/models/rule_reference.rb
@@ -18,16 +18,29 @@ class RuleReference < ApplicationRecord
                      message: 'and label combination already taken'
                    }
 
-  def self.find_from_oscap(oscap_references)
-    oscap_references.inject(where('1=0')) do |rel, reference|
-      rel.or(where(href: reference.href, label: reference.label))
+  class << self
+    def find_from_oscap(oscap_references)
+      oscap_references.inject(where('1=0')) do |rel, reference|
+        rel.or(where(href: reference.href, label: reference.label))
+      end
     end
-  end
 
-  def self.from_openscap_parser(op_rule_reference)
-    find_or_initialize_by(
-      href: op_rule_reference.href,
-      label: op_rule_reference.label
-    )
+    def from_openscap_parser(op_rule_reference)
+      find_or_initialize_by(
+        href: op_rule_reference.href,
+        label: op_rule_reference.label
+      )
+    end
+
+    def new_from_openscap_parser(op_rule_references)
+      preexisting_rule_references = ::RuleReference.where(
+        href: op_rule_references.map(&:href),
+        label: op_rule_references.map(&:label)
+      ).pluck(:href, :label)
+      op_rule_references.reject do |rule_reference|
+        preexisting_rule_references.include?([rule_reference.href,
+                                              rule_reference.label])
+      end
+    end
   end
 end

--- a/app/services/concerns/xccdf/rule_references.rb
+++ b/app/services/concerns/xccdf/rule_references.rb
@@ -7,7 +7,9 @@ module Xccdf
 
     included do
       def save_rule_references
-        @rule_references ||= @op_rule_references.map do |op_reference|
+        @rule_references ||= RuleReference.new_from_openscap_parser(
+          @op_rule_references
+        ).map do |op_reference|
           ::RuleReference.from_openscap_parser(op_reference)
         end
 
@@ -17,7 +19,7 @@ module Xccdf
       private
 
       def new_rule_references
-        @new_rule_references ||= @rule_references.select(&:new_record?)
+        @rule_references.select(&:new_record?)
       end
     end
   end

--- a/app/services/concerns/xccdf/rule_results.rb
+++ b/app/services/concerns/xccdf/rule_results.rb
@@ -19,7 +19,10 @@ module Xccdf
     private
 
     def rule_ids
-      @rule_ids ||= @rules.map { |r| [r.ref_id, r.id] }.to_h
+      @rule_ids = ::Rule.where(
+        ref_id: selected_rule_results.map(&:id),
+        benchmark_id: @benchmark&.id
+      ).pluck(:ref_id, :id).to_h
     end
 
     def selected_rule_results

--- a/app/services/concerns/xccdf/rules.rb
+++ b/app/services/concerns/xccdf/rules.rb
@@ -7,7 +7,9 @@ module Xccdf
 
     included do
       def save_rules
-        @rules ||= @op_rules.map do |op_rule|
+        @rules ||= Rule.new_from_openscap_parser(
+          @op_rules, benchmark_id: @benchmark&.id
+        ).map do |op_rule|
           ::Rule.from_openscap_parser(op_rule, benchmark_id: @benchmark&.id)
         end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
   reports-consumer:
     image: compliance-backend-rails
     restart: on-failure
+    tty: true
+    stdin_open: true
     command: bundle exec racecar -l log/consumer.log ComplianceReportsConsumer
     volumes:
       - .:/app:z
@@ -35,6 +37,7 @@ services:
       - SETTINGS__REDIS_URL=redis:6379
       - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
       - DATABASE_SERVICE_NAME=postgres
+      - RAILS_LOG_TO_STDOUT=true
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev
       - POSTGRESQL_TEST_DATABASE=compliance_test
@@ -63,6 +66,8 @@ services:
   sidekiq:
     image: compliance-backend-rails
     restart: on-failure
+    tty: true
+    stdin_open: true
     volumes:
       - .:/app:z
     depends_on:

--- a/test/services/concerns/xccdf/rule_references_test.rb
+++ b/test/services/concerns/xccdf/rule_references_test.rb
@@ -17,7 +17,7 @@ class RuleReferencesTest < ActiveSupport::TestCase
       save_rule_references
     end
 
-    @rule_references, @new_rule_references = nil # un-cache it from ||=
+    @rule_references, @rule_references_to_create = nil # un-cache it from ||=
     @op_rule_references = [OpenStruct.new(label: 'foo', href: ''),
                            OpenStruct.new(label: 'bar', href: '')]
     stubs(:new_rules).returns(

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -211,6 +211,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     end
 
     should 'save new rules in the database, ignore old rules' do
+      # 2 pre-existing rules
       Rule.new(
         ref_id: @arbitrary_rules[0],
         benchmark: @report_parser.benchmark
@@ -220,17 +221,19 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         benchmark: @report_parser.benchmark
       ).save(validate: false)
 
+      assert_equal 367, @report_parser.op_rules.count
       assert_difference('Rule.count', 365) do
         @report_parser.save_rules
       end
+      assert_equal @report_parser.op_rules.count - 2, @report_parser.rules.count
 
       @report_parser.rules = nil
-
+      # All rules already exist so none are saved
       assert_difference('Rule.count', 0) do
         @report_parser.save_rules
       end
 
-      assert_equal @report_parser.op_rules.count, @report_parser.rules.count
+      assert_equal 0, @report_parser.rules.count
     end
 
     should 'not try to append already assigned profiles to a rule' do


### PR DESCRIPTION
Before this commit, every time a new report came in, the report would
look for every Rule, RuleIdentifier, etc... by iterating over all of
them and calling SQL on every rule. On top of instantiating a lot of
objects, this is much slower than the alternative we have.

Instead, we can search in bulk which of the Rule, RuleIdentifiers,
etc... have already been saved in DB. If they have already been saved,
then skip saving them (which involved finding them, instantiating the
object and then saving them).

```
sidekiq_1           | 2019-11-20T18:01:30.798Z 1 TID-gshcdmt95 ParseReportJob JID-2c5e207599e41c6b3f43cac0 INFO: start
sidekiq_1           | 2019-11-20T18:01:33.781Z 1 TID-gshcdmt95 ParseReportJob JID-2c5e207599e41c6b3f43cac0 INFO: done: 2.983 sec
sidekiq_1           | 2019-11-20T18:02:20.823Z 1 TID-gshd3wlw9 ParseReportJob JID-49e9604a22cbce9ff3357a10 INFO: start
sidekiq_1           | 2019-11-20T18:02:22.852Z 1 TID-gshd3wlw9 ParseReportJob JID-49e9604a22cbce9ff3357a10 INFO: done: 2.029 sec
```