### PR TITLE
Disable rails asset pipeline

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,12 +12,7 @@ require 'action_controller/railtie'
 require 'action_mailer/railtie'
 require 'action_view/railtie'
 require 'action_cable/engine'
-# require "sprockets/railtie"
 require 'rails/test_unit/railtie'
-
-if Rails.env.development?
-  require 'sprockets/railtie'
-end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,8 +46,6 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
-  config.assets.prefix = "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/assets"
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
Fixes this error:

> /usr/local/bundle/gems/sprockets-rails-3.2.1/lib/sprockets/railtie.rb:105:in `block in <class:Railtie>': Expected to find a manifest file in `app/assets/config/manifest.js` 

Signed-off-by: Andrew Kofink <akofink@redhat.com>