### PR TITLE
Associate parent profiles outside of own benchmark

### DIFF
--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -16,6 +16,9 @@ class DuplicateBenchmarkResolver
     private
 
     def migrate_benchmark(existing_bm, duplicate_bm)
+      logger.info(
+        "Duplicate benchmark found for #{existing_bm.id} - #{duplicate_bm.id}"
+      )
       migrate_rules(existing_bm, duplicate_bm)
       migrate_profiles(existing_bm, duplicate_bm)
       duplicate_bm.delete
@@ -37,13 +40,23 @@ class DuplicateBenchmarkResolver
     # we expect validations to fail due to nonunique rules/profiles
     # accept duplicate rules for now
     def migrate_rules(existing_bm, duplicate_bm)
+      logger.info(
+        "Migrating rules for #{existing_bm.id} - #{duplicate_bm.id}..."
+      )
       duplicate_bm.rules.update_all(benchmark_id: existing_bm.id)
     end
 
     # accept duplicate profiles for now
     def migrate_profiles(existing_bm, duplicate_bm)
+      logger.info(
+        "Migrating profiles for #{existing_bm.id} - #{duplicate_bm.ref_id}..."
+      )
       duplicate_bm.profiles.update_all(benchmark_id: existing_bm.id)
     end
     # rubocop:enable Rails/SkipsModelValidations
+
+    def logger
+      Rails.logger
+    end
   end
 end

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -21,7 +21,7 @@ class ParentProfileAssociator
         ref_id: profile.ref_id,
         benchmark_id: parent.benchmark.id
       ).count
-      return false unless duplicate_profiles > 1
+      return false unless duplicate_profiles >= 1
 
       profile.delete_all_test_results = true
       profile.destroy
@@ -51,7 +51,13 @@ class ParentProfileAssociator
       Profile.where(name: profile.name,
                     ref_id: profile.ref_id,
                     description: profile.description,
-                    account_id: nil)
+                    account_id: nil).or(
+                      Profile.where(
+                        name: profile.name,
+                        ref_id: profile.ref_id,
+                        account_id: nil
+                      )
+                    )
     end
 
     def find_most_recent_parent(parents)

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -6,7 +6,7 @@ class ParentProfileAssociator
     def run!
       Profile.transaction do
         Profile.where.not(account: nil).find_each do |profile|
-          next if profile_already_in_account(profile)
+          next if profile_already_in_account!(profile)
 
           parent = find_parent(profile)
           profile.update!(parent_profile: parent, benchmark: parent.benchmark)

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -6,8 +6,19 @@ class ParentProfileAssociator
     def run!
       Profile.transaction do
         Profile.where.not(account: nil).find_each do |profile|
-          profile.update!(parent_profile: find_parent(profile))
+          if profile.account.profiles.where(ref_id: profile.ref_id).count > 1
+            profile.delete_all_test_results = true
+            profile.destroy
+            next
+          end
+          parent = find_parent(profile)
+          profile.update!(parent_profile: parent, benchmark: parent.benchmark)
         end
+        empty_benchmarks = ::Xccdf::Benchmark.where.not(id: Profile.select(:benchmark_id).distinct)
+        empty_benchmarks.each do |empty_benchmark|
+          empty_benchmark.rules.delete_all
+        end
+        empty_benchmarks.destroy_all
       end
     end
 

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -14,18 +14,46 @@ class ParentProfileAssociator
     private
 
     def find_parent(profile)
-      parents = Profile.where(ref_id: profile.ref_id,
-                              benchmark_id: profile.benchmark_id,
-                              account_id: nil)
-      raise not_found(profile) unless parents.one?
+      logger.info("Finding parents for profile #{profile.id}")
+      parents = find_in_same_benchmark(profile)
+      parents = find_in_other_benchmarks(profile) if parents.blank?
 
-      parents.first
+      raise not_found(profile) unless parents.any?
+
+      parent = find_most_recent_parent(parents)
+      logger.info("Found parent #{parent.id} for profile #{profile.id}")
+      parent
+    end
+
+    def find_in_same_benchmark(profile)
+      Profile.where(ref_id: profile.ref_id,
+                    benchmark_id: profile.benchmark_id,
+                    account_id: nil)
+    end
+
+    # Profiles in the phony-benchmark will have to be assigned to
+    # a real benchmark if it can be found.
+    def find_in_other_benchmarks(profile)
+      Profile.where(name: profile.name,
+                    ref_id: profile.ref_id,
+                    account_id: nil)
+    end
+
+    def find_most_recent_parent(parents)
+      latest_benchmark = ::Xccdf::Benchmark.find_latest(
+        parents.map(&:benchmark)
+      )
+      parents.find { |p| p.benchmark == latest_benchmark }
     end
 
     def not_found(profile)
       ActiveRecord::RecordNotFound.new(
         "Failed to find parent for profile with ID #{profile.id}."
       )
+    end
+
+    def logger
+      Rails.logger
     end
   end
 end

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -21,7 +21,7 @@ class ParentProfileAssociator
         ref_id: profile.ref_id,
         benchmark_id: parent.benchmark.id
       ).count
-      return false unless duplicate_profiles >= 1
+      return false unless duplicate_profiles > 1
 
       profile.delete_all_test_results = true
       profile.destroy

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -28,7 +28,7 @@ class ParentProfileAssociator
       # as there's a profile already in the account with the right attributes.
       return false if (possible_duplicate_profiles.count == 1 &&
                        possible_duplicate_profiles.include?(profile)) ||
