### PR TITLE
Heavy caching GQL

### DIFF
--- a/app/graphql/types/benchmark.rb
+++ b/app/graphql/types/benchmark.rb
@@ -15,7 +15,8 @@ module Types
     field :rules, [::Types::Rule], null: true
 
     def profiles
-      ::Rails.cache.fetch(benchmark: object.id, relation: 'canonical_profiles') do
+      ::Rails.cache.fetch(benchmark: object.id,
+                          relation: 'canonical_profiles') do
         object.profiles.canonical
       end
     end

--- a/app/graphql/types/benchmark.rb
+++ b/app/graphql/types/benchmark.rb
@@ -15,7 +15,15 @@ module Types
     field :rules, [::Types::Rule], null: true
 
     def profiles
-      object.profiles.canonical
+      ::Rails.cache.fetch(benchmark: object.id, relation: 'canonical_profiles') do
+        object.profiles.canonical
+      end
+    end
+
+    def rules
+      ::Rails.cache.fetch(benchmark: object.id, relation: 'rules') do
+        object.rules
+      end
     end
   end
 end

--- a/app/graphql/types/concerns/test_results.rb
+++ b/app/graphql/types/concerns/test_results.rb
@@ -23,6 +23,7 @@ module Types
 
     def score(args = {})
       return cached_score if cached_score(object.id, system_id(args))
+
       latest_test_result_batch(args).then do |latest_test_result|
         if latest_test_result.blank?
           0
@@ -41,7 +42,9 @@ module Types
     end
 
     def rules_passed(args = {})
-      return cached_rules_passed(object.id, system_id(args)) if cached_rules_passed(object.id, system_id(args))
+      return cached_rules_passed(object.id, system_id(args)) if
+             cached_rules_passed(object.id, system_id(args))
+
       latest_test_result_batch(args).then do |latest_test_result|
         if latest_test_result.blank?
           0
@@ -52,7 +55,9 @@ module Types
     end
 
     def rules_failed(args = {})
-      return cached_rules_failed(object.id, system_id(args)) if cached_rules_failed(object.id, system_id(args))
+      return cached_rules_failed(object.id, system_id(args)) if
+             cached_rules_failed(object.id, system_id(args))
+
       latest_test_result_batch(args).then do |latest_test_result|
         if latest_test_result.blank?
           0

--- a/app/graphql/types/concerns/test_results.rb
+++ b/app/graphql/types/concerns/test_results.rb
@@ -6,11 +6,13 @@ module Types
     extend ActiveSupport::Concern
 
     def score(args = {})
-      latest_test_result_batch(args).then do |latest_test_result|
-        if latest_test_result.blank?
-          0
-        else
-          latest_test_result.score
+      ::Rails.cache.fetch("#{system_id(args)}/#{object.id}/score") do
+        latest_test_result_batch(args).then do |latest_test_result|
+          if latest_test_result.blank?
+            0
+          else
+            latest_test_result.score
+          end
         end
       end
     end
@@ -24,21 +26,25 @@ module Types
     end
 
     def rules_passed(args = {})
-      latest_test_result_batch(args).then do |latest_test_result|
-        if latest_test_result.blank?
-          0
-        else
-          latest_test_result.rule_results.passed.count
+      ::Rails.cache.fetch("#{system_id(args)}/#{object.id}/rules_passed") do
+        latest_test_result_batch(args).then do |latest_test_result|
+          if latest_test_result.blank?
+            0
+          else
+            latest_test_result.rule_results.passed.count
+          end
         end
       end
     end
 
     def rules_failed(args = {})
-      latest_test_result_batch(args).then do |latest_test_result|
-        if latest_test_result.blank?
-          0
-        else
-          latest_test_result.rule_results.failed.count
+      ::Rails.cache.fetch("#{system_id(args)}/#{object.id}/rules_failed") do
+        latest_test_result_batch(args).then do |latest_test_result|
+          if latest_test_result.blank?
+            0
+          else
+            latest_test_result.rule_results.failed.count
+          end
         end
       end
     end

--- a/app/graphql/types/concerns/test_results.rb
+++ b/app/graphql/types/concerns/test_results.rb
@@ -22,7 +22,8 @@ module Types
     end
 
     def score(args = {})
