### PR TITLE
Assign parent_profile on profile clone

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -103,7 +103,8 @@ class Profile < ApplicationRecord
   def clone_to(account: nil, host: nil)
     new_profile = in_account(account)
     if new_profile.nil?
-      (new_profile = dup).update!(account: account, hosts: [host])
+      (new_profile = dup).update!(account: account, hosts: [host],
+                                  parent_profile: self)
     else
       new_profile.hosts << host unless new_profile.hosts.include?(host)
     end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -119,5 +119,17 @@ class ProfileTest < ActiveSupport::TestCase
         assert hosts(:one).profiles.include?(cloned_profile)
       end
     end
+
+    should 'set the parent profile ID to the original profile' do
+      canonical = Profile.canonical.first
+
+      assert_difference('Profile.count', 1) do
+        cloned_profile = canonical.clone_to(
+          account: accounts(:one), host: hosts(:one)
+        )
+
+        assert_equal canonical, cloned_profile.parent_profile
+      end
+    end
   end
 end


### PR DESCRIPTION
I think this is the last place in our code where we create a non-canonical profile and need to set its parent_profile.

Signed-off-by: Andrew Kofink <akofink@redhat.com>