### PR TITLE
Migrate existing profiles during db migration

### DIFF
--- a/app/services/external_profile_updater.rb
+++ b/app/services/external_profile_updater.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# A service class to migrate profiles to be external before a certain date
+class ExternalProfileUpdater
+  class << self
+    # rubocop:disable Rails/SkipsModelValidations
+    def run!(date = DateTime.now)
+      Profile.where('created_at < ?', date)
+             .update_all(external: true,
+                         compliance_threshold: 100,
+                         business_objective_id: nil)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/db/migrate/20200414143250_add_external_to_profiles.rb
+++ b/db/migrate/20200414143250_add_external_to_profiles.rb
@@ -1,6 +1,12 @@
 class AddExternalToProfiles < ActiveRecord::Migration[5.2]
-  def change
+  def up
     add_column :profiles, :external, :boolean, default: false, null: false
     add_index :profiles, :external
+    ExternalProfileUpdater.run!(DateTime.parse('2020-04-13T10:44:00+00:00'))
+  end
+
+  def down
+    remove_index :profiles, :external
+    remove_column :profiles, :external
   end
 end

--- a/test/services/external_profile_updater_test.rb
+++ b/test/services/external_profile_updater_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ExternalProfileUpdaterTest < ActiveSupport::TestCase
+  test 'updates profiles before a certain date to be external with default '\
+       'threshold and business objective' do
+    expected_change = Profile.count
+    date = DateTime.now
+
+    assert_difference('Profile.where(external: false).count' => 1) do
+      profiles(:one).dup.update(ref_id: 'foo')
+    end
+
+    assert_difference('Profile.where(external: true).count' =>
+                      expected_change) do
+      ExternalProfileUpdater.run!(date)
+    end
+  end
+end


### PR DESCRIPTION
Any profiles created before we released policy creation changes to
prod-beta should be external. Others created after our release should
stay external=false in order to show in the SCAP policies UI.

Signed-off-by: Andrew Kofink <akofink@redhat.com>