### PR TITLE
Profiles created during report parse are external

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -71,11 +71,12 @@ class Profile < ApplicationRecord
     business_objective.destroy if business_objective.profiles.empty?
   end
 
-  def clone_to(account: nil, host: nil)
+  def clone_to(account: nil, host: nil, external: true)
     new_profile = in_account(account)
     if new_profile.nil?
       (new_profile = dup).update!(account: account, hosts: [host],
-                                  parent_profile: self)
+                                  parent_profile: self,
+                                  external: external)
     else
       new_profile.hosts << host unless new_profile.hosts.include?(host)
     end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -158,6 +158,28 @@ class ProfileTest < ActiveSupport::TestCase
         assert_equal canonical, cloned_profile.parent_profile
       end
     end
+
+    should 'clone profiles as external by default' do
+      profiles(:one).update!(account: nil, hosts: [])
+      assert_difference('ProfileHost.count' => 1, 'Profile.count' => 1) do
+        cloned_profile = profiles(:one).clone_to(
+          account: accounts(:one), host: hosts(:one)
+        )
+        assert hosts(:one).profiles.include?(cloned_profile)
+        assert cloned_profile.external
+      end
+    end
+
+    should 'clone profiles as internal if specified' do
+      profiles(:one).update!(account: nil, hosts: [])
+      assert_difference('ProfileHost.count' => 1, 'Profile.count' => 1) do
+        cloned_profile = profiles(:one).clone_to(
+          account: accounts(:one), host: hosts(:one), external: false
+        )
+        assert hosts(:one).profiles.include?(cloned_profile)
+        assert_not cloned_profile.external
+      end
+    end
   end
 
   context 'profile tailoring' do


### PR DESCRIPTION
Requires https://github.com/RedHatInsights/compliance-backend/pull/389

Signed-off-by: Andrew Kofink <akofink@redhat.com>