-      return cached_score if cached_score(object.id, system_id(args))
+      return cached_score(object.id, system_id(args)) if
+             cached_score(object.id, system_id(args))
 
       latest_test_result_batch(args).then do |latest_test_result|
         if latest_test_result.blank?

--- a/app/graphql/types/concerns/test_results.rb
+++ b/app/graphql/types/concerns/test_results.rb
@@ -5,14 +5,29 @@ module Types
   module TestResults
     extend ActiveSupport::Concern
 
+    def cached_score(profile, host)
+      ::Rails.cache.read(profile: profile, host: host, attribute: 'score')
+    end
+
+    def cached_rules_passed(profile, host)
+      ::Rails.cache.read(
+        profile: profile, host: host, attribute: 'rules_passed'
+      )
+    end
+
+    def cached_rules_failed(profile, host)
+      ::Rails.cache.read(
+        profile: profile, host: host, attribute: 'rules_failed'
+      )
+    end
+
     def score(args = {})
-      ::Rails.cache.fetch("#{system_id(args)}/#{object.id}/score") do
-        latest_test_result_batch(args).then do |latest_test_result|
-          if latest_test_result.blank?
-            0
-          else
-            latest_test_result.score
-          end
+      return cached_score if cached_score(object.id, system_id(args))
+      latest_test_result_batch(args).then do |latest_test_result|
+        if latest_test_result.blank?
+          0
+        else
+          latest_test_result.score
         end
       end
     end
@@ -26,25 +41,23 @@ module Types
     end
 
     def rules_passed(args = {})
-      ::Rails.cache.fetch("#{system_id(args)}/#{object.id}/rules_passed") do
-        latest_test_result_batch(args).then do |latest_test_result|
-          if latest_test_result.blank?
-            0
-          else
-            latest_test_result.rule_results.passed.count
-          end
+      return cached_rules_passed(object.id, system_id(args)) if cached_rules_passed(object.id, system_id(args))
+      latest_test_result_batch(args).then do |latest_test_result|
+        if latest_test_result.blank?
+          0
+        else
+          latest_test_result.rule_results.passed.count
         end
       end
     end
 
     def rules_failed(args = {})
-      ::Rails.cache.fetch("#{system_id(args)}/#{object.id}/rules_failed") do
-        latest_test_result_batch(args).then do |latest_test_result|
-          if latest_test_result.blank?
-            0
-          else
-            latest_test_result.rule_results.failed.count
-          end
+      return cached_rules_failed(object.id, system_id(args)) if cached_rules_failed(object.id, system_id(args))
+      latest_test_result_batch(args).then do |latest_test_result|
+        if latest_test_result.blank?
+          0
+        else
+          latest_test_result.rule_results.failed.count
         end
       end
     end

--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -29,11 +29,14 @@ module RulesPreload
     ::RecordLoader.for(::Rule).load_many(rule_results.pluck(:rule_id))
   end
 
+  def cached_rules
+    ::Rails.cache.fetch(profile: object.id, relation: "rules")
+  end
+
   def all_rules
-    ::Rails.cache.fetch("#{object.id}/rules") do
-      ::CollectionLoader.for(::Profile, :rules).load(object).then do |rules|
-        rules
-      end
+    return cached_rules if cached_rules
+    ::CollectionLoader.for(::Profile, :rules).load(object).then do |rules|
+      rules
     end
   end
 

--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -30,8 +30,10 @@ module RulesPreload
   end
 
   def all_rules
-    ::CollectionLoader.for(::Profile, :rules).load(object).then do |rules|
-      rules
+    ::Rails.cache.fetch("#{object.id}/rules") do
+      ::CollectionLoader.for(::Profile, :rules).load(object).then do |rules|
+        rules
+      end
     end
   end
 

--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -30,11 +30,12 @@ module RulesPreload
   end
 
   def cached_rules
-    ::Rails.cache.fetch(profile: object.id, relation: "rules")
+    ::Rails.cache.fetch(profile: object.id, relation: 'rules')
   end
 
   def all_rules
     return cached_rules if cached_rules
+
     ::CollectionLoader.for(::Profile, :rules).load(object).then do |rules|
       rules
     end

--- a/app/graphql/types/rule.rb
+++ b/app/graphql/types/rule.rb
@@ -24,11 +24,9 @@ module Types
     end
 
     def compliant(args = {})
