### PR TITLE
Migrate profiles using account_id to parent_profile_id

### DIFF
--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# A service class to associate profiles to their parent profiles
+class ParentProfileAssociator
+  class << self
+    def run!
+      Profile.transaction do
+        Profile.where.not(account: nil).find_each do |profile|
+          profile.update!(parent_profile: find_parent(profile))
+        end
+      end
+    end
+
+    private
+
+    def find_parent(profile)
+      parents = Profile.where(ref_id: profile.ref_id,
+                              benchmark_id: profile.benchmark_id,
+                              account_id: nil)
+      raise not_found(profile) unless parents.one?
+
+      parents.first
+    end
+
+    def not_found(profile)
+      ActiveRecord::RecordNotFound.new(
+        "Failed to find parent for profile with ID #{profile.id}."
+      )
+    end
+  end
+end

--- a/db/migrate/20200120203124_add_parent_profile_id_to_profiles.rb
+++ b/db/migrate/20200120203124_add_parent_profile_id_to_profiles.rb
@@ -1,5 +1,11 @@
 class AddParentProfileIdToProfiles < ActiveRecord::Migration[5.2]
-  def change
+  def down
+    remove_reference :profiles, :parent_profile
+  end
+
+  def up
     add_reference :profiles, :parent_profile, type: :uuid, foreign_key: { to_table: :profiles }
+
+    ParentProfileAssociator.run!
   end
 end

--- a/test/services/parent_profile_associator_test.rb
+++ b/test/services/parent_profile_associator_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ParentProfileAssociatorTest < ActiveSupport::TestCase
+  test 'finds a single parent profile per profile' do
+    child_profile = profiles(:one).dup
+    child_profile.account = accounts(:test)
+    assert child_profile.save
+
+    assert_difference('Profile.where.not(parent_profile_id: nil).count', 1) do
+      ParentProfileAssociator.run!
+    end
+  end
+end


### PR DESCRIPTION
Since the parent_profile migration hasn't made it past CI and given it's the latest migration in the repo, I propose we rollback CI 1 migration and re-migrate to get this data migration in. I think it's more consistent with how we've done this in the past than to create another migration.

Signed-off-by: Andrew Kofink <akofink@redhat.com>