### PR TITLE
RHICOMPL-502 - Tailoring mutation

### DIFF
--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -14,25 +14,17 @@ module Mutations
       argument :description, String, required: false
       argument :business_objective_id, String, required: false
       argument :compliance_threshold, Float, required: false
+      argument :selected_rules, [String], required: true
       field :profile, Types::Profile, null: false
 
       def resolve(args = {})
-        original_profile = find_original_profile(args[:clone_from_profile_id])
         profile = ::Profile.new(new_profile_options(args))
         profile.save!
-        profile.add_rules_from(profile: original_profile)
+        profile.add_rules(args[:selected_rules])
         { profile: profile }
       end
 
       private
-
-      def find_original_profile(profile_id)
-        ::Pundit.authorize(
-          context[:current_user],
-          ::Profile.find(profile_id),
-          :show?
-        )
-      end
 
       def new_profile_options(args)
         {

--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -14,13 +14,13 @@ module Mutations
       argument :description, String, required: false
       argument :business_objective_id, String, required: false
       argument :compliance_threshold, Float, required: false
-      argument :selected_rules, [String], required: true
+      argument :selected_rule_ref_ids, [String], required: true
       field :profile, Types::Profile, null: false
 
       def resolve(args = {})
         profile = ::Profile.new(new_profile_options(args))
         profile.save!
-        profile.add_rules(args[:selected_rules])
+        profile.add_rule_ref_ids(args[:selected_rule_ref_ids])
         { profile: profile }
       end
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -672,7 +672,7 @@ input createProfileInput {
   description: String
   name: String!
   refId: ID!
-  selectedRules: [String!]!
+  selectedRuleRefIds: [String!]!
 }
 
 """

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -672,6 +672,7 @@ input createProfileInput {
   description: String
   name: String!
   refId: ID!
+  selectedRules: [String!]!
 }
 
 """

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -110,7 +110,7 @@ class Profile < ApplicationRecord
     else
       new_profile.hosts << host unless new_profile.hosts.include?(host)
     end
-    new_profile.add_rules_from(profile: self)
+    new_profile.add_rules(rules.map(&:ref_id))
     new_profile
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -119,12 +119,10 @@ class Profile < ApplicationRecord
                     benchmark_id: benchmark_id)
   end
 
-  def add_rules_from(profile: nil)
-    new_profile_rules = profile.profile_rules - profile_rules
-    ProfileRule.import!(new_profile_rules.map do |profile_rule|
-      new_profile_rule = profile_rule.dup
-      new_profile_rule.profile = self
-      new_profile_rule
+  def add_rules(ref_ids)
+    rules = benchmark.rules.where(ref_id: ref_ids)
+    ProfileRule.import!(rules.map do |rule|
+      ProfileRule.new(profile_id: id, rule_id: rule.id)
     end, ignore: true)
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -110,7 +110,7 @@ class Profile < ApplicationRecord
     else
       new_profile.hosts << host unless new_profile.hosts.include?(host)
     end
-    new_profile.add_rules(rules.map(&:ref_id))
+    new_profile.add_rule_ref_ids(rules.pluck(&:ref_id))
     new_profile
   end
 
@@ -119,7 +119,7 @@ class Profile < ApplicationRecord
                     benchmark_id: benchmark_id)
   end
 
