### PR TITLE
Notify Slack on Rake job exception

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
 APP_NAME=compliance
 PATH_PREFIX=/api
 OLD_PATH_PREFIX=/r/insights/platform
+SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus.compliance-test.svc
+APPLICATION_TYPE=test
+HOSTNAME=testmachine
+OPENSHIFT_BUILD_NAME=testmachine-test-42

--- a/app/controllers/concerns/exception_notifier_custom_data.rb
+++ b/app/controllers/concerns/exception_notifier_custom_data.rb
@@ -11,8 +11,10 @@ module ExceptionNotifierCustomData
   private
 
   def prepare_exception_notifier
-    request.env['exception_notifier.exception_data'] = {
+    request.env[
+      'exception_notifier.exception_data'
+    ] = OpenshiftEnvironment.summary.merge(
       current_user: current_user
-    }
+    )
   end
 end

--- a/app/services/openshift_environment.rb
+++ b/app/services/openshift_environment.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Module to fetch info related to the current pod running
+module OpenshiftEnvironment
+  class << self
+    def environment
+      ENV['SETTINGS__PROMETHEUS_EXPORTER_HOST'].split('.')[1]
+    end
+
+    def application
+      ENV['APPLICATION_TYPE']
+    end
+
+    def pod
+      ENV['HOSTNAME']
+    end
+
+    def build
+      ENV['OPENSHIFT_BUILD_NAME']
+    end
+
+    def summary
+      {
+        environment: environment,
+        application: application,
+        pod: pod,
+        build: build
+      }
+    end
+  end
+end

--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -1,24 +1,38 @@
 # frozen_string_literal: true
 
+# Disabling BlockLength here because the namespace of a Rake job resembles more
+# a class than a block and should be able to handle multiple tasks.
+# rubocop:disable Metrics/BlockLength
 namespace :ssg do
   desc 'Update compliance DB with the latest release of the SCAP Security Guide'
   task import_rhel: [:environment, 'ssg:sync_rhel'] do
     # DATASTREAM_FILENAMES from openscap_parser's ssg:sync_rhel
-    DATASTREAM_FILENAMES.flatten.each do |filename|
-      start = Time.zone.now
-      puts "Importing #{filename} at #{start}"
-      DatastreamImporter.new(filename).import!
-      puts "Finished importing #{filename} in #{Time.zone.now - start} seconds."
+    begin
+      DATASTREAM_FILENAMES.flatten.each do |filename|
+        start = Time.zone.now
+        puts "Importing #{filename} at #{start}"
+        DatastreamImporter.new(filename).import!
+        puts "Finished importing #{filename} in #{Time.zone.now - start}"\
+             ' seconds.'
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify_exception(e)
     end
   end
 
   desc 'Update compliance DB with data from an Xccdf datastream file'
   task import: [:environment] do
-    if (filename = ENV['DATASTREAM_FILE'])
-      start = Time.zone.now
-      puts "Importing #{filename} at #{start}"
-      DatastreamImporter.new(filename).import!
-      puts "Finished importing #{filename} in #{Time.zone.now - start} seconds."
+    begin
+      if (filename = ENV['DATASTREAM_FILE'])
+        start = Time.zone.now
+        puts "Importing #{filename} at #{start}"
+        DatastreamImporter.new(filename).import!
+        puts "Finished importing #{filename} in #{Time.zone.now - start}"\
+             ' seconds.'
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify_exception(e)
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -16,7 +16,10 @@ namespace :ssg do
              ' seconds.'
       end
     rescue StandardError => e
-      ExceptionNotifier.notify_exception(e)
+      ExceptionNotifier.notify_exception(
+        e,
+        data: OpenshiftEnvironment.summary
+      )
     end
   end
 
@@ -31,7 +34,10 @@ namespace :ssg do
              ' seconds.'
       end
     rescue StandardError => e
-      ExceptionNotifier.notify_exception(e)
+      ExceptionNotifier.notify_exception(
+        e,
+        data: OpenshiftEnvironment.summary
+      )
     end
   end
 end

--- a/lib/tasks/import_remediations.rake
+++ b/lib/tasks/import_remediations.rake
@@ -12,13 +12,17 @@ desc <<-END_DESC
 END_DESC
 
 task import_remediations: :environment do
-  start_time = Time.now.utc
-  puts "Starting import_remediations job at #{start_time}"
-  RemediationsAPI.new(
-    Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
-  ).import_remediations
-  end_time = Time.now.utc
-  duration = end_time - start_time
-  puts "Finishing import_remediations job at #{end_time} "\
-       "and last #{duration} seconds "
+  begin
+    start_time = Time.now.utc
+    puts "Starting import_remediations job at #{start_time}"
+    RemediationsAPI.new(
+      Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
+    ).import_remediations
+    end_time = Time.now.utc
+    duration = end_time - start_time
+    puts "Finishing import_remediations job at #{end_time} "\
+         "and last #{duration} seconds "
+  rescue StandardError => e
+    ExceptionNotifier.notify_exception(e)
+  end
 end

--- a/lib/tasks/import_remediations.rake
+++ b/lib/tasks/import_remediations.rake
@@ -23,6 +23,9 @@ task import_remediations: :environment do
     puts "Finishing import_remediations job at #{end_time} "\
          "and last #{duration} seconds "
   rescue StandardError => e
-    ExceptionNotifier.notify_exception(e)
+    ExceptionNotifier.notify_exception(
+      e,
+      data: OpenshiftEnvironment.summary
+    )
   end
 end


### PR DESCRIPTION
ExceptionNotification only notifies on 500 errors on the controllers. For Rake jobs, we have to rescue any error and send it over to Slack. We have missed some errors on jobs without this.