### PR TITLE
308: Add tailoring file service for creating tailorings

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -12,6 +12,7 @@ class Profile < ApplicationRecord
   belongs_to :account, optional: true
   belongs_to :business_objective, optional: true
   belongs_to :benchmark, class_name: 'Xccdf::Benchmark'
+  belongs_to :parent_profile, class_name: 'Profile', optional: true
 
   validates :ref_id, uniqueness: { scope: %i[account_id benchmark_id] },
                      presence: true

--- a/app/services/xccdf_tailoring_file.rb
+++ b/app/services/xccdf_tailoring_file.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# A class representing an XCCDF Tailoring File
+class XccdfTailoringFile
+  extend Forwardable
+
+  XCCDF = 'xccdf'
+
+  def initialize(profile:, rule_ref_ids: [], set_values: {})
+    @profile = profile
+    @rule_ref_ids = rule_ref_ids
+    @set_values = set_values
+  end
+
+  def_delegator :builder, :to_xml
+
+  private
+
+  def builder
+    @builder ||= create_builder do |xml|
+      xml[XCCDF].benchmark(id: @profile.benchmark.ref_id)
+      xml[XCCDF].version(1, time: DateTime.now.iso8601)
+      xml[XCCDF].Profile(id: @profile.ref_id,
+                         extends: @profile.parent_profile.ref_id)
+    end
+  end
+
+  def create_builder
+    handle_missing_parent_profile
+    Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+      xml[XCCDF].Tailoring('xmlns:xccdf' =>
+                           'http://checklists.nist.gov/xccdf/1.2',
+                           id: 'xccdf_csfr-compliance_tailoring_default') do
+        yield xml
+      end
+    end
+  end
+
+  def handle_missing_parent_profile
+    e = ArgumentError.new("Profile(id=#{@profile.id}) has no parent profile.")
+    raise e if @profile.parent_profile.nil?
+  end
+end

--- a/db/migrate/20200120203124_add_parent_profile_id_to_profiles.rb
+++ b/db/migrate/20200120203124_add_parent_profile_id_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddParentProfileIdToProfiles < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :profiles, :parent_profile, type: :uuid, foreign_key: { to_table: :profiles }
+  end
+end

--- a/test/services/xccdf_tailoring_file_test.rb
+++ b/test/services/xccdf_tailoring_file_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class XccdfTailoringFileTest < ActiveSupport::TestCase
+  test 'builds a valid tailoring file' do
+    profile = profiles(:one)
+    profile.parent_profile = profile
+    tailoring_file = XccdfTailoringFile.new(profile: profile)
+    op_tailoring = OpenscapParser::TailoringFile.new(tailoring_file.to_xml)
+                                                .tailoring
+    assert_equal 'xccdf_csfr-compliance_tailoring_default', op_tailoring.id
+    assert_equal [profile.ref_id],
+                 op_tailoring.profiles.map(&:id)
+    assert_equal profile.benchmark.ref_id,
+                 op_tailoring.at_xpath('benchmark')[:id]
+    assert_equal '1', op_tailoring.version
+    assert DateTime.parse(op_tailoring.version_time) < DateTime.now,
+           'Invalid date in tailoring file'
+  end
+
+  test 'handles nil parent_profile' do
+    assert_raises(ArgumentError) do
+      XccdfTailoringFile.new(profile: OpenStruct.new).to_xml
+    end
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHICOMPL-308

Also adds parent_profile_id to the profiles table without any code so far to populate this field.

Compare the output of `XccdfTailoringFile.new(profile: Profile.first).to_xml` to the following tailoring generated from openscap workbench:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<xccdf:Tailoring xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
  <xccdf:benchmark href="/tmp/SCAP Workbench-zVBxUA/ssg-rhel7-ds.xml"/>
  <xccdf:version time="2019-10-07T11:49:49">1</xccdf:version>
  <xccdf:Profile id="xccdf_org.ssgproject.content_profile_standard_customized" extends="xccdf_org.ssgproject.content_profile_standard">
    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">Standard System Security Profile for Red Hat Enterprise Linux 7 [CUSTOMIZED]</xccdf:title>
    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This profile contains rules to ensure standard security baseline
of a Red Hat Enterprise Linux 7 system. Regardless of your system's workload
all of these checks should pass.</xccdf:description>
    <xccdf:select idref="xccdf_org.ssgproject.content_rule_clean_components_post_updating" selected="true"/>
    <xccdf:select idref="xccdf_org.ssgproject.content_rule_sshd_disable_root_login" selected="true"/>
    <xccdf:select idref="xccdf_org.ssgproject.content_group_ssh_server" selected="true"/>
    <xccdf:select idref="xccdf_org.ssgproject.content_group_ssh" selected="true"/>
    <xccdf:select idref="xccdf_org.ssgproject.content_rule_sshd_set_max_auth_tries" selected="true"/>
    <xccdf:select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key" selected="true"/>
    <xccdf:select idref="xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key" selected="true"/>
    <xccdf:select idref="xccdf_org.ssgproject.content_rule_package_openssh-server_installed" selected="true"/>
    <xccdf:set-value idref="xccdf_org.ssgproject.content_value_sshd_max_auth_tries_value">10</xccdf:set-value>
  </xccdf:Profile>
</xccdf:Tailoring>
```

For reference, the official XCCDF 1.2 spec is at https://csrc.nist.gov/CSRC/media/Publications/nistir/7275/rev-4/final/documents/nistir-7275r4_updated-march-2012_clean.pdf.

Signed-off-by: Andrew Kofink <akofink@redhat.com>