### PR TITLE
Remove cache expiration date

### DIFF
--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -63,8 +63,7 @@ module Types
     end
 
     def rule_objects_failed
-      ::Rails.cache.fetch("#{object.id}/failed_rule_objects_result",
-                          expires_in: 1.week) do
+      ::Rails.cache.fetch("#{object.id}/failed_rule_objects_result") do
         ::Rule.where(
           id: ::RuleResult.failed.for_system(object.id)
               .includes(:rule).pluck(:rule_id).uniq

--- a/app/models/concerns/profile_scoring.rb
+++ b/app/models/concerns/profile_scoring.rb
@@ -19,7 +19,7 @@ module ProfileScoring
   # Disabling MethodLength because it measures things wrong
   # for a multi-line string SQL query.
   def results(host)
-    Rails.cache.fetch("#{id}/#{host.id}/results", expires_in: 1.week) do
+    Rails.cache.fetch("#{id}/#{host.id}/results") do
       rule_results = TestResult.where(profile: self, host: host)
                                .order('created_at DESC')&.first&.rule_results
       return [] if rule_results.blank?

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -68,7 +68,7 @@ class Rule < ApplicationRecord
   end
 
   def compliant?(host, profile)
-    Rails.cache.fetch("#{id}/#{host.id}/compliant", expires_in: 1.week) do
+    Rails.cache.fetch("#{id}/#{host.id}/compliant") do
       return false unless profile.present? && profile.rules.include?(self)
 
       latest_rule_result = latest_result(host, profile)


### PR DESCRIPTION
    These values are meant to be expired during report parsing, in the
    invalidate_cache method. No need to manually expire them in a week.