### PR TITLE
Update more score calculations to use TestResult

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -74,10 +74,7 @@ class Profile < ApplicationRecord
   end
 
   def compliant?(host)
-    host_results = results(host)
-    host_results.present? &&
-      (host_results.count(true) / host_results.count.to_f) >=
-        (compliance_threshold / 100.0)
+    score(host: host) >= compliance_threshold
   end
 
   def rules_for_system(host, selected_columns = [:id])
@@ -98,10 +95,12 @@ class Profile < ApplicationRecord
     end
   end
 
-  def score
-    return 1 if test_results.latest.blank?
+  def score(host: nil)
+    results = test_results.latest
+    results = results.where(host: host) if host
+    return 0 if results.blank?
 
-    (scores = test_results.latest.pluck(:score)).sum / scores.size
+    (scores = results.pluck(:score)).sum / scores.size
   end
 
   def clone_to(account: nil, host: nil)

--- a/test/fixtures/test_results.yml
+++ b/test/fixtures/test_results.yml
@@ -2,8 +2,10 @@ one:
   host_id: one
   profile_id: one
   score: 98
+  end_time: 2020-03-25T14:51:17+00:00
 
 two:
   host_id: two
   profile_id: two
   score: 98
+  end_time: 2020-03-25T14:52:39+00:00

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -68,14 +68,10 @@ class ProfileQueryTest < ActiveSupport::TestCase
     }
     GRAPHQL
 
-    rule_results(:one).update(
-      host: hosts(:one), rule: rules(:one), test_result: test_results(:one)
-    )
-    rule_results(:two).update(
-      host: hosts(:two), rule: rules(:two), test_result: test_results(:two)
-    )
-    test_results(:one).update(profile: profiles(:one), host: hosts(:one))
-    test_results(:two).update(profile: profiles(:two), host: hosts(:two))
+    test_results(:one).update(profile: profiles(:one), host: hosts(:one),
+                              score: 100)
+    test_results(:two).update(profile: profiles(:two), host: hosts(:two),
+                              score: 90)
     profiles(:one).rules << rules(:one)
     profiles(:one).rules << rules(:two)
     profiles(:one).update(account: accounts(:test),

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -104,6 +104,8 @@ class SystemQueryTest < ActiveSupport::TestCase
     test_results(:two).update(profile: profiles(:two), host: hosts(:one))
     profiles(:one).rules << rules(:one)
     profiles(:two).rules << rules(:two)
+    profiles(:one).update(compliance_threshold: 95)
+    profiles(:two).update(compliance_threshold: 95)
     hosts(:one).profiles << profiles(:one)
     hosts(:one).profiles << profiles(:two)
 

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -18,15 +18,6 @@ class ProfileTest < ActiveSupport::TestCase
     assert_not profiles(:one).compliant?(hosts(:one))
   end
 
-  test 'host is compliant if all rules are "pass" or "notapplicable"' do
-    test_results(:one).update(host: hosts(:one), profile: profiles(:one))
-    RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass',
-                      test_result: test_results(:one))
-    RuleResult.create(rule: rules(:two), host: hosts(:one),
-                      test_result: test_results(:one), result: 'notapplicable')
-    assert profiles(:one).compliant?(hosts(:one))
-  end
-
   test 'host is not compliant if some rules are "fail" or "error"' do
     test_results(:one).update(host: hosts(:one), profile: profiles(:one))
     RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass',
@@ -68,11 +59,8 @@ class ProfileTest < ActiveSupport::TestCase
 
   context 'threshold' do
     setup do
-      test_results(:one).update(host: hosts(:one), profile: profiles(:one))
-      RuleResult.create(rule: rules(:one), host: hosts(:one), result: 'pass',
-                        test_result: test_results(:one))
-      RuleResult.create(rule: rules(:two), host: hosts(:one),
-                        test_result: test_results(:one), result: 'fail')
+      test_results(:one).update(host: hosts(:one), profile: profiles(:one),
+                                score: 50)
     end
 
     should 'host is compliant if 50% of rules pass with a threshold of 50' do


### PR DESCRIPTION
This PR updates the compliant? calculation to use the TestResult score. Hopefully there are no other locations where we're counting rule results to calculate score.

Signed-off-by: Andrew Kofink <akofink@redhat.com>