### PR TITLE
Serialise score as float

### DIFF
--- a/app/models/concerns/profile_scoring.rb
+++ b/app/models/concerns/profile_scoring.rb
@@ -35,6 +35,6 @@ module ProfileScoring
     results = results.where(host: host) if host
     return 0 if results.blank?
 
-    (scores = results.pluck(:score)).sum / scores.size
+    ((scores = results.pluck(:score)).sum / scores.size).to_f
   end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -4,7 +4,7 @@
 class ProfileSerializer
   include FastJsonapi::ObjectSerializer
   set_type :profile
-  attributes :name, :ref_id, :description, :score, :parent_profile_id
+  attributes :name, :ref_id, :description, :parent_profile_id
   attribute :canonical, &:canonical?
   attribute :tailored, &:tailored?
   attribute :total_host_count do |profile|
@@ -12,5 +12,8 @@ class ProfileSerializer
   end
   attribute :compliant_host_count do |profile|
     profile.hosts.count { |host| profile.compliant?(host) }
+  end
+  attribute :score do |object|
+    object.score.to_f
   end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -4,7 +4,7 @@
 class ProfileSerializer
   include FastJsonapi::ObjectSerializer
   set_type :profile
-  attributes :name, :ref_id, :description, :parent_profile_id
+  attributes :name, :ref_id, :description, :score, :parent_profile_id
   attribute :canonical, &:canonical?
   attribute :tailored, &:tailored?
   attribute :total_host_count do |profile|
@@ -12,8 +12,5 @@ class ProfileSerializer
   end
   attribute :compliant_host_count do |profile|
     profile.hosts.count { |host| profile.compliant?(host) }
-  end
-  attribute :score do |object|
-    object.score.to_f
   end
 end


### PR DESCRIPTION
The score either gives a integer (0) or a string, but the score should be a float in the API.

Disabling `encode_big_decimal_as_string` does not work with the serializer used.