### PR TITLE
RHICOMPL-568 - Re-import benchmark if rules count isn't correct

### DIFF
--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -12,8 +12,19 @@ module Xccdf
       end
 
       def benchmark_saved?
-        benchmark.persisted? &&
-          (benchmark.rules.count == @op_benchmark.rules.count)
+        benchmark.persisted?
+      end
+
+      def benchmark_profiles_saved?
+        benchmark.profiles.count == @op_benchmark.profiles.count
+      end
+
+      def benchmark_rules_saved?
+        benchmark.rules.count == @op_benchmark.rules.count
+      end
+
+      def benchmark_contents_equal_to_op?
+        benchmark_saved? && benchmark_rules_saved? && benchmark_profiles_saved?
       end
 
       def benchmark

--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -12,7 +12,7 @@ module Xccdf
       end
 
       def benchmark_saved?
-        benchmark.persisted?
+        benchmark.persisted? && benchmark.rules.count == @op_benchmark.rules.count
       end
 
       def benchmark

--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -12,7 +12,8 @@ module Xccdf
       end
 
       def benchmark_saved?
-        benchmark.persisted? && benchmark.rules.count == @op_benchmark.rules.count
+        benchmark.persisted? &&
+          (benchmark.rules.count == @op_benchmark.rules.count)
       end
 
       def benchmark

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -18,7 +18,7 @@ module Xccdf
       include ::Xccdf::TestResult
 
       def save_all_benchmark_info
-        return if benchmark_saved?
+        return if benchmark_contents_equal_to_op?
 
         save_benchmark
         save_profiles

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -7,7 +7,8 @@ module Xccdf
   # A class to test Xccdf::Benchmarks
   class BenchmarksTest < ActiveSupport::TestCase
     OP_BENCHMARK = OpenStruct.new(id: '1', version: 'v0.1.49',
-                                  title: 'one', description: 'first')
+                                  title: 'one', description: 'first',
+                                  rules: ['rule-mock1'])
 
     class Mock
       include Xccdf::Util
@@ -15,10 +16,16 @@ module Xccdf
       def initialize(op_benchmark)
         @op_benchmark = op_benchmark
       end
+
+      def rules
+        ['rule-mock']
+      end
     end
 
     test 'save_benchmark' do
       mock = Mock.new(OP_BENCHMARK)
+      ::Xccdf::Benchmark.any_instance.expects(:rules)
+                        .returns(['rule-mock1']).at_least_once
       assert_difference('Xccdf::Benchmark.count', 1) do
         mock.save_benchmark
       end
@@ -27,6 +34,8 @@ module Xccdf
 
     test 'does not try to save an existing benchmark' do
       mock = Mock.new(OP_BENCHMARK)
+      ::Xccdf::Benchmark.any_instance.expects(:rules)
+                        .returns(['rule-mock1']).at_least_once
       mock.save_benchmark
       assert mock.benchmark_saved?
 
@@ -35,6 +44,12 @@ module Xccdf
         mock.save_all_benchmark_info
       end
       assert mock.benchmark_saved?
+    end
+
+    test 'benchmark is not saved if rules count differ' do
+      mock = Mock.new(OP_BENCHMARK)
+      assert_not_equal mock.benchmark.rules.count, OP_BENCHMARK.rules.count
+      assert_not mock.benchmark_saved?
     end
   end
 end

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -60,8 +60,9 @@ module Xccdf
     test 'benchmark is not saved if profiles count differ' do
       mock = Mock.new(OP_BENCHMARK)
       ::Xccdf::Benchmark.any_instance.expects(:profiles)
-                        .returns(['profiles-mock1', 'mock2']).at_least_once
-      assert_not_equal mock.benchmark.profiles.count, OP_BENCHMARK.profiles.count
+                        .returns(%w[profiles-mock1 mock2]).at_least_once
+      assert_not_equal mock.benchmark.profiles.count,
+                       OP_BENCHMARK.profiles.count
       assert_not mock.benchmark_contents_equal_to_op?
     end
   end

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -8,6 +8,7 @@ module Xccdf
   class BenchmarksTest < ActiveSupport::TestCase
     OP_BENCHMARK = OpenStruct.new(id: '1', version: 'v0.1.49',
                                   title: 'one', description: 'first',
+                                  profiles: ['profile-mock1'],
                                   rules: ['rule-mock1'])
 
     class Mock
@@ -26,30 +27,42 @@ module Xccdf
       mock = Mock.new(OP_BENCHMARK)
       ::Xccdf::Benchmark.any_instance.expects(:rules)
                         .returns(['rule-mock1']).at_least_once
+      ::Xccdf::Benchmark.any_instance.expects(:profiles)
+                        .returns(['profile-mock1']).at_least_once
       assert_difference('Xccdf::Benchmark.count', 1) do
         mock.save_benchmark
       end
-      assert mock.benchmark_saved?
+      assert mock.benchmark_contents_equal_to_op?
     end
 
     test 'does not try to save an existing benchmark' do
       mock = Mock.new(OP_BENCHMARK)
       ::Xccdf::Benchmark.any_instance.expects(:rules)
                         .returns(['rule-mock1']).at_least_once
+      ::Xccdf::Benchmark.any_instance.expects(:profiles)
+                        .returns(['profile-mock1']).at_least_once
       mock.save_benchmark
-      assert mock.benchmark_saved?
+      assert mock.benchmark_contents_equal_to_op?
 
       mock.expects(:save_benchmark).never
       assert_no_difference('Xccdf::Benchmark.count') do
         mock.save_all_benchmark_info
       end
-      assert mock.benchmark_saved?
+      assert mock.benchmark_contents_equal_to_op?
     end
 
     test 'benchmark is not saved if rules count differ' do
       mock = Mock.new(OP_BENCHMARK)
       assert_not_equal mock.benchmark.rules.count, OP_BENCHMARK.rules.count
-      assert_not mock.benchmark_saved?
+      assert_not mock.benchmark_contents_equal_to_op?
+    end
+
+    test 'benchmark is not saved if profiles count differ' do
+      mock = Mock.new(OP_BENCHMARK)
+      ::Xccdf::Benchmark.any_instance.expects(:profiles)
+                        .returns(['profiles-mock1', 'mock2']).at_least_once
+      assert_not_equal mock.benchmark.profiles.count, OP_BENCHMARK.profiles.count
+      assert_not mock.benchmark_contents_equal_to_op?
     end
   end
 end


### PR DESCRIPTION
Basically, for whatever reason, some benchmarks (in the JIRA card, the benchmark 0.1.43) are missing a few rules, so when we tried to save results it wasn't able to do it. Normally, when we parse a report, we do 2 big steps:

1- Parse the benchmark UNLESS the benchmark is already found in our DB
2- Parse the results

In this bug, we jump straight to Parse the results, because compliance thought that the version of the benchmark '0.1.43' already contained everything that could be on those results, but turns out that's not the case. I think we should do smarter checking and check at least the number of rules, maybe other basic stuff, and import them if they are unavailable, or else step 2 fails. 

I'm not sure yet why our SSG 0.1.43 had 8 rules less than the SSG in the report. It looks like there were 13 revisions of that package in RHEL7, whereas the upstream wasn't   can you check the date your scap-security-guide package was updated? Maybe there are 8 rules in the package that are not in the upstream version, but I need to verify this. 