### PR TITLE
Revert "RHICOMPL-363 - Make uniqueness constraint for profile account…

### DIFF
--- a/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
+++ b/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
@@ -1,5 +1,0 @@
-class AddUniqueConstraintToProfileByAccount < ActiveRecord::Migration[5.2]
-  def change
-    add_index(:profiles , %i[account_id ref_id benchmark_id], unique: true)
-  end
-end

--- a/test/services/xccdf_report_migration_test.rb
+++ b/test/services/xccdf_report_migration_test.rb
@@ -55,7 +55,7 @@ class XCCDFReportMigrationTest < ActiveSupport::TestCase
     conflict_profile = Profile.create!(
       account: accounts(:test),
       hosts: [hosts(:one)],
-      name: 'footitle2',
+      name: 'footitle',
       benchmark: benchmarks(:one),
       ref_id: "xccdf_org.ssgproject.content_profile_#{@profile.ref_id}"
     )


### PR DESCRIPTION
This migration needs to come after the benchmark index for uniqueness. If we constrain profiles before benchmarks, then we must migrate duplicate benchmarks _and_ duplicate profiles at the same time. Otherwise, we can migrate just duplicate benchmarks and accept duplicate profiles for the time being and fix the duplicate profiles in a later migration. This helps keep our migrations fast (PR coming with updates to benchmark uniqueness).

This reverts commit 5dda52598cc7163ce8d8920528c25c0cab48c0da.