### PR TITLE
RHICOMPL-292 - Filter by hosts with test results

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -8,6 +8,8 @@ class Host < ApplicationRecord
                 only_explicit: true
   scoped_search on: :compliance_score, ext_method: 'filter_by_compliance_score',
                 only_explicit: true
+  scoped_search on: :has_test_results, ext_method: 'has_test_results',
+                only_explicit: true
   scoped_search relation: :profile_hosts, on: :profile_id
   has_many :rule_results, dependent: :delete_all
   has_many :rules, through: :rule_results, source: :rule
@@ -25,11 +27,7 @@ class Host < ApplicationRecord
         host.compliant.values.all?(ActiveModel::Type::Boolean.new.cast(value))
       end
       ids = ids.pluck(:id).map { |id| "'#{id}'" }
-      return { conditions: '1=0' } if ids.empty?
-
-      operator = operator == '<>' ? 'NOT' : ''
-
-      { conditions: "hosts.id #{operator} IN(#{ids.join(',')})" }
+      scoped_search_sql_conditions(ids, operator)
     end
 
     def filter_by_compliance_score(_filter, operator, score)
@@ -41,5 +39,21 @@ class Host < ApplicationRecord
 
       { conditions: "hosts.id IN(#{ids.join(',')})" }
     end
+
+    def has_test_results(_filter, operator, value)
+      ids = Host.select do |h|
+        h.test_results.present? == ActiveModel::Type::Boolean.new.cast(value)
+      end
+      ids = ids.pluck(:id).map { |id| "'#{id}'" }
+      scoped_search_sql_conditions(ids, operator)
+    end
+
+    def scoped_search_sql_conditions(ids, operator)
+      return { conditions: '1=0' } if ids.empty?
+      operator = operator == '<>' ? 'NOT' : ''
+      { conditions: "hosts.id #{operator} IN(#{ids.join(',')})" }
+    end
   end
+
+  private_class_method :scoped_search_sql_conditions
 end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -71,12 +71,6 @@ class HostTest < ActiveSupport::TestCase
       assert_includes Host.search_for('has_test_results = false'), hosts(:two)
       assert_not_includes(Host.search_for('has_test_results = false'),
                           hosts(:one))
-      assert_includes Host.search_for('has_test_results != true'), hosts(:two)
-      assert_not_includes(Host.search_for('has_test_results != true'),
-                          hosts(:one))
-      assert_includes Host.search_for('has_test_results != false'), hosts(:one)
-      assert_not_includes(Host.search_for('has_test_results != false'),
-                          hosts(:two))
     end
   end
 end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -61,5 +61,22 @@ class HostTest < ActiveSupport::TestCase
       assert_includes Host.search_for('compliant != true'), hosts(:one)
       assert_not_includes Host.search_for('compliant != false'), hosts(:one)
     end
+
+    should 'be able to filter by "has test results"' do
+      assert hosts(:one).test_results.present?
+      assert hosts(:two).test_results.empty?
+      assert_includes Host.search_for('has_test_results = true'), hosts(:one)
+      assert_not_includes(Host.search_for('has_test_results = true'),
+                          hosts(:two))
+      assert_includes Host.search_for('has_test_results = false'), hosts(:two)
+      assert_not_includes(Host.search_for('has_test_results = false'),
+                          hosts(:one))
+      assert_includes Host.search_for('has_test_results != true'), hosts(:two)
+      assert_not_includes(Host.search_for('has_test_results != true'),
+                          hosts(:one))
+      assert_includes Host.search_for('has_test_results != false'), hosts(:one)
+      assert_not_includes(Host.search_for('has_test_results != false'),
+                          hosts(:two))
+    end
   end
 end


### PR DESCRIPTION
This allows us to only display hosts with test results on certain pages, such as "Reports by system" or "Report details" - where we do not want systems that have no reports. 