### PR TITLE
Add unique constraint on rules table

### DIFF
--- a/app/services/duplicate_rule_resolver.rb
+++ b/app/services/duplicate_rule_resolver.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate Rule objects
+class DuplicateRuleResolver
+  class << self
+    def run!
+      @rules = nil
+      duplicate_rules.find_each do |rule|
+        if existing_rule(rule)
+          migrate_rule(existing_rule(rule), rule)
+        else
+          self.existing_rule = rule
+        end
+      end
+    end
+
+    private
+
+    def existing_rule(rule)
+      rules[[rule.ref_id, rule.benchmark_id]]
+    end
+
+    def existing_rule=(rule)
+      rules[[rule.ref_id, rule.benchmark_id]] = rule
+    end
+
+    def rules
+      @rules ||= {}
+    end
+
+    def migrate_rule(existing_r, duplicate_r)
+      migrate_profile_rules(existing_r, duplicate_r)
+      migrate_rule_results(existing_r, duplicate_r)
+      duplicate_r.destroy # RuleResults, RuleReferenceRules, RuleIdentifier
+    end
+
+    def duplicate_rules
+      Rule.joins(
+        "JOIN (#{grouped_nonunique_rule_tuples.to_sql}) as r on "\
+        'rules.ref_id = r.ref_id AND '\
+        'rules.benchmark_id = r.benchmark_id'
+      )
+    end
+
+    def grouped_nonunique_rule_tuples
+      Rule.select(:ref_id, :benchmark_id)
+          .group(:ref_id, :benchmark_id)
+          .having('COUNT(id) > 1')
+    end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def migrate_profile_rules(existing_r, duplicate_r)
+      duplicate_r.profile_rules.where.not(profile: existing_r.profiles)
+                 .update_all(rule_id: existing_r.id)
+    end
+
+    def migrate_rule_results(existing_r, duplicate_r)
+      duplicate_r.rule_results.update_all(rule_id: existing_r.id)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/db/migrate/20200415201445_add_unique_index_to_rules.rb
+++ b/db/migrate/20200415201445_add_unique_index_to_rules.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToRules < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateRuleResolver.run!
+
+    add_index(:rules, %i[ref_id benchmark_id], unique: true)
+  end
+
+  def down
+    remove_index(:rules, %i[ref_id benchmark_id])
+  end
+end

--- a/test/services/duplicate_rule_resolver_test.rb
+++ b/test/services/duplicate_rule_resolver_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200415201445_add_unique_index_to_rules.rb'
+
+class DuplicateRuleResolverTest < ActiveSupport::TestCase
+  setup do
+    # rubocop:disable Lint/SuppressedException
+    begin
+      AddUniqueIndexToRules.new.down
+    rescue ArgumentError # if index doesn't exist
+    end
+    # rubocop:enable Lint/SuppressedException
+
+    assert_difference('Rule.count' => 1) do
+      (@dup_rule = rules(:one).dup).save(validate: false)
+    end
+  end
+
+  test 'resolves identical rules' do
+    assert_difference('Rule.count' => -1) do
+      DuplicateRuleResolver.run!
+    end
+  end
+
+  test 'resolves profile_rules from a duplicate rule with '\
+       'different profiles' do
+    assert_difference('ProfileRule.count' => 2) do
+      rules(:one).profiles << profiles(:one)
+      @dup_rule.profiles << profiles(:two)
+    end
+
+    assert_difference('ProfileRule.count' => 0) do
+      DuplicateRuleResolver.run!
+    end
+  end
+
+  test 'resolves profile_rules from a duplicate rule with '\
+       'the same profiles' do
+    assert_difference('ProfileRule.count' => 2) do
+      rules(:one).profiles << profiles(:two)
+      @dup_rule.profiles << profiles(:two)
+    end
+
+    assert_difference('ProfileRule.count' => -1) do
+      DuplicateRuleResolver.run!
+    end
+  end
+
+  test 'resolves rule_results from a duplicate rule' do
+    assert_difference('RuleResult.count' => 2) do
+      (rr = rule_results(:one).dup).save(validate: false)
+      (rr2 = rule_results(:one).dup).save(validate: false)
+      rules(:one).rule_results << rr
+      @dup_rule.rule_results << rr2
+    end
+
+    assert_difference('RuleResult.count' => 0) do
+      DuplicateRuleResolver.run!
+    end
+  end
+end


### PR DESCRIPTION
Rules should be constrained to be unique by the database. We must resolve duplicates before adding such an index. We must migrate associated `profile_rules` if any additoinal exist on the duplicate rule, and we must migrate associated `rule_results`.

Signed-off-by: Andrew Kofink <akofink@redhat.com>