### PR TITLE
Correct latestBenchmarks pundit policy invocation

### DIFF
--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -100,7 +100,8 @@ module Types
     def latest_benchmarks
       Pundit.authorize(
         context[:current_user],
-        ::Xccdf::Benchmark.latest
+        ::Xccdf::Benchmark.latest,
+        :index?, policy_class: BenchmarkPolicy
       )
     end
 


### PR DESCRIPTION
I'm not sure how this was working before, but this fixed it for me.

Here's the issue:

```
Started POST "/api/compliance/graphql" for 172.18.0.1 at 2020-03-09 18:33:54 +0000                                                                                                                                                                                                                                                                                                            
Processing by GraphqlController#query as */*                                                                                                                                                                                                                                                                                                                                                  
  Parameters: {"operationName"=>"benchmarksAndProfiles", "variables"=>{}, "query"=>"query benchmarksAndProfiles {\n  latestBenchmarks {\n    id\n    title\n    version\n    profiles {\n      id\n      name\n      refId\n      description\n      complianceThreshold\n      __typename\n    }\n    __typename\n  }\n  profiles {\n    edges {\n      node {\n        id\n        refId\n  
      benchmarkId\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n", "graphql"=>{"operationName"=>"benchmarksAndProfiles", "variables"=>{}, "query"=>"query benchmarksAndProfiles {\n  latestBenchmarks {\n    id\n    title\n    version\n    profiles {\n      id\n      name\n      refId\n      description\n      complianceThreshold\n      __typename\n 
   }\n    __typename\n  }\n  profiles {\n    edges {\n      node {\n        id\n        refId\n        benchmarkId\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n"}}                                                                                                                                                                                         
  Account Load (1.2ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."account_number" = $1 LIMIT $2  [["account_number", "1212729"], ["LIMIT", 1]]                                                                                                                                                                                                                                   
  ↳ app/controllers/concerns/authentication.rb:60                                                                                                                                                                                                                                                                                                                                             
  User Load (1.7ms)  SELECT  "users".* FROM "users" WHERE "users"."username" = $1 AND "users"."account_id" = $2 LIMIT $3  [["username", "rhn-engineering-akofink"], ["account_id", "de350b90-63bd-47cb-aefe-76906b97ec84"], ["LIMIT", 1]]                                                                                                                                                     
  ↳ app/controllers/concerns/authentication.rb:37                                                                                                                                                                                                                                                                                                                                             
User authentication SUCCESS: {"account_number"=>"1212729", "type"=>"User", "user"=>{"username"=>"rhn-engineering-akofink", "email"=>"akofink+qa@redhat.com", "first_name"=>"Andrew", "last_name"=>"Kofink", "is_active"=>true, "is_org_admin"=>false, "is_internal"=>true, "locale"=>"en_US"}, "internal"=>{"org_id"=>7929311}}                                                               
  Xccdf::Benchmark Load (8.3ms)  SELECT DISTINCT ref_id, version, id, title FROM "benchmarks"                                                                                                                                                                                                                                                                                                 
  ↳ app/models/xccdf/benchmark.rb:36                                                                                                                                                                                                                                                                                                                                                          
Completed 500 Internal Server Error in 1481ms (ActiveRecord: 18.7ms)

ArgumentError (wrong number of arguments (given 2, expected 3)):                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                              
app/graphql/types/query.rb:101:in `latest_benchmarks'                                                                                                                                                                                                                                                                                                                                         
app/controllers/graphql_controller.rb:8:in `query'
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>