### PR TITLE
Find inventory systems by passed ID before hostname

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -45,7 +45,7 @@ class HostInventoryAPI
   def find_results(body)
     body['results'].find do |host|
       host['account'] == @account.account_number && (
-        host['id'] == @host_inventory_id ||
+        host['id'] == @id ||
         host['fqdn'] == @hostname
       )
     end

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -51,4 +51,28 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     @api.expects(:create_host_in_inventory).returns(@host)
     assert_equal @host, @api.inventory_host
   end
+
+  test 'find_results matches on ID' do
+    assert_equal(
+      @api.send(
+        :find_results, 'results' => [
+          { 'account' => @account.account_number, 'id' => @host.id }
+        ]
+      )['id'],
+      @host.id,
+      'find_results did not return the expected match by ID'
+    )
+  end
+
+  test 'find_results matches on hostname' do
+    assert_equal(
+      @api.send(
+        :find_results, 'results' => [
+          { 'account' => @account.account_number, 'fqdn' => @host.name }
+        ]
+      )['fqdn'],
+      @host.name,
+      'find_results did not return the expected match by hostname'
+    )
+  end
 end


### PR DESCRIPTION
Finding hosts by ID has never worked correctly until this change. It has been verifying a match with the inventory only based on the fqdn returned by the insights-client metadata.

Without the change, the ID test fails:

```
 FAIL["test_find_results_matches_on_ID", #<Minitest::Reporters::Suite:0x000055a0d359d5c0 @name="HostInventoryApiTest">, 0.18526139999812585]
 test_find_results_matches_on_ID#HostInventoryApiTest (0.19s)
        find_results did not return the expected match by ID.
        Expected nil to not be nil.
        test/services/host_inventory_api_test.rb:56:in `block in <class:HostInventoryApiTest>'
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>