### PR TITLE
Set image for compliance services in  Smoke Tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ def runStages() {
     if (currentBuild.currentResult == "SUCCESS" && env.CHANGE_TARGET == "stable" && env.CHANGE_ID) {
         execSmokeTest (
             ocDeployerBuilderPath: "compliance/compliance-backend",
-            ocDeployerComponentPath: "compliance/compliance-backend",
+            ocDeployerComponentPath: "compliance",
             ocDeployerServiceSets: "rbac,compliance,platform,platform-mq",
             iqePlugins: ["iqe-compliance-plugin"],
             pytestMarker: "compliance_smoke",


### PR DESCRIPTION
 - Set the same base image generated from PR source code for all
   services in Compliance set.