-  def add_rules(ref_ids)
+  def add_rule_ref_ids(ref_ids)
     rules = benchmark.rules.where(ref_id: ref_ids)
     ProfileRule.import!(rules.map do |rule|
       ProfileRule.new(profile_id: id, rule_id: rule.id)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -110,7 +110,7 @@ class Profile < ApplicationRecord
     else
       new_profile.hosts << host unless new_profile.hosts.include?(host)
     end
-    new_profile.add_rule_ref_ids(rules.pluck(&:ref_id))
+    new_profile.add_rule_ref_ids(rules.pluck(:ref_id))
     new_profile
   end
 

--- a/test/graphql/mutations/create_profile_mutation_test.rb
+++ b/test/graphql/mutations/create_profile_mutation_test.rb
@@ -3,8 +3,8 @@
 require 'test_helper'
 
 class CreateProfileMutationTest < ActiveSupport::TestCase
-  test 'provide all required arguments' do
-    query = <<-GRAPHQL
+  setup do
+    @query = <<-GRAPHQL
        mutation createProfile($input: createProfileInput!) {
           createProfile(input: $input) {
              profile {
@@ -14,26 +14,53 @@ class CreateProfileMutationTest < ActiveSupport::TestCase
        }
     GRAPHQL
 
-    original_profile = profiles(:one)
-    original_profile.update account: accounts(:test)
+    @original_profile = profiles(:one)
+    @original_profile.update account: accounts(:test)
     users(:test).update account: accounts(:test)
+  end
 
+  test 'provide all required arguments' do
     result = Schema.execute(
-      query,
+      @query,
       variables: { input: {
-        benchmarkId: original_profile.benchmark_id,
-        cloneFromProfileId: original_profile.id,
+        benchmarkId: @original_profile.benchmark_id,
+        cloneFromProfileId: @original_profile.id,
         refId: 'xccdf-customized',
         name: 'customized profile',
         description: 'abcdf',
-        complianceThreshold: 90.0
+        complianceThreshold: 90.0,
+        selectedRules: @original_profile.rules.map(&:ref_id)
       } },
       context: { current_user: users(:test) }
     )['data']['createProfile']['profile']
 
     cloned_profile = ::Profile.find(result['id'])
     assert cloned_profile.ref_id, 'xccdf-customized'
-    assert_equal cloned_profile.rules, original_profile.rules
-    assert_equal cloned_profile.parent_profile, original_profile
+    assert_equal cloned_profile.rules, @original_profile.rules
+    assert_equal cloned_profile.parent_profile, @original_profile
+  end
+
+  test 'tailoring the list of rules via selectedRules' do
+    tailored_rules = [rules(:one).ref_id, rules(:two).ref_id]
+
+    result = Schema.execute(
+      @query,
+      variables: { input: {
+        benchmarkId: @original_profile.benchmark_id,
+        cloneFromProfileId: @original_profile.id,
+        refId: 'xccdf-customized',
+        name: 'customized profile',
+        description: 'abcdf',
+        complianceThreshold: 90.0,
+        selectedRules: tailored_rules
+      } },
+      context: { current_user: users(:test) }
+    )['data']['createProfile']['profile']
+
+    cloned_profile = ::Profile.find(result['id'])
+    assert cloned_profile.ref_id, 'xccdf-customized'
+    assert_not_equal cloned_profile.rules, @original_profile.rules
+    assert_equal cloned_profile.rules, Rule.where(ref_id: tailored_rules)
+    assert_equal cloned_profile.parent_profile, @original_profile
   end
 end

--- a/test/graphql/mutations/create_profile_mutation_test.rb
+++ b/test/graphql/mutations/create_profile_mutation_test.rb
@@ -29,7 +29,7 @@ class CreateProfileMutationTest < ActiveSupport::TestCase
         name: 'customized profile',
         description: 'abcdf',
         complianceThreshold: 90.0,
-        selectedRules: @original_profile.rules.map(&:ref_id)
+        selectedRuleRefIds: @original_profile.rules.map(&:ref_id)
       } },
       context: { current_user: users(:test) }
     )['data']['createProfile']['profile']
@@ -52,7 +52,7 @@ class CreateProfileMutationTest < ActiveSupport::TestCase
         name: 'customized profile',
         description: 'abcdf',
         complianceThreshold: 90.0,
-        selectedRules: tailored_rules
+        selectedRuleRefIds: tailored_rules
       } },
       context: { current_user: users(:test) }
     )['data']['createProfile']['profile']


### PR DESCRIPTION
Given a list of refIds, tailor the set of rules in the policy to it.

Enables https://github.com/RedHatInsights/compliance-frontend/pull/423