### PR TITLE
Add unique profile DB constraint

### DIFF
--- a/app/services/duplicate_profile_resolver.rb
+++ b/app/services/duplicate_profile_resolver.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate Profile objects
+class DuplicateProfileResolver
+  class << self
+    def run!
+      @profiles = nil
+      duplicate_profiles.find_each do |profile|
+        if existing_profile(profile)
+          migrate_profile(existing_profile(profile), profile)
+        else
+          self.existing_profile = profile
+        end
+      end
+    end
+
+    private
+
+    def existing_profile(profile)
+      profiles[[profile.ref_id, profile.account_id, profile.benchmark_id]]
+    end
+
+    def existing_profile=(profile)
+      profiles[[profile.ref_id,
+                profile.account_id,
+                profile.benchmark_id]] = profile
+    end
+
+    def profiles
+      @profiles ||= {}
+    end
+
+    def migrate_profile(existing_p, duplicate_p)
+      migrate_profile_hosts(existing_p, duplicate_p)
+      migrate_test_results(existing_p, duplicate_p)
+      migrate_child_profiles(existing_p, duplicate_p)
+      duplicate_p.destroy # BusinessObjectives, ProfileRules
+    end
+
+    def duplicate_profiles
+      Profile.joins(
+        "JOIN (#{grouped_nonunique_profile_tuples.to_sql}) as p on "\
+        'profiles.ref_id = p.ref_id AND '\
+        'profiles.account_id is not distinct from p.account_id AND '\
+        'profiles.benchmark_id = p.benchmark_id'
+      )
+    end
+
+    def grouped_nonunique_profile_tuples
+      Profile.select(:ref_id, :account_id, :benchmark_id)
+             .group(:ref_id, :account_id, :benchmark_id)
+             .having('COUNT(id) > 1')
+    end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def migrate_profile_hosts(existing_p, duplicate_p)
+      duplicate_p.profile_hosts.where.not(host: existing_p.hosts)
+                 .update_all(profile_id: existing_p.id)
+    end
+
+    def migrate_test_results(existing_p, duplicate_p)
+      duplicate_p.test_results.update_all(profile_id: existing_p.id)
+    end
+
+    def migrate_child_profiles(existing_p, duplicate_p)
+      Profile.where(parent_profile: duplicate_p)
+             .update_all(parent_profile_id: existing_p.id)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/db/migrate/20200325185540_add_unique_index_to_profiles.rb
+++ b/db/migrate/20200325185540_add_unique_index_to_profiles.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToProfiles < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateProfileResolver.run!
+
+    add_index(:profiles, %i[ref_id account_id benchmark_id], unique: true)
+  end
+
+  def down
+    remove_index(:profiles, %i[ref_id account_id benchmark_id])
+  end
+end

--- a/test/services/duplicate_profile_resolver_test.rb
+++ b/test/services/duplicate_profile_resolver_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200325185540_add_unique_index_to_profiles'
+
+class DuplicateProfileResolverTest < ActiveSupport::TestCase
+  setup do
+    # rubocop:disable Lint/SuppressedException
+    begin
+      AddUniqueIndexToProfiles.new.down
+    rescue ArgumentError # if index doesn't exist
+    end
+    # rubocop:enable Lint/SuppressedException
+
+    assert_difference('Profile.count' => 1) do
+      (@dup_profile = profiles(:one).dup).save(validate: false)
+    end
+  end
+
+  test 'resolves identical profiles' do
+    assert_difference('Profile.count' => -1) do
+      DuplicateProfileResolver.run!
+    end
+  end
+
+  test 'resolves profile_hosts from a duplicate profile with the different '\
+       'hosts' do
+    assert_difference('ProfileHost.count' => 2) do
+      profiles(:one).hosts << hosts(:one)
+      @dup_profile.hosts << hosts(:two)
+    end
+
+    assert_difference('ProfileHost.count' => 0) do
+      DuplicateProfileResolver.run!
+    end
+  end
+
+  test 'resolves profile_hosts from a duplicate profile with the same hosts' do
+    assert_difference('ProfileHost.count' => 2) do
+      profiles(:one).hosts << hosts(:one)
+      @dup_profile.hosts << hosts(:one)
+    end
+
+    assert_difference('ProfileHost.count' => -1) do
+      DuplicateProfileResolver.run!
+    end
+  end
+
+  test 'resolves children profiles' do
+    profiles(:two).update!(parent_profile: @dup_profile)
+
+    assert_difference('Profile.count' => -1) do
+      DuplicateProfileResolver.run!
+    end
+
+    assert_equal Profile.find_by(ref_id: profiles(:one).ref_id),
+                 profiles(:two).reload.parent_profile
+  end
+end


### PR DESCRIPTION
Profiles should be constrained to be unique by the database. We must resolve duplicates before adding such an index. We must resolve associated `test_results`, `profile_hosts`, and child `profiles`. `profile_rules` are destroyed without checking equivalence, as they should match on the existing profile.

![image](https://user-images.githubusercontent.com/761923/79369764-7ad95a80-7f1f-11ea-9a5e-2607ff225cea.png)


Signed-off-by: Andrew Kofink <akofink@redhat.com>