### PR TITLE
Add policy to GQL profile type

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -185,6 +185,7 @@ type Profile implements Node & RulesPreload {
     """
     ids: [ID!]!
   ): [Node]!
+  policy: Profile
   refId: String!
   rules(
     """

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -20,6 +20,7 @@ module Types
     field :compliance_threshold, Float, null: false
     field :benchmark_id, ID, null: false
     field :account_id, ID, null: false
+    field :policy, Types::Profile, null: true
     field :rules, [::Types::Rule], null: true, extras: [:lookahead] do
       argument :system_id, String,
                'System ID to filter by', required: false


### PR DESCRIPTION
This field is meant to return the "Policy" for a profile, so if the
profile is external, this would be any policy in the same benchmark
ref_id, same ref_id, different benchmark version, if it exists, or null.