### PR TITLE
RHICOMPL-515 - Calculate score from test results

### DIFF
--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -73,7 +73,9 @@ module Types
     end
 
     def last_scanned(args = {})
-      latest_test_result = TestResult.latest(args[:profile_id], object.id)
+      latest_test_result = TestResult.latest.find_by(
+        profile_id: args[:profile_id], host_id: object.id
+      )
       latest_test_result&.end_time&.iso8601 || 'Never'
     end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -97,9 +97,9 @@ class Profile < ApplicationRecord
   end
 
   def score
-    return 1 if hosts.blank?
+    return 1 if test_results.latest.blank?
 
-    (hosts.count { |host| compliant?(host) }).to_f / hosts.count
+    (scores = test_results.latest.pluck(:score)).sum / scores.size
   end
 
   def clone_to(account: nil, host: nil)

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -79,7 +79,8 @@ class Rule < ApplicationRecord
   end
 
   def latest_result(host, profile)
-    test_result = TestResult.latest(profile.id, host.id)
+    test_result = TestResult.latest.find_by(profile_id: profile.id,
+                                            host_id: host.id)
     return nil if test_result.blank?
 
     test_result.rule_results.find_by(rule_id: id)

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -50,16 +50,19 @@ class ProfileTest < ActiveSupport::TestCase
     assert 0.5, profiles(:one).compliance_score(hosts(:one))
   end
 
-  test 'score with non-blank hosts' do
-    assert_equal 0.0, profiles(:one).score
+  test 'score with non-blank test results' do
+    test_results(:one).update!(profile: profiles(:one), host: hosts(:one),
+                               score: 0.5, end_time: DateTime.now)
+    test_results(:two).update!(profile: profiles(:one), host: hosts(:two),
+                               score: 0.2, end_time: DateTime.now)
+    assert_equal 0.35, profiles(:one).score
   end
 
   test 'score returns at least one decimal' do
-    test_results(:one).update(host: hosts(:one), profile: profiles(:one))
-    RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass',
-                      test_result: test_results(:one))
-    profiles(:one).update(hosts: profiles(:one).hosts + [hosts(:two)],
-                          account: accounts(:test))
+    test_results(:one).update!(profile: profiles(:one), host: hosts(:one),
+                               score: 1, end_time: DateTime.now)
+    test_results(:two).update!(profile: profiles(:one), host: hosts(:two),
+                               score: 0, end_time: DateTime.now)
     assert_equal 0.5, profiles(:one).score
   end
 

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -23,7 +23,8 @@ class RuleTest < ActiveSupport::TestCase
   test 'host one is compliant?' do
     rules(:one).profiles << profiles(:one)
     rule_results(:one).update(host: hosts(:one), rule: rules(:one))
-    test_result = TestResult.create(profile: profiles(:one), host: hosts(:one))
+    test_result = TestResult.create(profile: profiles(:one), host: hosts(:one),
+                                    end_time: DateTime.now)
     test_result.rule_results << rule_results(:one)
     assert rules(:one).compliant?(hosts(:one), profiles(:one))
   end


### PR DESCRIPTION
I noticed this issue while trying to create REST API examples. The score for a profile is a simple average across all hosts' latest test_result scores. This PR contains a scope for latest TestResults, `TestResult.latest`, which we need for almost every TestResult query.

Signed-off-by: Andrew Kofink <akofink@redhat.com>