### PR TITLE
Update rswag specs to include limit/offset/search

### DIFF
--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -8,10 +8,12 @@ describe 'Profiles API' do
       fixtures :profiles
       tags 'profile'
       description 'Lists all profiles requested'
-      consumes 'application/vnd.api+json'
-      produces 'application/vnd.api+json'
       operationId 'ListProfiles'
-      parameter name: :'X-RH-IDENTITY', in: :header, schema: { type: :string }
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
 
       response '200', 'lists all profiles requested' do
         let(:'X-RH-IDENTITY') { encoded_header }
@@ -54,10 +56,13 @@ describe 'Profiles API' do
       fixtures :hosts, :benchmarks, :profiles
       tags 'profile'
       description 'Retrieves data for a profile'
-      consumes 'application/vnd.api+json'
-      produces 'application/vnd.api+json'
       operationId 'ShowProfile'
-      parameter name: :'X-RH-IDENTITY', in: :header, schema: { type: :string }
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
+
       parameter name: :id, in: :path, type: :string
 
       response '404', 'profile not found' do

--- a/spec/integration/rule_results_spec.rb
+++ b/spec/integration/rule_results_spec.rb
@@ -8,10 +8,12 @@ describe 'RuleResults API' do
       fixtures :rules, :hosts, :rule_results
       tags 'rule_result'
       description 'Lists all rule_results requested'
-      consumes 'application/vnd.api+json'
-      produces 'application/vnd.api+json'
       operationId 'ListRuleResults'
-      parameter name: :'X-RH-IDENTITY', in: :header, schema: { type: :string }
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
 
       response '200', 'lists all rule_results requested' do
         let(:'X-RH-IDENTITY') do

--- a/spec/integration/rules_spec.rb
+++ b/spec/integration/rules_spec.rb
@@ -8,10 +8,12 @@ describe 'Rules API' do
       fixtures :rules
       tags 'rule'
       description 'Lists all rules requested'
-      consumes 'application/vnd.api+json'
-      produces 'application/vnd.api+json'
       operationId 'ListRules'
-      parameter name: :'X-RH-IDENTITY', in: :header, schema: { type: :string }
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
 
       response '200', 'lists all rules requested' do
         let(:'X-RH-IDENTITY') { encoded_header }
@@ -71,10 +73,13 @@ describe 'Rules API' do
       fixtures :hosts, :benchmarks, :rules, :profiles
       tags 'rule'
       description 'Retrieves data for a rule'
-      consumes 'application/vnd.api+json'
-      produces 'application/vnd.api+json'
       operationId 'ShowRule'
-      parameter name: :'X-RH-IDENTITY', in: :header, schema: { type: :string }
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
+
       parameter name: :id, in: :path, type: :string
 
       response '404', 'rule not found' do

--- a/spec/integration/systems_spec.rb
+++ b/spec/integration/systems_spec.rb
@@ -8,10 +8,12 @@ describe 'Systems API' do
       fixtures :hosts
       tags 'host'
       description 'Lists all hosts requested'
-      consumes 'application/vnd.api+json'
-      produces 'application/vnd.api+json'
       operationId 'ListHosts'
-      parameter name: :'X-RH-IDENTITY', in: :header, schema: { type: :string }
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
 
       response '200', 'lists all hosts requested' do
         let(:'X-RH-IDENTITY') { encoded_header }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -191,3 +191,30 @@ def x_rh_identity
   }.with_indifferent_access
 end
 # rubocop:enable Metrics/MethodLength
