### PR TITLE
Determine canonical profiles based on parent_profile presence

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -28,7 +28,7 @@ class Profile < ApplicationRecord
   after_update :destroy_orphaned_business_objective
   before_destroy :destroy_all_test_results, if: -> { delete_all_test_results }
 
-  scope :canonical, -> { where(account_id: nil) }
+  scope :canonical, -> { where(parent_profile_id: nil) }
 
   def self.from_openscap_parser(op_profile, benchmark_id: nil, account_id: nil)
     profile = find_or_initialize_by(
@@ -46,7 +46,7 @@ class Profile < ApplicationRecord
   end
 
   def canonical?
-    account_id.blank?
+    parent_profile_id.blank?
   end
 
   def destroy_orphaned_business_objective

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -40,7 +40,8 @@ class ProfileQueryTest < ActiveSupport::TestCase
       }
     GRAPHQL
 
-    profiles(:one).update account: accounts(:test)
+    profiles(:one).update account: accounts(:test),
+                          parent_profile: profiles(:two)
     users(:test).update account: nil
 
     assert_raises(Pundit::NotAuthorizedError) do

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -92,6 +92,28 @@ class ProfileTest < ActiveSupport::TestCase
     assert_empty BusinessObjective.where(title: 'abcd')
   end
 
+  test 'canonical profiles have no parent_profile_id' do
+    assert Profile.new.canonical?, 'nil parent_profile_id should be canonical'
+  end
+
+  test 'non-canonical profiles have a parent_profile_id' do
+    assert_not Profile.new(
+      parent_profile_id: profiles(:one).id
+    ).canonical?, 'non-nil parent_profile_id should not be canonical'
+  end
+
+  test 'canonical scope finds only canonical profiles' do
+    p1 = Profile.create!(ref_id: 'p1_foo_ref_id',
+                         name: 'p1 foo',
+                         benchmark_id: benchmarks(:one).id,
+                         parent_profile_id: profiles(:one).id)
+    p2 = Profile.create!(ref_id: 'p2_foo_ref_id',
+                         name: 'p2 foo',
+                         benchmark_id: benchmarks(:one).id)
+    assert_includes Profile.canonical, p2
+    assert_not_includes Profile.canonical, p1
+  end
+
   context 'cloning profile to account' do
     should 'create host relation when the profile is created' do
       assert_difference('ProfileHost.count', 1) do

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -262,6 +262,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         benchmark: @report_parser.benchmark,
         name: @report_parser.op_profiles.first.name,
         account: accounts(:one),
+        parent_profile: profiles(:one),
         hosts: [hosts(:one)]
       )
       profile2 = Profile.find_or_create_by(
@@ -269,6 +270,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         benchmark: @report_parser.benchmark,
         name: @report_parser.op_profiles.first.name,
         account: accounts(:test),
+        parent_profile: profiles(:one),
         hosts: [hosts(:two)]
       )
 


### PR DESCRIPTION
With the added parent_profile_id field, we no longer need to check existence of an account to determine if a profile is canonical or not.

Signed-off-by: Andrew Kofink <akofink@redhat.com>