### PR TITLE
Fixes for rake tasks 

### DIFF
--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -34,7 +34,7 @@ namespace :ssg do
       Rake::Task['ssg:sync'].invoke
       DATASTREAM_FILENAMES.flatten.each do |filename|
         ENV['DATASTREAM_FILE'] = filename
-        Rake::Task['ssg:import'].invoke
+        Rake::Task['ssg:import'].execute
       end
     end
   end

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../app/services/concerns/xccdf/hosts'
+
 desc 'Remove systems in Compliance DB which are not in the inventory'
 task sync_with_inventory: [:environment] do
   ::Account.includes(:hosts).find_each do |account|


### PR DESCRIPTION
1. `HostInventoryNotFound` isn't required in the sync_inventory task, so if it's called and fails, it'll not be able to work. 
2. Calling `.invoke` more than once on a rake task will not work, as the task will be marked the first time as `@already_invoked` (see [the source](https://github.com/ruby/rake/blob/master/lib/rake/task.rb#L205)). We could either call `.reenable` to reset the flag, or just call `.execute` which runs the task directly without the task prerequisites - which is OK in this case.   