### PR TITLE
Check for rule within user rules scope

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -7,8 +7,9 @@ class RulesController < ApplicationController
   end
 
   def show
-    rule = Rule.friendly.find(params[:id])
-    authorize rule
+    rule = ::Pundit.policy_scope(User.current, ::Rule).friendly.find(
+      params[:id]
+    )
     render json: RuleSerializer.new(rule)
   end
 

--- a/test/controllers/rules_controller_test.rb
+++ b/test/controllers/rules_controller_test.rb
@@ -5,6 +5,9 @@ require 'test_helper'
 class RulesControllerTest < ActionDispatch::IntegrationTest
   setup do
     RulesController.any_instance.stubs(:authenticate_user)
+    User.current = users(:test)
+    users(:test).update account: accounts(:test)
+    profiles(:one).update(account: accounts(:test))
   end
 
   test 'index lists all rules' do
@@ -15,13 +18,17 @@ class RulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'shows a rule' do
-    RulesController.any_instance.expects(:authorize)
-    relation = mock('relation')
-    relation.expects(:find).with('1')
-    Rule.expects(:friendly).returns(relation)
-    get rule_url(1)
+  test 'finds a rule within the user scope' do
+    profiles(:one).update rules: [rules(:one)]
+    get rule_url(rules(:one).ref_id)
 
     assert_response :success
+  end
+
+  test 'does not find a rule outside of the user scope' do
+    profiles(:one).update rules: [rules(:one)]
+    get rule_url(rules(:two).ref_id)
+
+    assert_response :not_found
   end
 end

--- a/test/fixtures/rules.yml
+++ b/test/fixtures/rules.yml
@@ -8,6 +8,7 @@ one:
   description: MyText
   rationale: MyText
   benchmark: one
+  slug: MyStringOne
 
 two:
   ref_id: MyStringTwo
@@ -17,3 +18,4 @@ two:
   description: MyText
   rationale: MyText
   benchmark: one
+  slug: MyStringTwo


### PR DESCRIPTION
We're seeing some problems in production because /rules/$REF_ID does not work for some users, if the rule appears in multiple benchmarks. In that case `.find` will just find the first rule, which may appear in a benchmark that the current user has no policies in (hence, the user gets a 403 unauthorized). 

To avoid this, but keep the same behavior restricting visible rules to only rules for the policies visible by the user, we can query directly within the Rules policy scope for the user.  