### PR TITLE
Infer benchmark OS from ref_id

### DIFF
--- a/app/models/xccdf/benchmark.rb
+++ b/app/models/xccdf/benchmark.rb
@@ -30,5 +30,9 @@ module Xccdf
         BenchmarkPolicy
       end
     end
+
+    def inferred_os_major_version
+      ref_id[/(?<=RHEL-)\d/]
+    end
   end
 end

--- a/test/models/benchmark_test.rb
+++ b/test/models/benchmark_test.rb
@@ -23,5 +23,12 @@ module Xccdf
       assert benchmark.save
       assert_equal benchmark.id, Benchmark.from_openscap_parser(OP_BENCHMARK).id
     end
+
+    test 'inferred_os_major_version' do
+      OP_BENCHMARK[:id] = 'xccdf_org.ssgproject.content_benchmark_RHEL-7'
+      benchmark = Benchmark.from_openscap_parser(OP_BENCHMARK)
+
+      assert_equal '7', benchmark.inferred_os_major_version
+    end
   end
 end


### PR DESCRIPTION
No use for this yet, but it sounds like we'll need it in the future.

Signed-off-by: Andrew Kofink <akofink@redhat.com>