### PR TITLE
Resolve only duplicate benchmarks.

### DIFF
--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -4,54 +4,89 @@
 class DuplicateBenchmarkResolver
   class << self
     def run!
-      each_benchmark do |bm|
-        if benchmarks[[bm.ref_id, bm.version]]
-          migrate_benchmark(benchmarks[[bm.ref_id, bm.version]], bm)
+      @benchmarks = nil
+      duplicate_benchmarks.find_each do |bm|
+        if existing_benchmark(bm)
+          migrate_benchmark(existing_benchmark(bm), bm)
         else
-          benchmarks[[bm.ref_id, bm.version]] = bm
+          self.existing_benchmark = bm
         end
       end
     end
 
     private
 
-    def migrate_benchmark(existing_bm, duplicate_bm)
-      logger.info(
-        "Duplicate benchmark found for #{existing_bm.id} - #{duplicate_bm.id}"
-      )
-      migrate_rules(existing_bm, duplicate_bm)
-      migrate_profiles(existing_bm, duplicate_bm)
-      duplicate_bm.delete
+    def existing_benchmark(benchmark)
+      benchmarks[[benchmark.ref_id, benchmark.version]]
     end
 
-    def each_benchmark
-      Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
-        Xccdf::Benchmark.transaction do
-          yield bm
-        end
-      end
+    def existing_benchmark=(benchmark)
+      benchmarks[[benchmark.ref_id, benchmark.version]] = benchmark
     end
 
     def benchmarks
       @benchmarks ||= {}
     end
 
+    def duplicate_benchmarks
+      Xccdf::Benchmark.joins(
+        "JOIN (#{grouped_nonunique_benchmark_tuples.to_sql}) as bm on "\
+        'benchmarks.ref_id = bm.ref_id AND '\
+        'benchmarks.version = bm.version'
+      )
+    end
+
+    def grouped_nonunique_benchmark_tuples
+      Xccdf::Benchmark.select(:ref_id, :version)
+                      .group(:ref_id, :version)
+                      .having('COUNT(id) > 1')
+    end
+
+    def migrate_benchmark(existing_bm, duplicate_bm)
+      logger.info(
+        "Duplicate benchmark found for #{existing_bm.id} - #{duplicate_bm.id}"
+      )
+      migrate_rules(existing_bm, duplicate_bm)
+      migrate_parent_profiles(existing_bm, duplicate_bm)
+      migrate_profiles(existing_bm, duplicate_bm)
+      remove_remaining_parent_profiles(duplicate_bm)
+      duplicate_bm.destroy # Rules, Profiles
+    end
+
     # rubocop:disable Rails/SkipsModelValidations
-    # we expect validations to fail due to nonunique rules/profiles
-    # accept duplicate rules for now
     def migrate_rules(existing_bm, duplicate_bm)
       logger.info(
         "Migrating rules for #{existing_bm.id} - #{duplicate_bm.id}..."
       )
-      duplicate_bm.rules.update_all(benchmark_id: existing_bm.id)
+      duplicate_bm.rules.where.not(ref_id: existing_bm.rules.select(:ref_id))
+                  .update_all(benchmark_id: existing_bm.id)
     end
 
-    # accept duplicate profiles for now
+    def migrate_parent_profiles(existing_bm, duplicate_bm)
+      duplicate_bm.profiles.where.not(
+        ref_id: existing_bm.profiles.select(:ref_id),
+        parent_profile_id: nil
+      ).find_each do |profile|
+        profile.update!(
+          parent_profile: existing_bm.profiles.canonical.find_by!(
+            ref_id: profile.parent_profile.ref_id
+          )
+        )
+      end
+    end
+
+    def remove_remaining_parent_profiles(duplicate_bm)
+      duplicate_bm.profiles.where.not(parent_profile_id: nil)
+                  .update_all(parent_profile_id: nil)
+    end
+
     def migrate_profiles(existing_bm, duplicate_bm)
       logger.info(
         "Migrating profiles for #{existing_bm.id} - #{duplicate_bm.ref_id}..."
       )
-      duplicate_bm.profiles.update_all(benchmark_id: existing_bm.id)
+      duplicate_bm.profiles.where.not(
+        ref_id: existing_bm.profiles.select(:ref_id)
+      ).update_all(benchmark_id: existing_bm.id)
     end
     # rubocop:enable Rails/SkipsModelValidations
 


### PR DESCRIPTION
The test updates give a much higher level of confidence that we're doing
what we want to do with this resolver.

I've also updated the migration for adding a uniqueness constraint so
that it runs just before the profiles and rules uniqueness migrations

Signed-off-by: Andrew Kofink <akofink@redhat.com>