### PR TITLE
Add Pundit policy for TestResult

### DIFF
--- a/app/policies/test_result_policy.rb
+++ b/app/policies/test_result_policy.rb
@@ -3,20 +3,21 @@
 # Policies for accessing TestResults
 class TestResultPolicy < ApplicationPolicy
   def index?
-    Pundit.policy(user, record.profile)
+    Pundit.policy(user, record.profile) || Pundit.policy(user, record.host)
   end
 
   def show?
-    Pundit.policy(user, record.profile)
+    Pundit.policy(user, record.profile) || Pundit.policy(user, record.host)
   end
 
   # Only show TestResults belonging to profiles owned by the current user
   class Scope < ::ApplicationPolicy::Scope
     def resolve
-      available_profiles = HostPolicy::Scope.new(
-        user, ::Profile
-      ).resolve.pluck(:id)
-      scope.where(profile_id: available_profiles)
+      available_profiles = ProfilePolicy::Scope.new(user, ::Profile)
+      available_hosts = HostPolicy::Scope.new(user, ::Host)
+      scope.where(profile_id: available_profiles.resolve).or(
+        scope.where(host_id: available_hosts.resolve)
+      )
     end
   end
 end

--- a/app/policies/test_result_policy.rb
+++ b/app/policies/test_result_policy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Policies for accessing TestResults
+class TestResultPolicy < ApplicationPolicy
+  def index?
+    Pundit.policy(user, record.profile)
+  end
+
+  def show?
+    Pundit.policy(user, record.profile)
+  end
+
+  # Only show TestResults belonging to profiles owned by the current user
+  class Scope < ::ApplicationPolicy::Scope
+    def resolve
+      available_profiles = HostPolicy::Scope.new(user, ::Profile).resolve.pluck(:id)
+      scope.where(profile_id: available_profiles)
+    end
+  end
+end

--- a/app/policies/test_result_policy.rb
+++ b/app/policies/test_result_policy.rb
@@ -13,7 +13,9 @@ class TestResultPolicy < ApplicationPolicy
   # Only show TestResults belonging to profiles owned by the current user
   class Scope < ::ApplicationPolicy::Scope
     def resolve
-      available_profiles = HostPolicy::Scope.new(user, ::Profile).resolve.pluck(:id)
+      available_profiles = HostPolicy::Scope.new(
+        user, ::Profile
+      ).resolve.pluck(:id)
       scope.where(profile_id: available_profiles)
     end
   end

--- a/test/policies/test_result_policy_test.rb
+++ b/test/policies/test_result_policy_test.rb
@@ -3,19 +3,42 @@
 require 'test_helper'
 
 class TestResultPolicyTest < ActiveSupport::TestCase
-  test 'only rules within visible profiles are accessible' do
+  setup do
     assert Pundit.policy_scope(users(:test), TestResult), []
     users(:test).account = accounts(:test)
-    profiles(:one).account = accounts(:test)
     users(:test).save
+  end
+
+  test 'only test results within visible profiles are accessible' do
+    profiles(:one).account = accounts(:test)
     profiles(:one).save
     assert_includes Pundit.policy_scope(users(:test), Profile), profiles(:one)
-    test_results(:one).host = hosts(:one)
     test_results(:one).profile = profiles(:one)
     rule_results(:one).host = hosts(:one)
     rule_results(:one).rule = rules(:one)
     test_results(:one).rule_results = [rule_results(:one)]
-    test_results(:one).save
+    # Save without validations to force a TestResult with a profile
+    # but without a host
+    test_results(:one).save(validate: false)
+    assert_includes Pundit.policy_scope(users(:test), TestResult),
+                    test_results(:one)
+    assert Pundit.authorize(users(:test), test_results(:one), :index?)
+    assert Pundit.authorize(users(:test), test_results(:one), :show?)
+    assert_not_includes Pundit.policy_scope(users(:test), TestResult),
+                        test_results(:two)
+  end
+
+  test 'only test results within visible hosts are accessible' do
+    hosts(:one).account = accounts(:test)
+    hosts(:one).save
+    assert_includes Pundit.policy_scope(users(:test), Host), hosts(:one)
+    test_results(:one).host = hosts(:one)
+    rule_results(:one).host = hosts(:one)
+    rule_results(:one).rule = rules(:one)
+    test_results(:one).rule_results = [rule_results(:one)]
+    # Save without validations to force a TestResult with a host
+    # but without a profile
+    test_results(:one).save(validate: false)
     assert_includes Pundit.policy_scope(users(:test), TestResult),
                     test_results(:one)
     assert Pundit.authorize(users(:test), test_results(:one), :index?)

--- a/test/policies/test_result_policy_test.rb
+++ b/test/policies/test_result_policy_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestResultPolicyTest < ActiveSupport::TestCase
+  test 'only rules within visible profiles are accessible' do
+    assert Pundit.policy_scope(users(:test), TestResult), []
+    users(:test).account = accounts(:test)
+    profiles(:one).account = accounts(:test)
+    users(:test).save
+    profiles(:one).save
+    assert_includes Pundit.policy_scope(users(:test), Profile), profiles(:one)
+    test_results(:one).host = hosts(:one)
+    test_results(:one).profile = profiles(:one)
+    rule_results(:one).host = hosts(:one)
+    rule_results(:one).rule = rules(:one)
+    test_results(:one).rule_results = [rule_results(:one)]
+    test_results(:one).save
+    assert_includes Pundit.policy_scope(users(:test), TestResult),
+                    test_results(:one)
+    assert Pundit.authorize(users(:test), test_results(:one), :index?)
+    assert Pundit.authorize(users(:test), test_results(:one), :show?)
+    assert_not_includes Pundit.policy_scope(users(:test), TestResult),
+                        test_results(:two)
+  end
+end


### PR DESCRIPTION
This is meant to allow the `collection_field` TestResult GQL API
endpoint to return a set of filtered TestResults - without it, Pundit
will just return nil.