### PR TITLE
Create host from inventory on policy association

### DIFF
--- a/app/graphql/mutations/profile/associate_systems.rb
+++ b/app/graphql/mutations/profile/associate_systems.rb
@@ -24,15 +24,51 @@ module Mutations
 
       def find_profile(profile_id)
         ::Pundit.authorize(
-          context[:current_user],
+          current_user,
           ::Profile.find(profile_id),
           :edit?
         )
       end
 
       def find_hosts(system_ids)
-        ::Pundit.policy_scope(context[:current_user], ::Host)
-                .where(id: system_ids)
+        existing_systems = ::Pundit.policy_scope(current_user, ::Host)
+                                   .where(id: system_ids)
+        save_hosts(system_ids - existing_systems.pluck(:id))
+        existing_systems
+      end
+
+      def save_hosts(ids)
+        ids.map do |id|
+          save_host(id)
+        end
+      end
+
+      def save_host(id)
+        i_host = inventory_host(id)
+        host = ::Host.find_or_initialize_by(
+          id: i_host['id'],
+          account_id: current_user.account.id
+        )
+
+        host.update!(
+          name: i_host['fqdn']
+        )
+
+        host
+      end
+
+      def current_user
+        @current_user ||= context[:current_user]
+      end
+
+      def inventory_host(id)
+        ::HostInventoryAPI.new(
+          id,
+          nil, # unknown hostname
+          current_user.account,
+          ::Settings.host_inventory_url,
+          nil # infer identity from account
+        ).inventory_host
       end
     end
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -28,4 +28,8 @@ class Account < ApplicationRecord
     }
   end
   # rubocop:enable Metrics/MethodLength
+
+  def b64_identity
+    Base64.strict_encode64(fake_identity_header.to_json)
+  end
 end

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -11,7 +11,7 @@ class HostInventoryAPI
     @hostname = hostname
     @url = "#{URI.parse(url)}#{ENV['PATH_PREFIX']}/inventory/v1/hosts"
     @account = account
-    @b64_identity = b64_identity
+    @b64_identity = b64_identity || @account.b64_identity
   end
 
   def host_already_in_inventory(hostname_or_id)
@@ -36,7 +36,7 @@ class HostInventoryAPI
 
   def inventory_host
     @inventory_host ||= host_already_in_inventory(@id) ||
-                        host_already_in_inventory(@hostname) ||
+                        (@hostname && host_already_in_inventory(@hostname)) ||
                         create_host_in_inventory
   end
 

--- a/app/services/remediations_api.rb
+++ b/app/services/remediations_api.rb
@@ -5,7 +5,7 @@ class RemediationsAPI
   def initialize(account)
     @url = URI.parse("#{URI.parse(Settings.remediations_url)}"\
                      "#{ENV['PATH_PREFIX']}/remediations/v1/resolutions")
-    @b64_identity = Base64.strict_encode64(account.fake_identity_header.to_json)
+    @b64_identity = account.b64_identity
   end
 
   def import_remediations

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -32,4 +32,43 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
 
     assert_equal profiles(:one).reload.hosts, [hosts(:one), hosts(:two)]
   end
+
+  test 'finds inventory systems and creates them in compliance' do
+    query = <<-GRAPHQL
+       mutation associateSystems($input: associateSystemsInput!) {
+          associateSystems(input: $input) {
+             profile {
+                 id
+             }
+          }
+       }
+    GRAPHQL
+
+    NEW_ID = '7ccda3fb-bd28-4845-ab5a-061099eae7b3'
+
+    profiles(:one).update account: accounts(:test)
+    hosts(:one).update account: accounts(:test)
+    hosts(:two).update account: accounts(:test)
+    users(:test).update account: accounts(:test)
+
+    assert_empty profiles(:one).hosts
+
+    @api = mock('HostInventoryAPI')
+    HostInventoryAPI.expects(:new).returns(@api)
+    @api.expects(:inventory_host).returns(
+      'id' => NEW_ID,
+      'fqdn' => 'newhostname'
+    )
+
+    Schema.execute(
+      query,
+      variables: { input: {
+        id: profiles(:one).id,
+        systemIds: [NEW_ID]
+      } },
+      context: { current_user: users(:test) }
+    )['data']['associateSystems']['profile']
+
+    assert_equal(profiles(:one).hosts.pluck(:id), [NEW_ID])
+  end
 end


### PR DESCRIPTION
Create host from the inventory on policy assocate_systems only if the host doesn't already exist in compliance.

Related to https://projects.engineering.redhat.com/browse/RHICOMPL-306
Reported at https://projects.engineering.redhat.com/browse/RHICOMPL-485

Requires https://github.com/RedHatInsights/compliance-backend/pull/319

Signed-off-by: Andrew Kofink <akofink@redhat.com>