### PR TITLE
Allow pending migrations in devel

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  config.active_record.migration_error = false
 
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true


### PR DESCRIPTION
This has been really helpful while testing and debugging the database migrations locally.