### PR TITLE
Tailoring file service accepts rule selections

### DIFF
--- a/app/services/xccdf_tailoring_file.rb
+++ b/app/services/xccdf_tailoring_file.rb
@@ -6,7 +6,7 @@ class XccdfTailoringFile
 
   XCCDF = 'xccdf'
 
-  def initialize(profile:, rule_ref_ids: [], set_values: {})
+  def initialize(profile:, rule_ref_ids: {}, set_values: {})
     @profile = profile
     @rule_ref_ids = rule_ref_ids
     @set_values = set_values
@@ -18,15 +18,41 @@ class XccdfTailoringFile
 
   def builder
     @builder ||= create_builder do |xml|
-      xml[XCCDF].benchmark(id: @profile.benchmark.ref_id)
+      benchmark_builder(xml)
       xml[XCCDF].version(1, time: DateTime.now.iso8601)
-      xml[XCCDF].Profile(id: @profile.ref_id,
-                         extends: @profile.parent_profile.ref_id)
+      profile_builder(xml)
+    end
+  end
+
+  def benchmark_builder(xml)
+    xml[XCCDF].benchmark(
+      id: @profile.benchmark.ref_id,
+      version: @profile.benchmark.version,
+      href: "ssg-rhel#{@profile.benchmark.inferred_os_major_version}-ds.xml"
+    )
+  end
+
+  def profile_builder(xml)
+    xml[XCCDF].Profile(id: @profile.ref_id,
+                       extends: @profile.parent_profile.ref_id) do
+      xml[XCCDF].title(@profile.name,
+                       'xmlns:xhtml' => 'http://www.w3.org/1999/xhtml',
+                       'xml:lang' => 'en-US', override: true)
+      xml[XCCDF].description(@profile.description,
+                             'xmlns:xhtml' => 'http://www.w3.org/1999/xhtml',
+                             'xml:lang' => 'en-US', override: true)
+      rule_selections_builder(xml)
+    end
+  end
+
+  def rule_selections_builder(xml)
+    @rule_ref_ids.each do |rule_ref_id, selected|
+      xml[XCCDF].select(idref: rule_ref_id, selected: selected)
     end
   end
 
   def create_builder
-    handle_missing_parent_profile
+    validate_input
     Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
       xml[XCCDF].Tailoring('xmlns:xccdf' =>
                            'http://checklists.nist.gov/xccdf/1.2',
@@ -34,6 +60,21 @@ class XccdfTailoringFile
         yield xml
       end
     end
+  end
+
+  def validate_input
+    handle_missing_parent_profile
+    handle_missing_rules
+  end
+
+  def handle_missing_rules
+    missing_rules = @rule_ref_ids.keys -
+                    @profile.benchmark.rules
+                            .where(ref_id: @rule_ref_ids.keys).pluck(:ref_id)
+
+    e = ArgumentError.new("Benchmark(id=#{@profile.benchmark.id}) does not "\
+                          "contain selected rules: #{missing_rules.join(', ')}")
+    raise e if missing_rules.any?
   end
 
   def handle_missing_parent_profile


### PR DESCRIPTION
Test like this:

```rb
XccdfTailoringFile.new(
  profile: Profile.where.not(parent_profile_id: nil).first,
  rule_ref_ids: {'rule_ref_1' => true, 'rule_ref_2' => false}
).to_xml
```

which should return something like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<xccdf:Tailoring xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" id="xccdf_csfr-compliance_tailoring_default">
  <xccdf:benchmark id="xccdf_org.ssgproject.content_benchmark_RHEL-7"/>
  <xccdf:version time="2020-02-19T18:16:24+00:00">1</xccdf:version>
  <xccdf:Profile id="xccdf_org.ssgproject.content_profile_standard" extends="xccdf_org.ssgproject.content_profile_standard">
    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">Standard System Security Profile for Red Hat Enterprise Linux 7</xccdf:title>
    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This profile contains rules to ensure standard security baseline
of a Red Hat Enterprise Linux 7 system. Regardless of your system's workload
all of these checks should pass.</xccdf:description>
    <xccdf:select idref="rule_ref_1" selected="true"/>
    <xccdf:select idref="rule_ref_2" selected="false"/>
  </xccdf:Profile>
</xccdf:Tailoring>
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>