### PR TITLE
Add benchmarks API endpoint

### DIFF
--- a/app/controllers/benchmarks_controller.rb
+++ b/app/controllers/benchmarks_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# API for Benchmarks
+class BenchmarksController < ApplicationController
+  def index
+    render json: benchmarks
+  end
+
+  def show
+    render json: benchmark
+  end
+
+  private
+
+  def benchmarks
+    @benchmarks ||= BenchmarkSerializer.new(authorize(scope_search), metadata)
+  end
+
+  def benchmark
+    @benchmark ||= BenchmarkSerializer.new(
+      authorize(resource.find(params[:id]))
+    )
+  end
+
+  def scope
+    policy_scope(resource)
+  end
+
+  def resource
+    Xccdf::Benchmark
+  end
+end

--- a/app/models/xccdf/benchmark.rb
+++ b/app/models/xccdf/benchmark.rb
@@ -6,6 +6,11 @@ module Xccdf
   # for a given set of software in a specific release of the SCAP Security
   # Guide (i.e. RHEL 7, v0.1.43)
   class Benchmark < ApplicationRecord
+    scoped_search on: %i[id ref_id title version]
+    scoped_search relation: :profiles, on: :id, rename: :profile_ids,
+                  alias: :profile_id
+    scoped_search relation: :rules, on: :id, rename: :rule_ids, alias: :rule_id
+
     has_many :profiles, dependent: :destroy
     has_many :rules, dependent: :destroy
     validates :ref_id, uniqueness: { scope: %i[version] }, presence: true

--- a/app/serializers/benchmark_serializer.rb
+++ b/app/serializers/benchmark_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# JSON API serialization for an OpenSCAP Benchmark
+class BenchmarkSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :ref_id, :title, :version, :description
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   def draw_routes(prefix)
     scope "#{prefix}/#{ENV['APP_NAME']}" do
+      resources :benchmarks, only: [:index, :show]
       resources :profiles, only: [:index, :show] do
         member do
           get 'tailoring_file'

--- a/test/controllers/benchmarks_controller_test.rb
+++ b/test/controllers/benchmarks_controller_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BenchmarksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    BenchmarksController.any_instance.stubs(:authenticate_user)
+    User.current = users(:test)
+    users(:test).update! account: accounts(:test)
+  end
+
+  test '#index success' do
+    get benchmarks_url
+    assert_response :success
+  end
+
+  test '#show success' do
+    get benchmarks_url(benchmarks(:one))
+    assert_response :success
+  end
+end

--- a/test/policies/benchmark_policy_test.rb
+++ b/test/policies/benchmark_policy_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BenchmarkPolicyTest < ActiveSupport::TestCase
+  test 'all benchmarks are accessible' do
+    assert_equal Xccdf::Benchmark.all,
+                 Pundit.policy_scope(users(:test), Xccdf::Benchmark)
+    assert Pundit.authorize(users(:test), profiles(:one), :index?)
+    assert Pundit.authorize(users(:test), profiles(:one), :show?)
+  end
+end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHICOMPL-593

- New Benchmarks controller and tests
- scoped_search for benchmark and profile/rule ID
- New Benchmark serializer
- Benchmark routes for `#show` and `#index`
- New Benchmark policy tests

Signed-off-by: Andrew Kofink <akofink@redhat.com>