-      ::Rails.cache.fetch(
-        host: system_id(args), profile: profile_id(args), rule: object.id, attribute: 'compliant'
-      ) do
-        system_id(args) &&
-          profile_id(args) &&
+      ::Rails.cache.fetch(host: system_id(args), profile: profile_id(args),
+                          rule: object.id, attribute: 'compliant') do
+        system_id(args) && profile_id(args) &&
           %w[pass notapplicable notselected].include?(
             context[:rule_results][object.id][profile_id(args)]
           )
@@ -41,9 +39,10 @@ module Types
 
     def references
       return cached_references if cached_references
+
       if context[:"rule_references_#{object.id}"].nil?
         ::CollectionLoader.for(::Rule, :rule_references)
-          .load(object).then do |references|
+                          .load(object).then do |references|
           references.map { |ref| [ref.href, ref.label] }.to_json
         end
       else
@@ -65,8 +64,9 @@ module Types
 
     def identifier
       return cached_identifier if cached_identifier
+
       ::CollectionLoader.for(::Rule, :rule_identifier)
-        .load(object).then do |identifier|
+                        .load(object).then do |identifier|
         { label: identifier&.label, system: identifier&.system }.to_json
       end
     end
@@ -77,6 +77,7 @@ module Types
 
     def profiles
       return cached_profiles if cached_profiles
+
       ::CollectionLoader.for(::Rule, :profiles).load(object).then do |profiles|
         profiles
       end

--- a/app/graphql/types/rule.rb
+++ b/app/graphql/types/rule.rb
@@ -46,7 +46,7 @@ module Types
       if context[:"rule_references_#{object.id}"].nil?
         ::CollectionLoader.for(::Rule, :rule_references)
                           .load(object).then do |references|
-          references.map { |ref| [ref.href, ref.label] }.to_json
+          references.map { |ref| { href: ref.href, label: ref.label } }.to_json
         end
       else
         references_from_context

--- a/app/graphql/types/rule.rb
+++ b/app/graphql/types/rule.rb
@@ -23,6 +23,7 @@ module Types
                required: false
     end
 
+    # rubocop:disable Metrics/AbcSize
     def compliant(args = {})
       ::Rails.cache.fetch(host: system_id(args), profile: profile_id(args),
                           rule: object.id, attribute: 'compliant') do
@@ -32,11 +33,13 @@ module Types
           )
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def cached_references
       ::Rails.cache.read(rule: object.id, attribute: 'references')
     end
 
+    # rubocop:disable Metrics/AbcSize
     def references
       return cached_references if cached_references
 
@@ -49,6 +52,7 @@ module Types
         references_from_context
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def references_from_context
       ::RecordLoader.for(::RuleReference)

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 require_relative 'concerns/test_results'
 
 module Types

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+#
 require_relative 'concerns/test_results'
 
 module Types

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -73,7 +73,7 @@ module Types
     end
 
     def rule_objects_failed
