### PR TITLE
Determine policy from a profile

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -61,6 +61,26 @@ class Profile < ApplicationRecord
     parent_profile_id.blank?
   end
 
+  def policy
+    return self unless external
+
+    Profile.includes(:benchmark)
+           .find_by(account: account_id, external: false, ref_id: ref_id,
+                    benchmarks: { ref_id: benchmark.ref_id })
+  end
+
+  def business_objective
+    BusinessObjective.find(business_objective_id) if business_objective_id
+  end
+
+  def business_objective_id
+    (policy || self).read_attribute(:business_objective_id)
+  end
+
+  def compliance_threshold
+    (policy || self).read_attribute(:compliance_threshold)
+  end
+
   def destroy_orphaned_business_objective
     return unless previous_changes.include?(:business_objective_id) &&
                   previous_changes[:business_objective_id].first.present?

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -83,6 +83,28 @@ class ProfileTest < ActiveSupport::TestCase
     assert_empty BusinessObjective.where(title: 'abcd')
   end
 
+  test 'business_objective comes from policy for external profiles' do
+    (bm = benchmarks(:one).dup).update!(version: '0.1.47')
+    bo = BusinessObjective.create!(title: 'bo')
+    bo2 = BusinessObjective.create!(title: 'bo2')
+    (external_profile = profiles(:one).dup).update!(benchmark: bm,
+                                                    business_objective: bo,
+                                                    external: true)
+    profiles(:one).update!(business_objective: bo2)
+    assert_equal external_profile.policy, profiles(:one)
+    assert_equal bo2, external_profile.business_objective
+  end
+
+  test 'compliance_threshold comes from policy for external profiles' do
+    (bm = benchmarks(:one).dup).update!(version: '0.1.47')
+    (external_profile = profiles(:one).dup).update!(benchmark: bm,
+                                                    compliance_threshold: 100,
+                                                    external: true)
+    profiles(:one).update!(compliance_threshold: 30)
+    assert_equal external_profile.policy, profiles(:one)
+    assert_equal 30, external_profile.compliance_threshold
+  end
+
   test 'canonical profiles have no parent_profile_id' do
     assert Profile.new.canonical?, 'nil parent_profile_id should be canonical'
   end


### PR DESCRIPTION
External profiles can be associated to policies (an internal profile associated to a user account). We should get the business objective and compliance threshold from the internal policy that the user defined.

Signed-off-by: Andrew Kofink <akofink@redhat.com>