### PR TITLE
Destroy phony benchmark before parent profile association

### DIFF
--- a/app/services/parent_profile_associator.rb
+++ b/app/services/parent_profile_associator.rb
@@ -17,7 +17,7 @@ class ParentProfileAssociator
       parents = Profile.where(ref_id: profile.ref_id,
                               benchmark_id: profile.benchmark_id,
                               account_id: nil)
-      raise not_found(profile) unless parents.one?
+      raise not_found(profile) unless parents.any?
 
       parents.first
     end

--- a/db/migrate/20200120203124_add_parent_profile_id_to_profiles.rb
+++ b/db/migrate/20200120203124_add_parent_profile_id_to_profiles.rb
@@ -6,6 +6,7 @@ class AddParentProfileIdToProfiles < ActiveRecord::Migration[5.2]
   def up
     add_reference :profiles, :parent_profile, type: :uuid, foreign_key: { to_table: :profiles }
 
+    Xccdf::Benchmark.find_by(ref_id: 'phony_ref_id')&.destroy
     ParentProfileAssociator.run!
   end
 end


### PR DESCRIPTION
We introduced the phony benchmark Sept 24, 2019. If any data is still associated to the phony benchmark in prod now, it is laughably old. Let's make our lives easier and just delete the phony benchmark for good.

Signed-off-by: Andrew Kofink <akofink@redhat.com>