-      ::Rails.cache.fetch(host: host.id, attribute: 'rule_objects_failed') do
+      ::Rails.cache.fetch(host: object.id, attribute: 'rule_objects_failed') do
         ::Rule.where(
           id: ::RuleResult.failed.for_system(object.id)
               .includes(:rule).pluck(:rule_id).uniq

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative 'concerns/test_results'
 
 module Types
   # Definition of the System GraphQL type

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -51,14 +51,18 @@ module Types
     end
 
     def rules_passed(args = {})
-      ::RecordLoader.for(::Profile).load(args[:profile_id]).then do |profile|
-        object.rules_passed(profile)
+      ::Rails.cache.fetch("#{object.id}/#{args[:profile_id]}/rules_passed") do
+        ::RecordLoader.for(::Profile).load(args[:profile_id]).then do |profile|
+          object.rules_passed(profile)
+        end
       end
     end
 
     def rules_failed(args = {})
-      ::RecordLoader.for(::Profile).load(args[:profile_id]).then do |profile|
-        object.rules_failed(profile)
+      ::Rails.cache.fetch("#{object.id}/#{args[:profile_id]}/rules_failed") do
+        ::RecordLoader.for(::Profile).load(args[:profile_id]).then do |profile|
+          object.rules_failed(profile)
+        end
       end
     end
 

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -53,14 +53,18 @@ module Types
     end
 
     def rules_passed(args = {})
-      return cached_rules_passed(args[:profile_id], object.id) if cached_rules_passed(args[:profile_id], object.id)
+      return cached_rules_passed(args[:profile_id], object.id) if
+             cached_rules_passed(args[:profile_id], object.id)
+
       ::RecordLoader.for(::Profile).load(args[:profile_id]).then do |profile|
         object.rules_passed(profile)
       end
     end
 
     def rules_failed(args = {})
-      return cached_rules_failed(args[:profile_id], object.id) if cached_rules_failed(args[:profile_id], object.id)
+      return cached_rules_failed(args[:profile_id], object.id) if
+             cached_rules_failed(args[:profile_id], object.id)
+
       ::RecordLoader.for(::Profile).load(args[:profile_id]).then do |profile|
         object.rules_failed(profile)
       end

--- a/app/services/cache_helper.rb
+++ b/app/services/cache_helper.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/ModuleLength
+# Various methods to warm or invalidate the cache
 module CacheHelper
   class << self
     def warm
@@ -41,7 +47,8 @@ module CacheHelper
     end
 
     def warm_profile(profile)
-      Rails.cache.write({ profile: profile.id, relation: 'rules' }, profile.rules)
+      Rails.cache.write({ profile: profile.id, relation: 'rules' },
+                        profile.rules)
       profile.rules.find_each do |rule|
         Rails.cache.write(
           { rule: rule.id, attribute: 'references' },
@@ -49,7 +56,9 @@ module CacheHelper
         )
         Rails.cache.write(
           { rule: rule.id, attribute: 'identifier' },
-          { label: rule.identifier&.label, system: rule.identifier&.system }.to_json
+          {
+            label: rule.identifier&.label, system: rule.identifier&.system
+          }.to_json
         )
         Rails.cache.write(
           { rule: rule.id, relation: 'profiles' },
@@ -59,8 +68,14 @@ module CacheHelper
     end
 
     def warm_benchmark(benchmark)
-      Rails.cache.write({ benchmark: benchmark.id, relation: 'rules' }, benchmark.rules)
-      Rails.cache.write({ benchmark: benchmark.id, relation: 'canonical_profiles' }, benchmark.profiles.canonical)
+      Rails.cache.write({ benchmark: benchmark.id, relation: 'rules' },
+                        benchmark.rules)
+      Rails.cache.write(
+        {
+          benchmark: benchmark.id, relation: 'canonical_profiles'
+        },
+        benchmark.profiles.canonical
+      )
     end
 
     def invalidate
@@ -78,10 +93,14 @@ module CacheHelper
     def invalidate_host(host)
       Rails.cache.delete(host: host.id, attribute: 'rule_objects_failed')
       host.profiles.find_each do |profile|
-        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'results')
-        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'rules_passed')
-        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'rules_failed')
-        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'score')
+        Rails.cache.delete(profile: profile.id, host: host.id,
+                           attribute: 'results')
+        Rails.cache.delete(profile: profile.id, host: host.id,
+                           attribute: 'rules_passed')
+        Rails.cache.delete(profile: profile.id, host: host.id,
+                           attribute: 'rules_failed')
+        Rails.cache.delete(profile: profile.id, host: host.id,
+                           attribute: 'score')
       end
     end
 
@@ -96,7 +115,11 @@ module CacheHelper
 
     def invalidate_benchmark(benchmark)
       Rails.cache.delete(benchmark: benchmark.id, relation: 'rules')
-      Rails.cache.delete(benchmark: benchmark.id, relation: 'canonical_profiles')
+      Rails.cache.delete(benchmark: benchmark.id,
+                         relation: 'canonical_profiles')
     end
   end
 end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/ModuleLength

