### PR TITLE
Remove notapplicable from RuleResult::PASSED

### DIFF
--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -15,7 +15,7 @@ class RuleResult < ApplicationRecord
 
   SELECTED = %w[pass fail notapplicable error unknown].freeze
   FAIL = %w[fail error unknown notchecked].freeze
-  PASSED = %w[pass notapplicable].freeze
+  PASSED = %w[pass].freeze
 
   scope :passed, -> { where(result: PASSED) }
   scope :selected, -> { where(result: SELECTED) }


### PR DESCRIPTION
`notapplicable` happens, for example, when a system (i.e. RHEL7) is scanned with a mismatched benchmark (i.e. xccdf_org.ssgproject.content_benchmark_RHEL-6). We should not count these rule results as passed.

From the XCCDF spec:
![image](https://user-images.githubusercontent.com/761923/77814652-67a63e00-7089-11ea-86e1-5df2315b939f.png)