### PR TITLE
Find all rules by slug using LIKE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ gem 'oj'
 gem 'newrelic_rpm'
 gem 'gitlab-sidekiq-fetcher', require: 'sidekiq-reliable-fetch'
 
+gem 'uuid'
+
 gem 'openscap_parser', '~> 1.0.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       pry (~> 0.9)
       slop (~> 3.0)
     public_suffix (4.0.3)
-    puma (3.12.3)
+    puma (3.12.4)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     racecar (1.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -324,6 +326,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    systemu (2.6.5)
     thor (1.0.1)
     thread_safe (0.3.6)
     tty-color (0.5.0)
@@ -334,6 +337,8 @@ GEM
     unicode-display_width (1.6.0)
     uniform_notifier (1.13.0)
     url (0.3.2)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
     webmock (3.7.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -400,6 +405,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tty-command
   tzinfo-data
+  uuid
   webmock
   will_paginate
 

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -29,15 +29,12 @@ class RulesController < ApplicationController
   end
 
   def search_by_ref_id
-    rule = canonical.where(
+    rule = Rule.canonical.where(
       'rules.slug LIKE ?',
       "%#{ActiveRecord::Base.sanitize_sql_like(params[:id])}%"
     )
     raise ActiveRecord::RecordNotFound if rule.blank?
-    rule.first
-  end
 
-  def canonical
-    Rule.where(benchmark_id: ::Xccdf::Benchmark.latest.pluck(:id))
+    rule.first
   end
 end

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -7,9 +7,12 @@ class RulesController < ApplicationController
   end
 
   def show
-    rule = ::Pundit.policy_scope(User.current, ::Rule).friendly.find(
-      params[:id]
-    )
+    rule = ::Pundit.policy_scope(User.current, ::Rule).where(
+      'rules.slug LIKE ?',
+      "%#{ActiveRecord::Base.sanitize_sql_like(params[:id])}%"
+    ).first
+    raise ActiveRecord::RecordNotFound if rule.blank?
+
     render json: RuleSerializer.new(rule)
   end
 

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -29,7 +29,7 @@ class RulesController < ApplicationController
   end
 
   def search_by_ref_id
-    rule = Rule.canonical.where(
+    rule = Rule.latest.where(
       'rules.slug LIKE ?',
       "%#{ActiveRecord::Base.sanitize_sql_like(params[:id])}%"
     )

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -41,6 +41,10 @@ class Rule < ApplicationRecord
     joins(:profile_rules).where.not(profile_rules: { profile_id: nil }).distinct
   }
 
+  scope :canonical, lambda {
+    where(benchmark_id: ::Xccdf::Benchmark.latest.pluck(:id))
+  }
+
   def self.from_openscap_parser(op_rule, benchmark_id: nil)
     rule = find_or_initialize_by(ref_id: op_rule.id,
                                  benchmark_id: benchmark_id)

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -41,7 +41,7 @@ class Rule < ApplicationRecord
     joins(:profile_rules).where.not(profile_rules: { profile_id: nil }).distinct
   }
 
-  scope :canonical, lambda {
+  scope :latest, lambda {
     where(benchmark_id: ::Xccdf::Benchmark.latest.pluck(:id))
   }
 

--- a/app/serializers/rule_serializer.rb
+++ b/app/serializers/rule_serializer.rb
@@ -4,5 +4,5 @@
 class RuleSerializer
   include FastJsonapi::ObjectSerializer
   attributes :created_at, :updated_at, :ref_id, :title, :rationale,
-             :description, :severity
+             :description, :severity, :slug
 end

--- a/db/migrate/20200303102215_change_phony_benchmark.rb
+++ b/db/migrate/20200303102215_change_phony_benchmark.rb
@@ -1,0 +1,9 @@
+class ChangePhonyBenchmark < ActiveRecord::Migration[5.2]
+  def up
+    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update(version: '0.0.0')
+  end
+
+  def down
+    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update(version: 'v0.0.0')
+  end
+end

--- a/db/migrate/20200303102215_change_phony_benchmark.rb
+++ b/db/migrate/20200303102215_change_phony_benchmark.rb
@@ -1,9 +1,0 @@
-class ChangePhonyBenchmark < ActiveRecord::Migration[5.2]
-  def up
-    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update(version: '0.0.0')
-  end
-
-  def down
-    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update(version: 'v0.0.0')
-  end
-end

--- a/db/migrate/20200303102215_change_phony_benchmark_version.rb
+++ b/db/migrate/20200303102215_change_phony_benchmark_version.rb
@@ -2,7 +2,7 @@ class ChangePhonyBenchmarkVersion < ActiveRecord::Migration[5.2]
   # The `.latest` method of ::Xccdf::Benchmark is using Gem::Version, which
   # expects the version to have the same versioning syntax as a gemspec.
   def up
-    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update!(version: '0.0.0')
+    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').&update!(version: '0.0.0')
   end
 
   def down

--- a/db/migrate/20200303102215_change_phony_benchmark_version.rb
+++ b/db/migrate/20200303102215_change_phony_benchmark_version.rb
@@ -1,7 +1,10 @@
 class ChangePhonyBenchmarkVersion < ActiveRecord::Migration[5.2]
   # The `.latest` method of ::Xccdf::Benchmark is using Gem::Version, which
   # expects the version to have the same versioning syntax as a gemspec.
-  def change
-    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update(version: '0.0.0')
+  def up
+    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update!(version: '0.0.0')
+  end
+
+  def down
   end
 end

--- a/db/migrate/20200303102215_change_phony_benchmark_version.rb
+++ b/db/migrate/20200303102215_change_phony_benchmark_version.rb
@@ -1,0 +1,7 @@
+class ChangePhonyBenchmarkVersion < ActiveRecord::Migration[5.2]
+  # The `.latest` method of ::Xccdf::Benchmark is using Gem::Version, which
+  # expects the version to have the same versioning syntax as a gemspec.
+  def change
+    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').update(version: '0.0.0')
+  end
+end

--- a/db/migrate/20200303102215_change_phony_benchmark_version.rb
+++ b/db/migrate/20200303102215_change_phony_benchmark_version.rb
@@ -2,7 +2,7 @@ class ChangePhonyBenchmarkVersion < ActiveRecord::Migration[5.2]
   # The `.latest` method of ::Xccdf::Benchmark is using Gem::Version, which
   # expects the version to have the same versioning syntax as a gemspec.
   def up
-    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id').&update!(version: '0.0.0')
+    ::Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id')&.update!(version: '0.0.0')
   end
 
   def down

--- a/test/controllers/rules_controller_test.rb
+++ b/test/controllers/rules_controller_test.rb
@@ -25,6 +25,14 @@ class RulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'finds a rule with similar slug within the user scope' do
+    rules(:two).update(slug: "#{rules(:two).ref_id}-#{SecureRandom.uuid}")
+    profiles(:one).update rules: [rules(:two)]
+    get rule_url(rules(:two).ref_id)
+
+    assert_response :success
+  end
+
   test 'does not find a rule outside of the user scope' do
     profiles(:one).update rules: [rules(:one)]
     get rule_url(rules(:two).ref_id)

--- a/test/controllers/rules_controller_test.rb
+++ b/test/controllers/rules_controller_test.rb
@@ -7,7 +7,10 @@ class RulesControllerTest < ActionDispatch::IntegrationTest
     RulesController.any_instance.stubs(:authenticate_user)
     User.current = users(:test)
     users(:test).update account: accounts(:test)
-    profiles(:one).update(account: accounts(:test))
+    profiles(:one).update(
+      account: accounts(:test),
+      rules: [rules(:one)]
+    )
   end
 
   test 'index lists all rules' do
@@ -19,9 +22,7 @@ class RulesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'finds a rule within the user scope' do
-    profiles(:one).update rules: [rules(:one)]
     get rule_url(rules(:one).ref_id)
-
     assert_response :success
   end
 
@@ -33,10 +34,18 @@ class RulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'does not find a rule outside of the user scope' do
-    profiles(:one).update rules: [rules(:one)]
+  test 'finds a rule by ID' do
+    get rule_url(rules(:one).id)
+
+    assert_response :success
+  end
+
+  test 'finds rules not within the user scope but within canonical' do
+    assert_includes(Rule.canonical, rules(:two))
+    assert_not_includes(::Pundit.policy_scope(users(:test), ::Rule),
+                        rules(:two))
     get rule_url(rules(:two).ref_id)
 
-    assert_response :not_found
+    assert_response :success
   end
 end

--- a/test/controllers/rules_controller_test.rb
+++ b/test/controllers/rules_controller_test.rb
@@ -40,8 +40,8 @@ class RulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'finds rules not within the user scope but within canonical' do
-    assert_includes(Rule.canonical, rules(:two))
+  test 'finds rules not within the user scope but within latest' do
+    assert_includes(Rule.latest, rules(:two))
     assert_not_includes(::Pundit.policy_scope(users(:test), ::Rule),
                         rules(:two))
     get rule_url(rules(:two).ref_id)


### PR DESCRIPTION
Apparently our DB contains multiple slugged rules, one per benchmark. In that case, the regular `friendly.find` will not find it.  

Instead of that, when a user looks for a ref_id we can just find all of the ref_ids that look like it within the user scope. In that case, if you look for `xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies` but only `xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-98d17f35-6094-4071-b099-cb4bca02615d` is in the scope, it will still be found. 

```ruby
Rule.where(ref_id: "xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies").map(&:slug)
  Rule Load (3.6ms)  SELECT "rules".* FROM "rules" WHERE "rules"."ref_id" = $1  [["ref_id", "xccdf_org.ssgproject.content_rule_sysctl_net_ipv4_tcp_syncookies"]]
=> ["xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-98d17f35-6094-4071-b099-cb4bca02615d",
 "xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-85c2e772-8b39-48ad-8146-2813ce479ee5",
 "xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies",
 "xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-7c478946-f34a-45eb-a086-05e4b214bb8d",
 "xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-9eb475b7-9c5e-41e6-b5b5-ee0ea9485031",
 "xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-5c0699a9-1ba9-4453-bcbf-4294eb8ddb68",
 "xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-e00e81f0-971b-4ce3-b628-654200888e44",
 "xccdf_org-ssgproject-content_rule_sysctl_net_ipv4_tcp_syncookies-d4e05553-08b2-4c37-8bf0-439bd8516843"]
```

@Victoremepunto @akofink I'm adding also `slug` to the serializer so it's easier for QE to find these broken slugs. To avoid this in the future, a proper fix IMO would be to use:
```ruby
  friendly_id :ref_id, :use => :scoped, :scope => :benchmark
``` 
, which would also include removing the uniqueness constraint on the slug column, and a migration to change that. I don't want to get that change in right now as that would be problematic to get to production. 

http://norman.github.io/friendly_id/file.Guide.html#Uniqueness