-                      possible_duplicate_profiles.count == 0
+                      possible_duplicate_profiles.count.zero?
 
       profile.delete_all_test_results = true
       profile.destroy

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -6,9 +6,9 @@ class ParentProfileAssociator
     def run!
       Profile.transaction do
         Profile.where.not(account: nil).find_each do |profile|
-          next if profile_already_in_account!(profile)
-
           parent = find_parent(profile)
+          next if profile_already_in_account!(profile, parent)
+
           profile.update!(parent_profile: parent, benchmark: parent.benchmark)
         end
       end
@@ -16,9 +16,10 @@ class ParentProfileAssociator
 
     private
 
-    def profile_already_in_account!(profile)
+    def profile_already_in_account!(profile, parent)
       duplicate_profiles = profile.account.profiles.where(
-        ref_id: profile.ref_id
+        ref_id: profile.ref_id,
+        benchmark_id: parent.benchmark.id
       ).count
       return false unless duplicate_profiles > 1
 
@@ -49,6 +50,7 @@ class ParentProfileAssociator
     def find_in_other_benchmarks(profile)
       Profile.where(name: profile.name,
                     ref_id: profile.ref_id,
+                    description: profile.description,
                     account_id: nil)
     end
 

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -48,16 +48,15 @@ class ParentProfileAssociator
     # Profiles in the phony-benchmark will have to be assigned to
     # a real benchmark if it can be found.
     def find_in_other_benchmarks(profile)
-      Profile.where(name: profile.name,
-                    ref_id: profile.ref_id,
-                    description: profile.description,
-                    account_id: nil).or(
-                      Profile.where(
-                        name: profile.name,
-                        ref_id: profile.ref_id,
-                        account_id: nil
-                      )
-                    )
+      parent_matching_description = Profile.where(
+        name: profile.name,
+        ref_id: profile.ref_id,
+        description: profile.description,
+        account_id: nil
+      )
+      return parent_matching_description if parent_matching_description.present?
+
+      Profile.where(name: profile.name, ref_id: profile.ref_id, account_id: nil)
     end
 
     def find_most_recent_parent(parents)

--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -21,7 +21,7 @@ class ParentProfileAssociator
         ref_id: profile.ref_id,
         benchmark_id: parent.benchmark.id
       ).count
-      return false unless duplicate_profiles > 1
+      return false unless duplicate_profiles >= 1
 
       profile.delete_all_test_results = true
       profile.destroy

--- a/db/migrate/20200327170640_remove_empty_benchmarks.rb
+++ b/db/migrate/20200327170640_remove_empty_benchmarks.rb
@@ -1,0 +1,23 @@
+class RemoveEmptyBenchmarks < ActiveRecord::Migration[5.2]
+  def change
+    ::Xccdf::Benchmark.transaction do
+      empty_benchmarks = ::Xccdf::Benchmark.where.not(
+        id: Profile.select(:benchmark_id).distinct
+      )
+      empty_benchmarks.each do |empty_benchmark|
+        RuleIdentifier.where(
+          rule_id: empty_benchmark.rules.select(:id)
+        ).delete_all
+        empty_rule_references_rules = RuleReferencesRule.where(
+          rule_id: empty_benchmark.rules.select(:id)
+        )
+        RuleReferences.where(
+          id: empty_rule_references_rules.select(:rule_reference_id)
+        ).delete_all
+        empty_rule_references_rules.delete_all
+        empty_benchmark.rules.delete_all
+      end
+      empty_benchmarks.destroy_all
+    end
+  end
+end

--- a/db/migrate/20200327170640_remove_empty_benchmarks.rb
+++ b/db/migrate/20200327170640_remove_empty_benchmarks.rb
@@ -1,5 +1,5 @@
 class RemoveEmptyBenchmarks < ActiveRecord::Migration[5.2]
-  def change
+  def up
     ::Xccdf::Benchmark.transaction do
       empty_benchmarks = ::Xccdf::Benchmark.where.not(
         id: Profile.select(:benchmark_id).distinct
@@ -19,5 +19,8 @@ class RemoveEmptyBenchmarks < ActiveRecord::Migration[5.2]
       end
       empty_benchmarks.destroy_all
     end
+  end
+
+  def down
   end
 end

--- a/db/migrate/20200327170640_remove_empty_benchmarks.rb
+++ b/db/migrate/20200327170640_remove_empty_benchmarks.rb
@@ -5,13 +5,13 @@ class RemoveEmptyBenchmarks < ActiveRecord::Migration[5.2]
         id: Profile.select(:benchmark_id).distinct
       )
       empty_benchmarks.each do |empty_benchmark|
-        RuleIdentifier.where(
+        ::RuleIdentifier.where(
           rule_id: empty_benchmark.rules.select(:id)
         ).delete_all
-        empty_rule_references_rules = RuleReferencesRule.where(
+        empty_rule_references_rules = ::RuleReferencesRule.where(
           rule_id: empty_benchmark.rules.select(:id)
         )
-        RuleReferences.where(
+        ::RuleReference.where(
           id: empty_rule_references_rules.select(:rule_reference_id)
         ).delete_all
         empty_rule_references_rules.delete_all


### PR DESCRIPTION
Some profiles cannot be associated to parents within its own benchmark,
such as profiles that come from the phony benchmark (which has no
canonical profiles).