### PR TITLE
Remove default benchmark from rules and profiles

### DIFF
--- a/db/migrate/20200414144209_remove_default_benchmarks_from_rules.rb
+++ b/db/migrate/20200414144209_remove_default_benchmarks_from_rules.rb
@@ -1,0 +1,16 @@
+class RemoveDefaultBenchmarksFromRules < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :rules, :benchmark_id, nil
+  end
+
+  def down
+    phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
+      ref_id: 'phony_ref_id',
+      version: '0.0.0',
+      title: 'phony title',
+      description: 'phony description'
+    )
+
+    change_column_default :rules, :benchmark_id, phony_benchmark.id
+  end
+end

--- a/db/migrate/20200414144221_remove_default_benchmarks_from_profiles.rb
+++ b/db/migrate/20200414144221_remove_default_benchmarks_from_profiles.rb
@@ -1,0 +1,16 @@
+class RemoveDefaultBenchmarksFromProfiles < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :profiles, :benchmark_id, nil
+  end
+
+  def down
+    phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
+      ref_id: 'phony_ref_id',
+      version: '0.0.0',
+      title: 'phony title',
+      description: 'phony description'
+    )
+
+    change_column_default :profiles, :benchmark_id, phony_benchmark.id
+  end
+end


### PR DESCRIPTION
We've removed the phony benchmark. These defaults no longer make sense.

```rb
[1] pry(main)> Profile.new
=> #<Profile:0x0000556473172c30
 id: nil,
 name: nil,
 ref_id: nil,
 created_at: nil,
 updated_at: nil,
 description: nil,
 account_id: nil,
 compliance_threshold: 100.0,
 business_objective_id: nil,
 benchmark_id: "ad500579-c3e3-4d7a-b057-eba6b362509e", # wtf? lol this benchmark does not exist
 parent_profile_id: nil,
 external: false>
```

Caution when running `rollback` - the phony benchmark will get recreated!

Signed-off-by: Andrew Kofink <akofink@redhat.com>