### PR TITLE
Import remediations after report parse

### DIFF
--- a/app/services/datastream_importer.rb
+++ b/app/services/datastream_importer.rb
@@ -16,6 +16,15 @@ class DatastreamImporter
   def import!
     Xccdf::Benchmark.transaction do
       save_all_benchmark_info
+      import_remediations
     end
+  end
+
+  private
+
+  def import_remediations
+    RemediationsAPI.new(
+      Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
+    ).import_remediations
   end
 end

--- a/test/services/datastream_importer_test.rb
+++ b/test/services/datastream_importer_test.rb
@@ -11,6 +11,7 @@ class DatastreamImporterTest < ActiveSupport::TestCase
   test 'datastream import' do
     importer = DatastreamImporter.new(DATASTREAM_FILE)
     importer.expects(:save_all_benchmark_info)
+    ENV['JOBS_ACCOUNT_NUMBER'] ||= Account.first.account_number
     importer.import!
   end
 end


### PR DESCRIPTION
After importing a benchmark for the first time, we should import remediations rather than waiting until 8am the next morning.

Signed-off-by: Andrew Kofink <akofink@redhat.com>