+
+def pagination_params
+  parameter name: :limit, in: :query, required: false,
+            description: 'The number of items to return',
+            schema: { type: :integer, maximum: 100, minimum: 1, default: 10 }
+  parameter name: :offset, in: :query, required: false,
+            description: 'The number of items to skip before starting '\
+            'to collect the result set',
+            schema: { type: :integer, minimum: 1, default: 1 }
+end
+
+def search_params
+  parameter name: :search, in: :query, required: false,
+            description: 'Query string compliant with scoped_search '\
+            'query language: '\
+            'https://github.com/wvanbergen/scoped_search/wiki/Query-language',
+            schema: { type: :string, default: '' }
+end
+
+def content_types
+  consumes 'application/vnd.api+json'
+  produces 'application/vnd.api+json'
+end
+
+def auth_header
+  parameter name: :'X-RH-IDENTITY', in: :header, schema: { type: :string }
+end

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -13,19 +13,52 @@
           "profile"
         ],
         "description": "Lists all profiles requested",
+        "operationId": "ListProfiles",
         "consumes": [
           "application/vnd.api+json"
         ],
         "produces": [
           "application/vnd.api+json"
         ],
-        "operationId": "ListProfiles",
         "parameters": [
           {
             "name": "X-RH-IDENTITY",
             "in": "header",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
             }
           }
         ],
@@ -88,19 +121,52 @@
           "profile"
         ],
         "description": "Retrieves data for a profile",
+        "operationId": "ShowProfile",
         "consumes": [
           "application/vnd.api+json"
         ],
         "produces": [
           "application/vnd.api+json"
         ],
-        "operationId": "ShowProfile",
         "parameters": [
           {
             "name": "X-RH-IDENTITY",
             "in": "header",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
             }
           },
           {
@@ -174,19 +240,52 @@
           "rule_result"
         ],
         "description": "Lists all rule_results requested",
+        "operationId": "ListRuleResults",
         "consumes": [
           "application/vnd.api+json"
         ],
         "produces": [
           "application/vnd.api+json"
         ],
-        "operationId": "ListRuleResults",
         "parameters": [
           {
             "name": "X-RH-IDENTITY",
             "in": "header",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
             }
           }
         ],
@@ -262,19 +361,52 @@
           "rule"
         ],
         "description": "Lists all rules requested",
+        "operationId": "ListRules",
         "consumes": [
           "application/vnd.api+json"
         ],
         "produces": [
           "application/vnd.api+json"
         ],
-        "operationId": "ListRules",
         "parameters": [
           {
             "name": "X-RH-IDENTITY",
             "in": "header",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
             }
           }
         ],
@@ -291,7 +423,7 @@
                   "$ref": "#/definitions/links"
                 },
                 "data": {
-                  "type": "array",
+                  "type": "object",
                   "items": {
                     "properties": {
                       "type": {
@@ -340,19 +472,52 @@
           "rule"
         ],
         "description": "Retrieves data for a rule",
+        "operationId": "ShowRule",
         "consumes": [
           "application/vnd.api+json"
         ],
         "produces": [
           "application/vnd.api+json"
         ],
-        "operationId": "ShowRule",
         "parameters": [
           {
             "name": "X-RH-IDENTITY",
             "in": "header",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
             }
           },
           {
@@ -425,19 +590,52 @@
           "host"
         ],
         "description": "Lists all hosts requested",
+        "operationId": "ListHosts",
         "consumes": [
           "application/vnd.api+json"
         ],
         "produces": [
           "application/vnd.api+json"
         ],
-        "operationId": "ListHosts",
         "parameters": [
           {
             "name": "X-RH-IDENTITY",
             "in": "header",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
             }
           }
         ],


### PR DESCRIPTION
@Victoremepunto this one's for you :)

Just so we're all on the same page, the files in `spec` contain both the actual API definition as well as some tests for the API. This is just the way rswag works, but it's still an API definition first model (i.e. we're not generating the API from our controller code in `app/`, and there's no guarantee that our API behaves the way we defined it). `bundle exec rake rswag` generates the `swagger/v1/openapi.json` from what's defined in `spec`. It's much nicer to be able to define resources separately (and in Ruby) than in one big yaml or json file manually.

@Victoremepunto compare against your changes in https://github.com/RedHatInsights/compliance-backend/pull/250

Signed-off-by: Andrew Kofink <akofink@redhat.com>