### PR TITLE
Let codecov see safe_downloader test coverage

### DIFF
--- a/test/services/safe_downloader_test.rb
+++ b/test/services/safe_downloader_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'safe_downloader'
 
 class SafeDownloaderTest < ActiveSupport::TestCase
   setup do


### PR DESCRIPTION
Coverage for the safe_downloader isn't being counted for some reason. Codecov [mentions](https://github.com/codecov/codecov-ruby#caveat) to require app files in our tests. Let's see if it's picked up now. :crossed_fingers: 

Signed-off-by: Andrew Kofink <akofink@redhat.com>