### PR TITLE
Disable DB environment check locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - POSTGRESQL_TEST_DATABASE=compliance_test
       - POSTGRESQL_USER=postgres
       - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
     ports:
       - '3000:3000'
     volumes:


### PR DESCRIPTION
This is only useful when you import a prod DB dump and then try to drop the database. It hasn't always happened for me, so that may not be the complete reproducer steps.

The rake db:drop command runs this query to get the DB environment from the DB itself:

```
SELECT "ar_internal_metadata"."value" FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1  [["key", "environment"]]
```