--- a/app/services/cache_helper.rb
+++ b/app/services/cache_helper.rb
@@ -1,0 +1,102 @@
+module CacheHelper
+  class << self
+    def warm
+      Profile.find_each do |profile|
+        warm_profile(profile)
+      end
+      ::Xccdf::Benchmark.find_each do |benchmark|
+        warm_benchmark(benchmark)
+      end
+      Host.find_each do |host|
+        warm_host(host)
+      end
+    end
+
+    def warm_host(host)
+      Rails.cache.write(
+        { host: host.id, attribute: 'rule_objects_failed' },
+        ::Rule.where(
+          id: ::RuleResult.failed.for_system(host.id)
+          .includes(:rule).pluck(:rule_id).uniq
+        )
+      )
+      host.profiles.find_each do |profile|
+        Rails.cache.write(
+          { profile: profile.id, host: host.id, attribute: 'results' },
+          profile.results(host)
+        )
+        Rails.cache.write(
+          { profile: profile.id, host: host.id, attribute: 'rules_passed' },
+          host.rules_passed(profile)
+        )
+        Rails.cache.write(
+          { profile: profile.id, host: host.id, attribute: 'rules_failed' },
+          host.rules_passed(profile)
+        )
+        Rails.cache.write(
+          { profile: profile.id, host: host.id, attribute: 'score' },
+          profile.score(host: host)
+        )
+      end
+    end
+
+    def warm_profile(profile)
+      Rails.cache.write({ profile: profile.id, relation: 'rules' }, profile.rules)
+      profile.rules.find_each do |rule|
+        Rails.cache.write(
+          { rule: rule.id, attribute: 'references' },
+          rule.references.map { |ref| [ref.href, ref.label] }.to_json
+        )
+        Rails.cache.write(
+          { rule: rule.id, attribute: 'identifier' },
+          { label: rule.identifier&.label, system: rule.identifier&.system }.to_json
+        )
+        Rails.cache.write(
+          { rule: rule.id, relation: 'profiles' },
+          rule.profiles
+        )
+      end
+    end
+
+    def warm_benchmark(benchmark)
+      Rails.cache.write({ benchmark: benchmark.id, relation: 'rules' }, benchmark.rules)
+      Rails.cache.write({ benchmark: benchmark.id, relation: 'canonical_profiles' }, benchmark.profiles.canonical)
+    end
+
+    def invalidate
+      Host.find_each do |host|
+        invalidate_host(host)
+      end
+      Profile.find_each do |profile|
+        invalidate_profile(profile)
+      end
+      ::Xccdf::Benchmark.find_each do |benchmark|
+        invalidate_benchmark(benchmark)
+      end
+    end
+
+    def invalidate_host(host)
+      Rails.cache.delete(host: host.id, attribute: 'rule_objects_failed')
+      host.profiles.find_each do |profile|
+        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'results')
+        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'rules_passed')
+        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'rules_failed')
+        Rails.cache.delete(profile: profile.id, host: host.id, attribute: 'score')
+      end
+    end
+
+    def invalidate_profile(profile)
+      Rails.cache.delete(profile: profile.id, relation: 'rules')
+      profile.rules.each do |rule|
+        Rails.cache.delete(rule: rule.id, attribute: 'references')
+        Rails.cache.delete(rule: rule.id, attribute: 'identifier')
+        Rails.cache.delete(rule: rule.id, relation: 'profiles')
+      end
+    end
+
+    def invalidate_benchmark(benchmark)
+      Rails.cache.delete(benchmark: benchmark.id, relation: 'rules')
+      Rails.cache.delete(benchmark: benchmark.id, relation: 'canonical_profiles')
+    end
+  end
+end

