### PR TITLE
Sync compliance DB with inventory task

### DIFF
--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -2,9 +2,9 @@
 
 desc 'Remove systems in Compliance DB which are not in the inventory'
 task sync_with_inventory: [:environment] do
-  ::Account.all.find_each do |account|
+  ::Account.includes(:hosts).find_each do |account|
     puts "Starting to review account #{account.account_number}"
-    account.hosts.find_each do |host|
+    account.hosts.each do |host|
       begin
         host = ::HostInventoryAPI.new(
           host.id, account, ::Settings.host_inventory_url, account.b64_identity

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -2,21 +2,19 @@
 
 desc 'Remove systems in Compliance DB which are not in the inventory'
 task sync_with_inventory: [:environment] do
-  Account.all.find_each do |account|
+  ::Account.all.find_each do |account|
     puts "Starting to review account #{account.account_number}"
     account.hosts.find_each do |host|
       begin
-        host = HostInventoryAPI.new(
+        host = ::HostInventoryAPI.new(
           host.id, account, ::Settings.host_inventory_url, account.b64_identity
         ).inventory_host
       rescue ::InventoryHostNotFound
         print "Account #{account.account_number}: "\
           "System #{host.id} - #{host.name} not found in the inventory. "\
           'Removing it from DB...'
-        host.destroy!
+        ::DeleteHost.perform_async('id': host.id)
         puts 'REMOVED'
-      rescue ActiveRecord::RecordNotDestroyed => e
-        puts "Errors that prevented destruction: #{e.record.errors}"
       end
     end
     puts "Done reviewing account #{account.account_number}"

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+desc 'Remove systems in Compliance DB which are not in the inventory'
+task sync_with_inventory: [:environment] do
+  Account.all.find_each do |account|
+    puts "Starting to review account #{account.account_number}"
+    account.hosts.find_each do |host|
+      begin
+        host = HostInventoryAPI.new(
+          host.id, account, ::Settings.host_inventory_url, account.b64_identity
+        ).inventory_host
+      rescue ::InventoryHostNotFound
+        print "Account #{account.account_number}: "\
+          "System #{host.id} - #{host.name} not found in the inventory. "\
+          'Removing it from DB...'
+        host.destroy!
+        puts 'REMOVED'
+      rescue ActiveRecord::RecordNotDestroyed => e
+        puts "Errors that prevented destruction: #{e.record.errors}"
+      end
+    end
+    puts "Done reviewing account #{account.account_number}"
+  end
+end


### PR DESCRIPTION
This rake task simply sends requests to the inventory for every host,
and checks whether the host exists in the inventory. If it doesn't
exist, it deletes it from our DB.

I'm working on an improved version that fetches hosts in batches of 50, but this allows to get us off the hook now that there are some hosts like that, and in -beta envs, they show as hosts with no name in the Systems table.