### PR TITLE
RHICOMPL-548 - Add benchmark to Profile GQL schema

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -140,6 +140,7 @@ A Profile registered in Insights Compliance
 """
 type Profile implements Node & RulesPreload {
   accountId: ID!
+  benchmark: Benchmark
   benchmarkId: ID!
   businessObjective: BusinessObjective
   businessObjectiveId: ID

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -29,6 +29,7 @@ module Types
                'Rule references to filter by', required: false
     end
     field :hosts, [::Types::System], null: true
+    field :benchmark, ::Types::Benchmark, null: true
     field :business_objective, ::Types::BusinessObjective, null: true
     field :business_objective_id, ID, null: true
     field :total_host_count, Int, null: false


### PR DESCRIPTION
Having this available allows us to query the benchmark SSG version and title in the frontend - which we want for a tooltip in the Policies tabel