--- a/app/services/cache_helper.rb
+++ b/app/services/cache_helper.rb
@@ -57,7 +57,9 @@ module CacheHelper
     def warm_rule(rule)
       Rails.cache.write(
         { rule: rule.id, attribute: 'references' },
-        rule.references.map { |ref| [ref.href, ref.label] }.to_json
+        rule.references.map do |ref|
+          { href: ref.href, label: ref.label }
+        end.to_json
       )
       Rails.cache.write(
         { rule: rule.id, attribute: 'identifier' },

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -51,26 +51,8 @@ module Xccdf
       private
 
       def invalidate_cache
-        Rails.cache.delete("#{@host&.id}/failed_rule_objects_result")
-        Rails.cache.delete("#{@host_profile&.id}/#{@host&.id}/results")
-        Rails.cache.delete("#{@host_profile&.id}/rules")
-        Rails.cache.delete("#{@host.id}/#{@host_profile&.id}/rules_passed")
-        Rails.cache.delete("#{@host.id}/#{@host_profile&.id}/rules_failed")
-        Rails.cache.delete("#{@host.id}/#{@host_profile&.id}/score")
-        @host_profile.rules.each do |rule|
-          Rails.cache.delete("#{rule.id}/#{@host&.id}/compliant")
-          Rails.cache.delete("#{rule.id}/references")
-          Rails.cache.delete("#{rule.id}/identifier")
-          Rails.cache.delete("#{rule.id}/profiles")
-        end
-
-        @host_profile.rules.each do |rule|
-          Rails.cache.write("#{rule.id}/references", rule.references.map { |ref| [ref.href, ref.label] }.to_json)
-          Rails.cache.write("#{rule.id}/identifier", { label: rule.identifier&.label, system: rule.identifier&.system }.to_json
-                           )
-          Rails.cache.write("#{rule.id}/profiles", rule.profiles)
-        end
-
+        CacheHelper.invalidate_host(@host)
+        CacheHelper.invalidate_profile(@host_profile)
       end
     end
   end

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -52,10 +52,25 @@ module Xccdf
 
       def invalidate_cache
         Rails.cache.delete("#{@host&.id}/failed_rule_objects_result")
-        Rails.cache.delete("#{@new_host_profile&.id}/#{@host&.id}/results")
+        Rails.cache.delete("#{@host_profile&.id}/#{@host&.id}/results")
+        Rails.cache.delete("#{@host_profile&.id}/rules")
+        Rails.cache.delete("#{@host.id}/#{@host_profile&.id}/rules_passed")
+        Rails.cache.delete("#{@host.id}/#{@host_profile&.id}/rules_failed")
+        Rails.cache.delete("#{@host.id}/#{@host_profile&.id}/score")
         @host_profile.rules.each do |rule|
           Rails.cache.delete("#{rule.id}/#{@host&.id}/compliant")
+          Rails.cache.delete("#{rule.id}/references")
+          Rails.cache.delete("#{rule.id}/identifier")
+          Rails.cache.delete("#{rule.id}/profiles")
         end
+
+        @host_profile.rules.each do |rule|
+          Rails.cache.write("#{rule.id}/references", rule.references.map { |ref| [ref.href, ref.label] }.to_json)
+          Rails.cache.write("#{rule.id}/identifier", { label: rule.identifier&.label, system: rule.identifier&.system }.to_json
+                           )
+          Rails.cache.write("#{rule.id}/profiles", rule.profiles)
+        end
+
       end
     end
   end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+desc <<-END_DESC
+  Warms all possible objects in the cache.
+END_DESC
+
+task warm_cache: :environment do
+  begin
+    CacheHelper.warm
+  rescue StandardError => e
+    ExceptionNotifier.notify_exception(
+      e,
+      data: OpenshiftEnvironment.summary
+    )
+  end
+end

--- a/test/graphql/queries/rule_query_test.rb
+++ b/test/graphql/queries/rule_query_test.rb
@@ -101,8 +101,8 @@ class RuleQueryTest < ActiveSupport::TestCase
     assert_not result.dig('errors'),
                "Query was unsuccessful: #{result.dig('errors')}"
     assert result.dig('data', 'profile', 'rules').any?, 'No rules returned!'
-    assert_equal [[rule_references(:one).href,
-                   rule_references(:one).label]].to_json,
+    assert_equal [{ href: rule_references(:one).href,
+                    label: rule_references(:one).label }].to_json,
                  result.dig('data', 'profile', 'rules',
                             0, 'references')
   end


### PR DESCRIPTION
Just a draft for now. This requires us to manually warm up the cache first, or during parse. I think that would make sense though. The problem with `.fetch` is that it can't capture batched requests, as it only works for arrays or other basic data types (it'd be crazy if it could store AR relations).

Warm the cache with:

```

        def warm_cache
          Profile.find_each do |profile|
            Rails.cache.write("#{profile&.id}/rules", profile.rules)
            profile.hosts.find_each do |host|
              Rails.cache.write("#{profile.id}/#{host.id}/results", profile.results(host))
              Rails.cache.write("#{host.id}/#{profile.id}/rules_passed", host.rules_passed(profile))
              Rails.cache.write("#{host.id}/#{profile.id}/rules_failed", host.rules_passed(profile))
              Rails.cache.write("#{host.id}/#{profile.id}/score", profile.score(host: host))
            end
            profile.rules.each do |rule|
              Rails.cache.write("#{rule.id}/references", rule.references.map { |ref| [ref.href, ref.label] }.to_json)
              Rails.cache.write("#{rule.id}/identifier", { label: rule.identifier&.label, system: rule.identifier&.system }.to_json)
              Rails.cache.write("#{rule.id}/profiles", rule.profiles)
            end
          end
        end

``` 

