### PR TITLE
Format stale_timestamp properly

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -56,7 +56,7 @@ class HostInventoryAPI
       'facts': [{ 'facts': { 'fqdn': @hostname }, 'namespace': 'inventory' }],
       'fqdn': @hostname,
       'display_name': @hostname,
-      'stale_timestamp': 1.week.from_now.strftime('%FT%T%:z'),
+      'stale_timestamp': 1.week.from_now.iso8601,
       'reporter': 'compliance',
       'account': @account.account_number
     }].to_json

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -56,7 +56,7 @@ class HostInventoryAPI
       'facts': [{ 'facts': { 'fqdn': @hostname }, 'namespace': 'inventory' }],
       'fqdn': @hostname,
       'display_name': @hostname,
-      'stale_timestamp': 1.week.from_now.to_s,
+      'stale_timestamp': 1.week.from_now.strftime('%FT%T%:z'),
       'reporter': 'compliance',
       'account': @account.account_number
     }].to_json


### PR DESCRIPTION
Using the current format, we get the error `{'stale_timestamp': ['Not a valid datetime.']}`.
I don't think this is used in reality, I only noticed because I have this script to create fake hosts in the db:

```ruby
namespace :fake_data do
  task create_hosts_in_inventory: :environment do
    module Platform
      def self.connection
        faraday = Faraday.new do |f|
          f.response :raise_error
          f.adapter Faraday.default_adapter # this must be the last middleware
          f.basic_auth 'dlobatog@redhat.com', 'redhat'
          f.ssl[:verify] = false
        end
        faraday
      end
    end
    account = ::Account.where(account_number: '1460290').first

    200.times do |i|
      host = Host.new(name: "lobatolan-#{i}")
      host.save
      hostinventory = ::HostInventoryAPI.new(host.id, host.name, account, 'https://ci.cloud.redhat.com', nil)
      inventory_host = hostinventory.inventory_host
      host.update(id: inventory_host['id'])
      host.profiles << Profile.first
      tr = TestResult.new(
        profile: Profile.first,
        host: host,
        start_time: Time.now,
        end_time: Time.now,
        score: 50.0
      )
      tr.save
      RuleResult.create(host: host, rule: Profile.first.rules.first, result: 'fail', test_result: tr)
      RuleResult.create(host: host, rule: Profile.first.rules.first, result: 'pass', test_result: tr)
    end

    ::Host.all.each do |host|
      hostinventory = ::HostInventoryAPI.new(host.id, host.name, account, 'https://ci.cloud.redhat.com', nil)
      inventory_host = hostinventory.inventory_host
      host.update(id: inventory_host['id'])
    end
  end
end

```