### PR TITLE
Allow datastream import without any accounts

### DIFF
--- a/app/services/datastream_importer.rb
+++ b/app/services/datastream_importer.rb
@@ -24,7 +24,8 @@ class DatastreamImporter
 
   def import_remediations
     RemediationsAPI.new(
-      Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
+      Account.find_by(account_number: ENV['JOBS_ACCOUNT_NUMBER']) ||
+        Account.new
     ).import_remediations
   end
 end

--- a/test/services/datastream_importer_test.rb
+++ b/test/services/datastream_importer_test.rb
@@ -14,4 +14,11 @@ class DatastreamImporterTest < ActiveSupport::TestCase
     ENV['JOBS_ACCOUNT_NUMBER'] ||= Account.first.account_number
     importer.import!
   end
+
+  test 'works without any accounts' do
+    importer = DatastreamImporter.new(DATASTREAM_FILE)
+    importer.expects(:save_all_benchmark_info)
+    ENV['JOBS_ACCOUNT_NUMBER'] ||= nil
+    importer.import!
+  end
 end


### PR DESCRIPTION
The following happens if you try to import a datastream file without any accounts:

```
Importing ./test/fixtures/files/ssg-rhel7-ds.xml at 2020-01-21 15:57:03 UTC                                                                                                                                                                                                                                                                                                                   
rake aborted!                                                                                                                                                                                                                                                                                                                                                                                 
ActiveRecord::RecordNotFound: Couldn't find Account                                                                                                                                                                                                                                                                                                                                           
/usr/local/bundle/gems/activerecord-5.2.4.1/lib/active_record/core.rb:217:in `find_by!'                                                                                                                                                                                                                                                                                                       
/app/app/services/datastream_importer.rb:27:in `import_remediations'                                                                                                                                                                                                                                                                                                                          
/app/app/services/datastream_importer.rb:19:in `block in import!'                                                                                                                                                                                                                                                                                                                             
/usr/local/bundle/gems/activerecord-5.2.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `block in transaction'                                                                                                                                                                                                                                               
/usr/local/bundle/gems/activerecord-5.2.4.1/lib/active_record/connection_adapters/abstract/transaction.rb:239:in `block in within_new_transaction'                                                                                                                                                                                                                                            
/usr/local/bundle/gems/activerecord-5.2.4.1/lib/active_record/connection_adapters/abstract/transaction.rb:236:in `within_new_transaction'                                                                                                                                                                                                                                                     
/usr/local/bundle/gems/activerecord-5.2.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `transaction'                                                                                                                                                                                                                                                        
/usr/local/bundle/gems/activerecord-5.2.4.1/lib/active_record/transactions.rb:212:in `transaction'                                                                                                                                                                                                                                                                                            
/app/app/services/datastream_importer.rb:17:in `import!'                                                                                                                                                                                                                                                                                                                                      
/app/lib/tasks/import_datastream.rake:20:in `block (2 levels) in <top (required)>'                                                                                                                                                                                                                                                                                                            
/usr/local/bundle/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'                                                                                                                                                                                                                                                                                                                          
/usr/local/bin/bundle:30:in `block in <main>'                                                                                                                                                                                                                                                                                                                                                 
/usr/local/bin/bundle:22:in `<main>'                                                                                                                                                                                                                                                                                                                                                          
Tasks: TOP => ssg:import                                                                                                                                                                                                                                                                                                                                                                      
(See full trace by running task with --trace)
```

The remediations api does not actually require a valid account, so using `Account.new` is adequate for importing remediations after importing the datastream.

Signed-off-by: Andrew Kofink <akofink@redhat.com>