### PR TITLE
[RHICOMPL-412] - Don't parse already parsed benchmarks

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -22,6 +22,8 @@ class Profile < ApplicationRecord
 
   after_update :destroy_orphaned_business_objective
 
+  scope :canonical, lambda { where(account_id: nil) }
+
   def self.from_openscap_parser(op_profile, benchmark_id: nil, account_id: nil)
     profile = find_or_initialize_by(
       ref_id: op_profile.id,

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # OpenSCAP profile
-class Profile < ApplicationRecord
+class Profile < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scoped_search on: %i[id name ref_id account_id compliance_threshold]
 
   has_many :profile_rules, dependent: :delete_all
@@ -22,7 +22,7 @@ class Profile < ApplicationRecord
 
   after_update :destroy_orphaned_business_objective
 
-  scope :canonical, lambda { where(account_id: nil) }
+  scope :canonical, -> { where(account_id: nil) }
 
   def self.from_openscap_parser(op_profile, benchmark_id: nil, account_id: nil)
     profile = find_or_initialize_by(

--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -7,9 +7,16 @@ module Xccdf
 
     included do
       def save_benchmark
-        @benchmark = ::Xccdf::Benchmark.from_openscap_parser(@op_benchmark)
-        ::Xccdf::Benchmark.import!([@benchmark].select(&:new_record?),
+        ::Xccdf::Benchmark.import!([benchmark].select(&:new_record?),
                                    ignore: true)
+      end
+
+      def benchmark_saved?
+        benchmark.persisted?
+      end
+
+      def benchmark
+        @benchmark ||= ::Xccdf::Benchmark.from_openscap_parser(@op_benchmark)
       end
     end
   end

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -20,9 +20,9 @@ module Xccdf
     private
 
     def test_result_profile
-      @profiles.find do |profile|
-        profile.ref_id == @test_result_file.test_result.profile_id
-      end
+      ::Profile.canonical
+        .find_by(ref_id: @test_result_file.test_result.profile_id,
+                 benchmark: @benchmark)
     end
 
     def inventory_host

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -21,8 +21,8 @@ module Xccdf
 
     def test_result_profile
       ::Profile.canonical
-        .find_by(ref_id: @test_result_file.test_result.profile_id,
-                 benchmark: @benchmark)
+               .find_by(ref_id: @test_result_file.test_result.profile_id,
+                        benchmark: @benchmark)
     end
 
     def inventory_host

--- a/app/services/concerns/xccdf/rule_results.rb
+++ b/app/services/concerns/xccdf/rule_results.rb
@@ -19,7 +19,9 @@ module Xccdf
     private
 
     def rule_ids
-      @rule_ids ||= @rules.map { |r| [r.ref_id, r.id] }.to_h
+      @rule_ids ||= Rule.where(
+        benchmark: @benchmark, ref_id: selected_rule_results.map(&:id)
+      ).pluck(:ref_id, :id).to_h
     end
 
     def selected_rule_results

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -18,6 +18,7 @@ module Xccdf
 
       def save_all_benchmark_info
         return if benchmark_saved?
+
         save_benchmark
         save_profiles
         save_rules

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -17,15 +17,14 @@ module Xccdf
       include ::Xccdf::RuleResults
 
       def save_all_benchmark_info
-        unless benchmark_saved? # rubocop:disable Style/GuardClause
-          save_benchmark
-          save_profiles
-          save_rules
-          save_rule_identifiers
-          save_profile_rules
-          save_rule_references
-          save_rule_references_rules
-        end
+        return if benchmark_saved?
+        save_benchmark
+        save_profiles
+        save_rules
+        save_rule_identifiers
+        save_profile_rules
+        save_rule_references
+        save_rule_references_rules
       end
 
       def save_all_test_result_info

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -17,13 +17,15 @@ module Xccdf
       include ::Xccdf::RuleResults
 
       def save_all_benchmark_info
-        save_benchmark
-        save_profiles
-        save_rules
-        save_rule_identifiers
-        save_profile_rules
-        save_rule_references
-        save_rule_references_rules
+        unless benchmark_saved?
+          save_benchmark
+          save_profiles
+          save_rules
+          save_rule_identifiers
+          save_profile_rules
+          save_rule_references
+          save_rule_references_rules
+        end
       end
 
       def save_all_test_result_info

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -17,7 +17,7 @@ module Xccdf
       include ::Xccdf::RuleResults
 
       def save_all_benchmark_info
-        unless benchmark_saved?
+        unless benchmark_saved? # rubocop:disable Style/GuardClause
           save_benchmark
           save_profiles
           save_rules

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -10,7 +10,7 @@ module Xccdf
                                   title: 'one', description: 'first')
 
     class Mock
-      include Xccdf::Benchmarks
+      include Xccdf::Util
 
       def initialize(op_benchmark)
         @op_benchmark = op_benchmark
@@ -19,7 +19,21 @@ module Xccdf
 
     test 'save_benchmark' do
       mock = Mock.new(OP_BENCHMARK)
+      assert_difference('Xccdf::Benchmark.count', 1) do
+        mock.save_benchmark
+      end
+      assert mock.benchmark_saved?
+    end
+
+    test 'does not try to save an existing benchmark' do
+      mock = Mock.new(OP_BENCHMARK)
       mock.save_benchmark
+      assert mock.benchmark_saved?
+
+      mock.expects(:save_benchmark).never
+      assert_no_difference('Xccdf::Benchmark.count') do
+        mock.save_all_benchmark_info
+      end
       assert mock.benchmark_saved?
     end
   end

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -12,8 +12,6 @@ module Xccdf
     class Mock
       include Xccdf::Benchmarks
 
-      attr_accessor :benchmark
-
       def initialize(op_benchmark)
         @op_benchmark = op_benchmark
       end
@@ -22,7 +20,7 @@ module Xccdf
     test 'save_benchmark' do
       mock = Mock.new(OP_BENCHMARK)
       mock.save_benchmark
-      assert mock.benchmark.persisted?
+      assert mock.benchmark_saved?
     end
   end
 end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -6,7 +6,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
   class TestParser < ::XccdfReportParser
     attr_accessor :op_benchmark, :op_test_result, :op_profiles, :op_rules,
                   :op_rule_results, :rules
-    attr_reader :benchmark, :test_result_file, :host, :rule_results, :profiles
+    attr_reader :test_result_file, :host, :rule_results, :profiles
   end
 
   setup do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHICOMPL-412

Initial and subsequent parse of RHEL 7 standard profile:

```
2019-11-21T17:03:05.957Z 1 TID-gni5eoqyl ParseReportJob JID-580531214732438c34fe3e78 INFO: start
2019-11-21T17:03:52.511Z 1 TID-gni5eoqyl ParseReportJob JID-580531214732438c34fe3e78 INFO: done: 46.553 sec
2019-11-21T17:04:02.524Z 1 TID-gni5eoqyl ParseReportJob JID-0910570d946ff49f5b2d9e31 INFO: start
2019-11-21T17:04:03.860Z 1 TID-gni5eoqyl ParseReportJob JID-0910570d946ff49f5b2d9e31 INFO: done: 1.336 sec
```

TODO:

- [x] tests

Signed-off-by: Andrew Kofink <akofink@redhat.com>