### PR TITLE
Resolve only duplicate benchmarks, not rules and profiles

### DIFF
--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -18,12 +18,12 @@ class DuplicateBenchmarkResolver
     def migrate_benchmark(existing_bm, duplicate_bm)
       migrate_rules(existing_bm, duplicate_bm)
       migrate_profiles(existing_bm, duplicate_bm)
-      duplicate_bm.destroy! # profiles, rules
+      duplicate_bm.delete
     end
 
     def each_benchmark
-      Xccdf::Benchmark.transaction do
-        Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
+      Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
+        Xccdf::Benchmark.transaction do
           yield bm
         end
       end
@@ -33,39 +33,17 @@ class DuplicateBenchmarkResolver
       @benchmarks ||= {}
     end
 
+    # rubocop:disable Rails/SkipsModelValidations
+    # we expect validations to fail due to nonunique rules/profiles
+    # accept duplicate rules for now
     def migrate_rules(existing_bm, duplicate_bm)
-      duplicate_bm.rules.find_each do |rule|
-        if existing_bm.rules.pluck(:ref_id).include?(rule.ref_id)
-          migrate_rule(existing_bm.rules.find_by(ref_id: rule.ref_id), rule)
-        else
-          rule.update!(benchmark_id: existing_bm.id)
-        end
-      end
+      duplicate_bm.rules.update_all(benchmark_id: existing_bm.id)
     end
 
-    def migrate_rule(existing_rule, duplicate_rule)
-      duplicate_rule.rule_results.update(rule_id: existing_rule.id)
-      duplicate_rule
-        .destroy # profile_rules, rule_references_rules, rule_identifier
-    end
-
+    # accept duplicate profiles for now
     def migrate_profiles(existing_bm, duplicate_bm)
-      duplicate_bm.profiles.find_each do |profile|
-        if existing_bm.profiles.pluck(:ref_id, :account_id)
-                      .include?([profile.ref_id, profile.account_id])
-          migrate_profile(existing_bm.profiles.find_by(ref_id: profile.ref_id),
-                          profile)
-        else
-          profile.update!(benchmark_id: existing_bm.id)
-        end
-      end
+      duplicate_bm.profiles.update_all(benchmark_id: existing_bm.id)
     end
-
-    def migrate_profile(existing_profile, duplicate_profile)
-      duplicate_profile.profile_hosts.update(
-        profile_id: existing_profile.id
-      )
-      duplicate_profile.destroy # profile_rules, profile_hosts
-    end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/test/services/duplicate_benchmark_resolver_test.rb
+++ b/test/services/duplicate_benchmark_resolver_test.rb
@@ -41,8 +41,8 @@ class DuplicateBenchmarkResolverTest < ActiveSupport::TestCase
   test 'resolves identical benchmarks' do
     assert_difference(
       'Xccdf::Benchmark.count' => -1,
-      'Profile.count' => -2,
-      'Rule.count' => -2,
+      'Profile.count' => 0,
+      'Rule.count' => 0,
       'RuleResult.count' => 0,
       'TestResult.count' => 0,
       'RuleReference.count' => 0,


### PR DESCRIPTION
This migration was so slow because of the fan out to profiles and rules. A better strategy is to allow intermediate duplicates and only resolve duplicate benchmarks in order to add the DB constraint for benchmarks. Later migrations will add uniqueness constraints for rules and profiles - duplicates will be reconciled at that point. This should keep our migrations fast.

In the UI, duplicate profiles and rules may appear, but this might happen today without this PR. Again, we need to solve this in a future PR and migration.

Signed-off-by: Andrew Kofink <akofink@redhat.com>