### PR TITLE
Correct sidekiq configuration

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,46 +1,30 @@
-if $0.include?('sidekiq')
-  Sidekiq.configure_server do |config|
-    config.redis = {
-      url: "redis://#{Settings.redis_url}",
-      network_timeout: 5 # Default is 1 second, let's be more lenient
-    }
-    Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
-    config.server_middleware do |chain|
-      require 'prometheus_exporter/instrumentation'
-      chain.add PrometheusExporter::Instrumentation::Sidekiq
-    end
-    config.on :startup do
-      require 'prometheus_exporter/instrumentation'
-      PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
-    end
-    config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
-    at_exit do
-      PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
-    end
+sidekiq_config = lambda do |config|
+  config.redis = {
+    url: "redis://#{Settings.redis_url}",
+    network_timeout: 5
+  }
+  Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
+
+  config.server_middleware do |chain|
+    require 'prometheus_exporter/instrumentation'
+    chain.add PrometheusExporter::Instrumentation::Sidekiq
+  end
+  config.on :startup do
+    require 'prometheus_exporter/instrumentation'
+    PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
+  end
+  config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+
+  at_exit do
+    PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
   end
 end
 
-if Rails.env != 'test' && ($0.include?('sidekiq') || $0.include?('racecar') ||
-    $0.include?('rake'))
-  Sidekiq.configure_client do |config|
-    config.redis = {
-      url: "redis://#{Settings.redis_url}",
-      network_timeout: 5
-    }
-    Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
-    config.server_middleware do |chain|
-      require 'prometheus_exporter/instrumentation'
-      chain.add PrometheusExporter::Instrumentation::Sidekiq
-    end
-    config.on :startup do
-      require 'prometheus_exporter/instrumentation'
-      PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
-    end
-    config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
-    at_exit do
-      PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
-    end
-  end
+if $0.include?('sidekiq')
+  Sidekiq.configure_server(&sidekiq_config)
+end
 
+if Rails.env != 'test'
+  Sidekiq.configure_client(&sidekiq_config)
   Sidekiq.default_worker_options = { 'backtrace' => true, 'retry' => 3, 'unique' => true }
 end


### PR DESCRIPTION
Currently sidekiq is not configured correctly for running in a `rails` process.
This causes issues when trying to create a job from the backend, since it will try to connect to the default `127.0.0.1` address. 

Since the two blocks were identical it's now one in a lambda.