### PR TITLE
Skip broken ProfileHost on db migration

### DIFF
--- a/db/migrate/20191126181009_seed_test_results.rb
+++ b/db/migrate/20191126181009_seed_test_results.rb
@@ -4,6 +4,10 @@ class SeedTestResults < ActiveRecord::Migration[5.2]
     ProfileHost.find_each do |profile_host|
       host = profile_host.host
       profile = profile_host.profile
+      if host.nil? || profile.nil?
+        profile_host.destroy
+        next
+      end
       puts(" - Migrating results for host #{host.name}"\
            " - profile #{profile.name}")
       rule_results_by_end_time = scan_results(host, profile)


### PR DESCRIPTION
There seem to exist some broken ProfileHost records from what we're seeing when trying to migrate the db on QA using a prod dump. This allows the migration to safely skip and remove any broken records. 