### PR TITLE
Find policy for profile

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -265,49 +265,9 @@ The root of all queries
 """
 type Query implements Node {
   """
-  All benchmarks visible by the user
-  """
-  allBenchmarks: [Benchmark!]
-
-  """
-  All image streams visible by the user
-  """
-  allImageStreams(
-    """
-    Search query
-    """
-    search: String
-  ): [System!]
-
-  """
   All profiles visible by the user
   """
   allProfiles: [Profile!]
-
-  """
-  All systems visible by the user
-  """
-  allSystems(
-    """
-    Per page
-    """
-    page: Int
-
-    """
-    Page
-    """
-    perPage: Int
-
-    """
-    Profile Id
-    """
-    profileId: String
-
-    """
-    Search query
-    """
-    search: String
-  ): [System!]
   benchmark(id: String!): Benchmark
 
   """

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -185,6 +185,7 @@ type Profile implements Node & RulesPreload {
     """
     ids: [ID!]!
   ): [Node]!
+  policy: Profile
   refId: String!
   rules(
     """

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -20,6 +20,7 @@ module Types
     field :compliance_threshold, Float, null: false
     field :benchmark_id, ID, null: false
     field :account_id, ID, null: false
+    field :policy, Types::Profile, null: true
     field :rules, [::Types::Rule], null: true, extras: [:lookahead] do
       argument :system_id, String,
                'System ID to filter by', required: false

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -14,30 +14,13 @@ module Types
     record_field :profile, Types::Profile
     record_field :test_result, Types::TestResult
 
-    field :all_systems, [Types::System], null: true do
-      description 'All systems visible by the user'
-      argument :search, String, 'Search query', required: false
-      argument :per_page, Int, 'Page', required: false
-      argument :page, Int, 'Per page', required: false
-      argument :profile_id, String, 'Profile Id', required: false
-    end
-
     field :system, Types::System, null: true do
       description 'Details for a system'
       argument :id, String, required: true
     end
 
-    field :all_image_streams, [Types::System], null: true do
-      description 'All image streams visible by the user'
-      argument :search, String, 'Search query', required: false
-    end
-
     field :all_profiles, [Types::Profile], null: true do
       description 'All profiles visible by the user'
-    end
-
-    field :all_benchmarks, [Types::Benchmark], null: true do
-      description 'All benchmarks visible by the user'
     end
 
     field :latest_benchmarks, [Types::Benchmark], null: true do
@@ -56,18 +39,8 @@ module Types
       description 'All business objectives visible by the user'
     end
 
-    def all_systems(args = {})
-      Pundit.policy_scope(context[:current_user], ::Host)
-            .search_for(args[:search])
-            .paginate(page: args[:page], per_page: args[:per_page])
-    end
-
     def system(id:)
       Pundit.authorize(context[:current_user], ::Host.find(id), :show?)
-    end
-
-    def all_image_streams
-      []
     end
 
     def all_profiles
@@ -84,10 +57,6 @@ module Types
 
     def business_objectives
       Pundit.policy_scope(context[:current_user], ::BusinessObjective)
-    end
-
-    def all_benchmarks
-      Pundit.policy_scope(context[:current_user], ::Xccdf::Benchmark)
     end
 
     def latest_benchmarks

--- a/app/graphql/types/rule.rb
+++ b/app/graphql/types/rule.rb
@@ -59,6 +59,12 @@ module Types
       end
     end
 
+    def profiles
+      ::CollectionLoader.for(::Rule, :profiles).load(object).then do |profiles|
+        profiles
+      end
+    end
+
     private
 
     def system_id(args)

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -63,8 +63,7 @@ module Types
     end
 
     def rule_objects_failed
-      ::Rails.cache.fetch("#{object.id}/failed_rule_objects_result",
-                          expires_in: 1.week) do
+      ::Rails.cache.fetch("#{object.id}/failed_rule_objects_result") do
         ::Rule.where(
           id: ::RuleResult.failed.for_system(object.id)
               .includes(:rule).pluck(:rule_id).uniq

--- a/app/jobs/destroy_profiles_job.rb
+++ b/app/jobs/destroy_profiles_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Job meant to destroy profiles and associated objects asynchronously
+class DestroyProfilesJob
+  include Sidekiq::Worker
+
+  def perform(ids)
+    Profile.where(id: ids).destroy_all
+  end
+end

--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Methods that are related to a profile's policy
+module ProfilePolicyAssociation
+  extend ActiveSupport::Concern
+
+  included do
+    after_destroy :destroy_policy_test_results
+
+    def policy
+      return self unless external
+
+      Profile.includes(:benchmark)
+             .find_by(account: account_id, external: false, ref_id: ref_id,
+                      benchmarks: { ref_id: benchmark.ref_id })
+    end
+
+    def policy_profiles
+      Profile.includes(:benchmark)
+             .where(account: account_id, ref_id: ref_id,
+                    benchmarks: { ref_id: benchmark.ref_id })
+    end
+
+    def business_objective
+      BusinessObjective.find(business_objective_id) if business_objective_id
+    end
+
+    def business_objective_id
+      (policy || self).read_attribute(:business_objective_id)
+    end
+
+    def compliance_threshold
+      (policy || self).read_attribute(:compliance_threshold)
+    end
+
+    def destroy_policy_test_results
+      DestroyProfilesJob.perform_async(policy_profiles.pluck(:id))
+    end
+  end
+end

--- a/app/models/concerns/profile_scoring.rb
+++ b/app/models/concerns/profile_scoring.rb
@@ -19,7 +19,7 @@ module ProfileScoring
   # Disabling MethodLength because it measures things wrong
   # for a multi-line string SQL query.
   def results(host)
-    Rails.cache.fetch("#{id}/#{host.id}/results", expires_in: 1.week) do
+    Rails.cache.fetch("#{id}/#{host.id}/results") do
       rule_results = TestResult.where(profile: self, host: host)
                                .order('created_at DESC')&.first&.rule_results
       return [] if rule_results.blank?

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,6 +4,7 @@
 class Profile < ApplicationRecord
   include ProfileTailoring
   include ProfileScoring
+  include ProfilePolicyAssociation
 
   scoped_search on: %i[id name ref_id account_id compliance_threshold external]
   scoped_search relation: :hosts, on: :id, rename: :system_ids
@@ -59,26 +60,6 @@ class Profile < ApplicationRecord
 
   def canonical?
     parent_profile_id.blank?
-  end
-
-  def policy
-    return self unless external
-
-    Profile.includes(:benchmark)
-           .find_by(account: account_id, external: false, ref_id: ref_id,
-                    benchmarks: { ref_id: benchmark.ref_id })
-  end
-
-  def business_objective
-    BusinessObjective.find(business_objective_id) if business_objective_id
-  end
-
-  def business_objective_id
-    (policy || self).read_attribute(:business_objective_id)
-  end
-
-  def compliance_threshold
-    (policy || self).read_attribute(:compliance_threshold)
   end
 
   def destroy_orphaned_business_objective

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -61,6 +61,26 @@ class Profile < ApplicationRecord
     parent_profile_id.blank?
   end
 
+  def policy
+    return self unless external
+
+    Profile.includes(:benchmark)
+           .find_by(account: account_id, external: false, ref_id: ref_id,
+                    benchmarks: { ref_id: benchmark.ref_id })
+  end
+
+  def business_objective
+    BusinessObjective.find(business_objective_id) if business_objective_id
+  end
+
+  def business_objective_id
+    (policy || self).read_attribute(:business_objective_id)
+  end
+
+  def compliance_threshold
+    (policy || self).read_attribute(:compliance_threshold)
+  end
+
   def destroy_orphaned_business_objective
     return unless previous_changes.include?(:business_objective_id) &&
                   previous_changes[:business_objective_id].first.present?

--- a/app/models/profile_host.rb
+++ b/app/models/profile_host.rb
@@ -8,10 +8,4 @@ class ProfileHost < ApplicationRecord
 
   validates :profile, presence: true
   validates :host, presence: true, uniqueness: { scope: :profile }
-
-  before_destroy :delete_orphaned_profiles
-
-  def delete_orphaned_profiles
-    profile.destroy unless (profile.hosts - [host]).any?
-  end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -68,7 +68,7 @@ class Rule < ApplicationRecord
   end
 
   def compliant?(host, profile)
-    Rails.cache.fetch("#{id}/#{host.id}/compliant", expires_in: 1.week) do
+    Rails.cache.fetch("#{id}/#{host.id}/compliant") do
       return false unless profile.present? && profile.rules.include?(self)
 
       latest_rule_result = latest_result(host, profile)

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+desc 'Remove systems in Compliance DB which are not in the inventory'
+task sync_with_inventory: [:environment] do
+  ::Account.includes(:hosts).find_each do |account|
+    puts "Starting to review account #{account.account_number}"
+    account.hosts.each do |host|
+      begin
+        host = ::HostInventoryAPI.new(
+          host.id, account, ::Settings.host_inventory_url, account.b64_identity
+        ).inventory_host
+      rescue ::InventoryHostNotFound
+        print "Account #{account.account_number}: "\
+          "System #{host.id} - #{host.name} not found in the inventory. "\
+          'Removing it from DB...'
+        ::DeleteHost.perform_async('id': host.id)
+        puts 'REMOVED'
+      end
+    end
+    puts "Done reviewing account #{account.account_number}"
+  end
+end

--- a/test/graphql/queries/benchmark_query_test.rb
+++ b/test/graphql/queries/benchmark_query_test.rb
@@ -5,8 +5,8 @@ require 'test_helper'
 class BenchmarkQueryTest < ActiveSupport::TestCase
   test 'query benchmark owned by the user' do
     query = <<-GRAPHQL
-      query allBenchmarks {
-          allBenchmarks {
+      query latestBenchmarks {
+          latestBenchmarks {
               id
               title
               refId
@@ -27,12 +27,12 @@ class BenchmarkQueryTest < ActiveSupport::TestCase
     )
 
     assert_equal benchmarks(:one).id,
-                 result['data']['allBenchmarks'].first['id']
+                 result['data']['latestBenchmarks'].first['id']
     assert_equal benchmarks(:one).title,
-                 result['data']['allBenchmarks'].first['title']
+                 result['data']['latestBenchmarks'].first['title']
     assert_equal benchmarks(:one).ref_id,
-                 result['data']['allBenchmarks'].first['refId']
+                 result['data']['latestBenchmarks'].first['refId']
     assert_equal benchmarks(:one).version,
-                 result['data']['allBenchmarks'].first['version']
+                 result['data']['latestBenchmarks'].first['version']
   end
 end

--- a/test/models/profile_host_test.rb
+++ b/test/models/profile_host_test.rb
@@ -8,18 +8,4 @@ class ProfileHostTest < ActiveSupport::TestCase
     @host = hosts(:one)
     @profile_host = ProfileHost.new(profile: @profile, host: @host)
   end
-
-  test '#delete_orphaned_profiles when some other hosts still exist (noop)' do
-    @profile.expects(:destroy).never
-    @profile.stubs(:hosts).returns([hosts(:two)])
-
-    @profile_host.delete_orphaned_profiles
-  end
-
-  test '#delete_orphaned_profiles when only this host exists' do
-    @profile.expects(:destroy)
-    @profile.stubs(:hosts).returns([@host])
-
-    @profile_host.delete_orphaned_profiles
-  end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -83,6 +83,28 @@ class ProfileTest < ActiveSupport::TestCase
     assert_empty BusinessObjective.where(title: 'abcd')
   end
 
+  test 'business_objective comes from policy for external profiles' do
+    (bm = benchmarks(:one).dup).update!(version: '0.1.47')
+    bo = BusinessObjective.create!(title: 'bo')
+    bo2 = BusinessObjective.create!(title: 'bo2')
+    (external_profile = profiles(:one).dup).update!(benchmark: bm,
+                                                    business_objective: bo,
+                                                    external: true)
+    profiles(:one).update!(business_objective: bo2)
+    assert_equal external_profile.policy, profiles(:one)
+    assert_equal bo2, external_profile.business_objective
+  end
+
+  test 'compliance_threshold comes from policy for external profiles' do
+    (bm = benchmarks(:one).dup).update!(version: '0.1.47')
+    (external_profile = profiles(:one).dup).update!(benchmark: bm,
+                                                    compliance_threshold: 100,
+                                                    external: true)
+    profiles(:one).update!(compliance_threshold: 30)
+    assert_equal external_profile.policy, profiles(:one)
+    assert_equal 30, external_profile.compliance_threshold
+  end
+
   test 'canonical profiles have no parent_profile_id' do
     assert Profile.new.canonical?, 'nil parent_profile_id should be canonical'
   end


### PR DESCRIPTION
This adds the following changes to stable:

* There is a new task (no job runs it yet, so it's only available via manual runs) to sync the DB with the inventory, and drop any records not found in the inventory
* Cache expiration date for failed rules, compliant, and results is 'never' - we only clear this cache when a new report comes in.
* Methods to determine a Policy from a Profile, and added Policy to GQL. 
* Destroy all Profiles if the "parent" Policy is destroyed.  

In addition to that, there are 2 commits which we couldn't put into prod until we got rid of current prod-stable. These changes have been already in CI for a long time.

* Don't destroy orphaned profiles (we do this in prod-stable, but it shouldn't be necessary in the "new app")
* Remove GQL endpoints that are unused