### PR TITLE
RHICOMPL-292 - Remove host when associating no profiles to it

### DIFF
--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -13,6 +13,7 @@ module Mutations
       def resolve(args = {})
         host = find_hosts([args[:id]]).first
         return delete_host(host) if args[:profile_ids].empty?
+
         profiles = find_profiles(args[:profile_ids])
         host.update(profiles: profiles)
         { system: host }

--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -12,8 +12,14 @@ module Mutations
 
       def resolve(args = {})
         host = find_hosts([args[:id]]).first
+        return delete_host(host) if args[:profile_ids].empty?
         profiles = find_profiles(args[:profile_ids])
         host.update(profiles: profiles)
+        { system: host }
+      end
+
+      def delete_host(host)
+        DeleteHost.perform_async(id: host.id)
         { system: host }
       end
 


### PR DESCRIPTION
When on the frontend we assign no profiles to a host, the host remains in the compliance DB, which is problematic as it's displayed still in the systems table with 0 profiles. Instead, we should delete the host and inform the user this is happening asynchronously.