### PR TITLE
Add benchmarks to GQL & external attributes

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -153,6 +153,7 @@ type Profile implements Node & RulesPreload {
   ): Boolean!
   compliantHostCount: Int!
   description: String
+  external: Boolean!
   globalId: ID!
   hosts: [System!]
   id: ID!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -140,6 +140,7 @@ A Profile registered in Insights Compliance
 """
 type Profile implements Node & RulesPreload {
   accountId: ID!
+  benchmark: Benchmark
   benchmarkId: ID!
   businessObjective: BusinessObjective
   businessObjectiveId: ID

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -29,6 +29,7 @@ module Types
                'Rule references to filter by', required: false
     end
     field :hosts, [::Types::System], null: true
+    field :benchmark, ::Types::Benchmark, null: true
     field :business_objective, ::Types::BusinessObjective, null: true
     field :business_objective_id, ID, null: true
     field :total_host_count, Int, null: false

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -33,6 +33,7 @@ module Types
     field :business_objective, ::Types::BusinessObjective, null: true
     field :business_objective_id, ID, null: true
     field :total_host_count, Int, null: false
+    field :external, Boolean, null: false
 
     field :score, Float, null: false do
       argument :system_id, String,

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -5,7 +5,7 @@ class Profile < ApplicationRecord
   include ProfileTailoring
   include ProfileScoring
 
-  scoped_search on: %i[id name ref_id account_id compliance_threshold]
+  scoped_search on: %i[id name ref_id account_id compliance_threshold external]
   scoped_search relation: :hosts, on: :id, rename: :system_ids
   scoped_search relation: :hosts, on: :name, rename: :system_names
   scoped_search on: :has_test_results, ext_method: 'test_results?',

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -71,11 +71,12 @@ class Profile < ApplicationRecord
     business_objective.destroy if business_objective.profiles.empty?
   end
 
-  def clone_to(account: nil, host: nil)
+  def clone_to(account: nil, host: nil, external: true)
     new_profile = in_account(account)
     if new_profile.nil?
       (new_profile = dup).update!(account: account, hosts: [host],
-                                  parent_profile: self)
+                                  parent_profile: self,
+                                  external: external)
     else
       new_profile.hosts << host unless new_profile.hosts.include?(host)
     end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -4,7 +4,7 @@
 class ProfileSerializer
   include FastJsonapi::ObjectSerializer
   set_type :profile
-  attributes :name, :ref_id, :description, :score, :parent_profile_id
+  attributes :name, :ref_id, :description, :score, :parent_profile_id, :external
   attribute :canonical, &:canonical?
   attribute :tailored, &:tailored?
   attribute :total_host_count do |profile|

--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -15,6 +15,18 @@ module Xccdf
         benchmark.persisted?
       end
 
+      def benchmark_profiles_saved?
+        benchmark.profiles.count == @op_benchmark.profiles.count
+      end
+
+      def benchmark_rules_saved?
+        benchmark.rules.count == @op_benchmark.rules.count
+      end
+
+      def benchmark_contents_equal_to_op?
+        benchmark_saved? && benchmark_rules_saved? && benchmark_profiles_saved?
+      end
+
       def benchmark
         @benchmark ||= ::Xccdf::Benchmark.from_openscap_parser(@op_benchmark)
       end

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -18,7 +18,7 @@ module Xccdf
       include ::Xccdf::TestResult
 
       def save_all_benchmark_info
-        return if benchmark_saved?
+        return if benchmark_contents_equal_to_op?
 
         save_benchmark
         save_profiles

--- a/db/migrate/20200414143250_add_external_to_profiles.rb
+++ b/db/migrate/20200414143250_add_external_to_profiles.rb
@@ -1,0 +1,6 @@
+class AddExternalToProfiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :profiles, :external, :boolean, default: false, null: false
+    add_index :profiles, :external
+  end
+end

--- a/db/migrate/20200414144209_remove_default_benchmarks_from_rules.rb
+++ b/db/migrate/20200414144209_remove_default_benchmarks_from_rules.rb
@@ -1,0 +1,16 @@
+class RemoveDefaultBenchmarksFromRules < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :rules, :benchmark_id, nil
+  end
+
+  def down
+    phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
+      ref_id: 'phony_ref_id',
+      version: '0.0.0',
+      title: 'phony title',
+      description: 'phony description'
+    )
+
+    change_column_default :rules, :benchmark_id, phony_benchmark.id
+  end
+end

--- a/db/migrate/20200414144221_remove_default_benchmarks_from_profiles.rb
+++ b/db/migrate/20200414144221_remove_default_benchmarks_from_profiles.rb
@@ -1,0 +1,16 @@
+class RemoveDefaultBenchmarksFromProfiles < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :profiles, :benchmark_id, nil
+  end
+
+  def down
+    phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
+      ref_id: 'phony_ref_id',
+      version: '0.0.0',
+      title: 'phony title',
+      description: 'phony description'
+    )
+
+    change_column_default :profiles, :benchmark_id, phony_benchmark.id
+  end
+end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -158,6 +158,28 @@ class ProfileTest < ActiveSupport::TestCase
         assert_equal canonical, cloned_profile.parent_profile
       end
     end
+
+    should 'clone profiles as external by default' do
+      profiles(:one).update!(account: nil, hosts: [])
+      assert_difference('ProfileHost.count' => 1, 'Profile.count' => 1) do
+        cloned_profile = profiles(:one).clone_to(
+          account: accounts(:one), host: hosts(:one)
+        )
+        assert hosts(:one).profiles.include?(cloned_profile)
+        assert cloned_profile.external
+      end
+    end
+
+    should 'clone profiles as internal if specified' do
+      profiles(:one).update!(account: nil, hosts: [])
+      assert_difference('ProfileHost.count' => 1, 'Profile.count' => 1) do
+        cloned_profile = profiles(:one).clone_to(
+          account: accounts(:one), host: hosts(:one), external: false
+        )
+        assert hosts(:one).profiles.include?(cloned_profile)
+        assert_not cloned_profile.external
+      end
+    end
   end
 
   context 'profile tailoring' do

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -7,7 +7,9 @@ module Xccdf
   # A class to test Xccdf::Benchmarks
   class BenchmarksTest < ActiveSupport::TestCase
     OP_BENCHMARK = OpenStruct.new(id: '1', version: 'v0.1.49',
-                                  title: 'one', description: 'first')
+                                  title: 'one', description: 'first',
+                                  profiles: ['profile-mock1'],
+                                  rules: ['rule-mock1'])
 
     class Mock
       include Xccdf::Util
@@ -15,26 +17,53 @@ module Xccdf
       def initialize(op_benchmark)
         @op_benchmark = op_benchmark
       end
+
+      def rules
+        ['rule-mock']
+      end
     end
 
     test 'save_benchmark' do
       mock = Mock.new(OP_BENCHMARK)
+      ::Xccdf::Benchmark.any_instance.expects(:rules)
+                        .returns(['rule-mock1']).at_least_once
+      ::Xccdf::Benchmark.any_instance.expects(:profiles)
+                        .returns(['profile-mock1']).at_least_once
       assert_difference('Xccdf::Benchmark.count', 1) do
         mock.save_benchmark
       end
-      assert mock.benchmark_saved?
+      assert mock.benchmark_contents_equal_to_op?
     end
 
     test 'does not try to save an existing benchmark' do
       mock = Mock.new(OP_BENCHMARK)
+      ::Xccdf::Benchmark.any_instance.expects(:rules)
+                        .returns(['rule-mock1']).at_least_once
+      ::Xccdf::Benchmark.any_instance.expects(:profiles)
+                        .returns(['profile-mock1']).at_least_once
       mock.save_benchmark
-      assert mock.benchmark_saved?
+      assert mock.benchmark_contents_equal_to_op?
 
       mock.expects(:save_benchmark).never
       assert_no_difference('Xccdf::Benchmark.count') do
         mock.save_all_benchmark_info
       end
-      assert mock.benchmark_saved?
+      assert mock.benchmark_contents_equal_to_op?
+    end
+
+    test 'benchmark is not saved if rules count differ' do
+      mock = Mock.new(OP_BENCHMARK)
+      assert_not_equal mock.benchmark.rules.count, OP_BENCHMARK.rules.count
+      assert_not mock.benchmark_contents_equal_to_op?
+    end
+
+    test 'benchmark is not saved if profiles count differ' do
+      mock = Mock.new(OP_BENCHMARK)
+      ::Xccdf::Benchmark.any_instance.expects(:profiles)
+                        .returns(%w[profiles-mock1 mock2]).at_least_once
+      assert_not_equal mock.benchmark.profiles.count,
+                       OP_BENCHMARK.profiles.count
+      assert_not mock.benchmark_contents_equal_to_op?
     end
   end
 end


### PR DESCRIPTION
This PR introduces 'external' in QA and benchmark in the GQL API so we can do things like : https://github.com/RedHatInsights/compliance-frontend/pull/499