### PR TITLE
Allow downloading tailoring of a profile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,12 +7,28 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    profile = Profile.find(params[:id])
     authorize profile
     render json: ProfileSerializer.new(profile)
   end
 
+  def tailoring_file
+    return unless profile.tailored?
+
+    send_data XccdfTailoringFile.new(
+      profile: profile,
+      rule_ref_ids: profile.tailored_rule_ref_ids
+    ).to_xml, filename: tailoring_filename, type: Mime[:xml]
+  end
+
   private
+
+  def tailoring_filename
+    "#{profile.benchmark.ref_id}__#{profile.ref_id}__tailoring.xml"
+  end
+
+  def profile
+    @profile ||= Profile.find(params[:id])
+  end
 
   def resource
     Profile

--- a/app/models/concerns/profile_tailoring.rb
+++ b/app/models/concerns/profile_tailoring.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Methods that are related to profile tailoring
+module ProfileTailoring
+  def tailored_rule_ref_ids
+    return [] unless tailored?
+
+    (added_rules.map do |rule|
+      [rule.ref_id, true] # selected
+    end + removed_rules.map do |rule|
+      [rule.ref_id, false] # notselected
+    end).to_h
+  end
+
+  def tailored?
+    !canonical? && (added_rules + removed_rules).any?
+  end
+
+  def added_rules
+    rules - parent_profile.rules
+  end
+
+  def removed_rules
+    parent_profile.rules - rules
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,6 +2,8 @@
 
 # OpenSCAP profile
 class Profile < ApplicationRecord
+  include ProfileTailoring
+
   attribute :delete_all_test_results, :boolean, default: false
 
   scoped_search on: %i[id name ref_id account_id compliance_threshold]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@
 Rails.application.routes.draw do
   def draw_routes(prefix)
     scope "#{prefix}/#{ENV['APP_NAME']}" do
-      resources :profiles, only: [:index, :show]
+      resources :profiles, only: [:index, :show] do
+        member do
+          get 'tailoring_file'
+        end
+      end
       resources :rule_results, only: [:index]
       resources :systems, only: [:index, :destroy]
       resources :rules, only: [:index, :show]

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -3,4 +3,34 @@
 require 'test_helper'
 
 class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    ProfilesController.any_instance.stubs(:authenticate_user)
+    User.current = users(:test)
+    users(:test).update! account: accounts(:test)
+    profiles(:one).update! account: accounts(:test)
+  end
+
+  test 'tailoring_file with a canonical profile returns no content' do
+    profiles(:one).update! rules: [rules(:one)]
+    get tailoring_file_profile_url(profiles(:one).id)
+    assert_response :no_content
+  end
+
+  test 'tailoring_file with a noncanonical profile matching its parent'\
+       'returns no content' do
+    profiles(:two).update!(rules: [rules(:one)])
+    profiles(:one).update!(parent_profile: profiles(:two),
+                           rules: [rules(:one)])
+    get tailoring_file_profile_url(profiles(:one).id)
+    assert_response :no_content
+  end
+
+  test 'tailoring_file with a noncanonical profile returns a tailoring file' do
+    profiles(:two).update!(rules: [rules(:one), rules(:two)])
+    profiles(:one).update!(parent_profile: profiles(:two),
+                           rules: [rules(:one)])
+    get tailoring_file_profile_url(profiles(:one).id)
+    assert_response :success
+    assert_equal Mime[:xml].to_s, @response.content_type
+  end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -154,4 +154,29 @@ class ProfileTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context 'profile tailoring' do
+    setup do
+      @parent_profile = Profile.create!(benchmark: benchmarks(:one),
+                                        ref_id: 'foo',
+                                        name: 'foo profile')
+      @parent_profile.update! rules: [rules(:one)]
+      @profile = @parent_profile.clone_to(account: accounts(:one),
+                                          host: hosts(:one))
+      @profile.update! rules: [rules(:two)]
+    end
+
+    should 'send the correct rule ref ids to the tailoring file service' do
+      assert_equal({ rules(:one).ref_id => false, rules(:two).ref_id => true },
+                   @profile.tailored_rule_ref_ids)
+    end
+
+    should 'properly detects added_rules' do
+      assert_equal [rules(:two)], @profile.added_rules
+    end
+
+    should 'properly detects removed_rules' do
+      assert_equal [rules(:one)], @profile.removed_rules
+    end
+  end
 end


### PR DESCRIPTION
~It works without https://github.com/RedHatInsights/compliance-backend/pull/324 (merged), but you won't be able to generate any useful tailoring file with selected/unselected rules without it.~

Signed-off-by: Andrew Kofink <akofink@redhat.com>