### PR TITLE
Don't delete orphaned profiles

### DIFF
--- a/app/models/profile_host.rb
+++ b/app/models/profile_host.rb
@@ -8,10 +8,4 @@ class ProfileHost < ApplicationRecord
 
   validates :profile, presence: true
   validates :host, presence: true, uniqueness: { scope: :profile }
-
-  before_destroy :delete_orphaned_profiles
-
-  def delete_orphaned_profiles
-    profile.destroy unless (profile.hosts - [host]).any?
-  end
 end

--- a/test/models/profile_host_test.rb
+++ b/test/models/profile_host_test.rb
@@ -8,18 +8,4 @@ class ProfileHostTest < ActiveSupport::TestCase
     @host = hosts(:one)
     @profile_host = ProfileHost.new(profile: @profile, host: @host)
   end
-
-  test '#delete_orphaned_profiles when some other hosts still exist (noop)' do
-    @profile.expects(:destroy).never
-    @profile.stubs(:hosts).returns([hosts(:two)])
-
-    @profile_host.delete_orphaned_profiles
-  end
-
-  test '#delete_orphaned_profiles when only this host exists' do
-    @profile.expects(:destroy)
-    @profile.stubs(:hosts).returns([@host])
-
-    @profile_host.delete_orphaned_profiles
-  end
 end


### PR DESCRIPTION
This doesn't really make much sense anymore now that users can create and delete policies themselves via the API and UI.

Signed-off-by: Andrew Kofink <akofink@redhat.com>