### PR TITLE
Use real X-RH-IDENTITY coming from original request

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -44,7 +44,7 @@ module Authentication
   end
 
   def rbac_allowed?
-    @rbac_api ||= ::RbacApi.new(account_from_header)
+    @rbac_api ||= ::RbacApi.new(request.headers['X-RH-IDENTITY'])
     @rbac_api.check_user
   end
 

--- a/app/services/rbac_api.rb
+++ b/app/services/rbac_api.rb
@@ -2,10 +2,10 @@
 
 # This class is meant to handle calls to the RBAC light API
 class RbacApi
-  def initialize(account)
+  def initialize(b64_identity)
     @url = URI.parse("#{URI.parse(Settings.rbac_url)}"\
                      "#{ENV['PATH_PREFIX']}/rbac/v1/access/")
-    @b64_identity = Base64.strict_encode64(account.fake_identity_header.to_json)
+    @b64_identity = b64_identity
   end
 
   def check_user

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -159,7 +159,7 @@ RSpec.configure do |config|
 end
 
 def encoded_header
-  Base64.encode64(x_rh_identity.to_json)
+  Base64.strict_encode64(x_rh_identity.to_json)
 end
 
 # Justification: It's mostly hash test data


### PR DESCRIPTION
There is no need to send the account fake identity header when we can send directly the request header. 