### PR TITLE
Add a unique db constraint for benchmarks

### DIFF
--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate Xccdf::Benchmark objects
+class DuplicateBenchmarkResolver
+  class << self
+    def run!
+      each_benchmark do |bm|
+        if benchmarks[[bm.ref_id, bm.version]]
+          migrate_benchmark(benchmarks[[bm.ref_id, bm.version]], bm)
+        else
+          benchmarks[[bm.ref_id, bm.version]] = bm
+        end
+      end
+    end
+
+    private
+
+    def migrate_benchmark(existing_bm, duplicate_bm)
+      migrate_rules(existing_bm, duplicate_bm)
+      migrate_profiles(existing_bm, duplicate_bm)
+      duplicate_bm.destroy! # profiles, rules
+    end
+
+    def each_benchmark
+      Xccdf::Benchmark.transaction do
+        Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
+          yield bm
+        end
+      end
+    end
+
+    def benchmarks
+      @benchmarks ||= {}
+    end
+
+    def migrate_rules(existing_bm, duplicate_bm)
+      duplicate_bm.rules.find_each do |rule|
+        if existing_bm.rules.pluck(:ref_id).include?(rule.ref_id)
+          migrate_rule(existing_bm.rules.find_by(ref_id: rule.ref_id), rule)
+        else
+          rule.update!(benchmark_id: existing_bm.id)
+        end
+      end
+    end
+
+    def migrate_rule(existing_rule, duplicate_rule)
+      duplicate_rule.rule_results.update(rule_id: existing_rule.id)
+      duplicate_rule
+        .destroy # profile_rules, rule_references_rules, rule_identifier
+    end
+
+    def migrate_profiles(existing_bm, duplicate_bm)
+      duplicate_bm.profiles.find_each do |profile|
+        if existing_bm.profiles.pluck(:ref_id, :account_id)
+                      .include?([profile.ref_id, profile.account_id])
+          migrate_profile(existing_bm.profiles.find_by(ref_id: profile.ref_id),
+                          profile)
+        else
+          profile.update!(benchmark_id: existing_bm.id)
+        end
+      end
+    end
+
+    def migrate_profile(existing_profile, duplicate_profile)
+      duplicate_profile.profile_hosts.update(
+        profile_id: existing_profile.id
+      )
+      duplicate_profile.destroy # profile_rules, profile_hosts
+    end
+  end
+end

--- a/db/migrate/20200106134953_add_unique_index_to_benchmarks.rb
+++ b/db/migrate/20200106134953_add_unique_index_to_benchmarks.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToBenchmarks < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateBenchmarkResolver.run!
+
+    add_index(:benchmarks, %i[ref_id version], unique: true)
+  end
+
+  def down
+    remove_index(:benchmarks, %i[ref_id version])
+  end
+end

--- a/test/services/duplicate_benchmark_resolver_test.rb
+++ b/test/services/duplicate_benchmark_resolver_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200106134953_add_unique_index_to_benchmarks'
+
+class DuplicateBenchmarkResolverTest < ActiveSupport::TestCase
+  setup do
+    @migration = AddUniqueIndexToBenchmarks.new
+    @migration.down # remove db constraint
+
+    (@dupe_bm = benchmarks(:one).dup).save(validate: false)
+
+    @dupe_rules = rules.map do |r|
+      dupe_r = r.dup
+      dupe_r.benchmark = @dupe_bm
+      dupe_r.save(validate: false)
+      dupe_r
+    end
+
+    @dupe_profiles = profiles.map do |p|
+      dupe_p = p.dup
+      dupe_p.benchmark = @dupe_bm
+      dupe_p.rules = [@dupe_rules.first]
+      dupe_p.save(validate: false)
+      dupe_p
+    end
+
+    @dupe_test_results = test_results.map do |tr|
+      dupe_tr = tr.dup
+      dupe_tr.save(validate: false)
+      dupe_tr
+    end
+
+    @dupe_rule_results = rule_results.map do |rr|
+      dupe_rr = rr.dup
+      dupe_rr.test_result = @dupe_test_results.sample
+      dupe_rr
+    end
+  end
+
+  test 'resolves identical benchmarks' do
+    assert_difference(
+      'Xccdf::Benchmark.count' => -1,
+      'Profile.count' => -2,
+      'Rule.count' => -2,
+      'RuleResult.count' => 0,
+      'TestResult.count' => 0,
+      'RuleReference.count' => 0,
+      'Host.count' => 0,
+      'ProfileHost.count' => 0
+    ) do
+      @migration.up
+    end
+  end
+end


### PR DESCRIPTION
The migration migrates a duplicate benchmark's rules and profiles and associated records (namely host_profiles and rule results) and then adds the unique benchmark DB constraint.

Test scenario ideas:

- Import 1 benchmark, duplicate it and save, run the migration
- Import 2 benchmarks of different versions, update the versions to match, run the migration
- Import 1 RHEL 7 benchmark, import 1 RHEL 6 benchmark, update ref_id and version to match, run the migration

For all cases: confirm 1 benchmark exists and no errors occurred
These counts should change: `[Xccdf::Benchmark.count, Profile.count, Rule.count, RuleIdentifier.count]`
These may or may not change: `[RuleReference.count, ProfileHost.count, ProfileRule.count]`
These should not change: `[RuleResult.count, Host.count, TestResult.count]`

Signed-off-by: Andrew Kofink <akofink@redhat.com>