### PR TITLE
Fix transient profile test failure

### DIFF
--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -107,6 +107,7 @@ class ProfileTest < ActiveSupport::TestCase
   end
 
   test "destroying a profile also destroys its policy's profiles" do
+    DestroyProfilesJob.clear
     (bm = benchmarks(:one).dup).update!(version: '0.1.47')
     (external_profile = profiles(:one).dup).update!(benchmark: bm,
                                                     external: true)


### PR DESCRIPTION
@dLobatog I think you mentioned this to me - This should fix the transient failure, which was sometimes finding more than 1 job due to other profiles being deleted in other tests.

Signed-off-by: Andrew Kofink <akofink@redhat.com>