### PR TITLE
Add specific config for cache redis

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: "redis://#{Settings.redis_url}/0" }
+  config.cache_store = :redis_cache_store, { url: "redis://#{Settings.redis_cache_url}" }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,4 +3,5 @@ rbac_url: https://insights-inventory-platform-ci.ask-on-slack-for-the-rbac-devel
 openshift_tokens_secret: MTwXl7kVp4inTho3N6aiw/7fr8iBJv49HwodiPHIdaw=
 #prometheus_exporter_host: prometheus
 #prometheus_exporter_port: 9394
-redis_url: 127.0.0.1:6379
+redis_url: redis:6379
+redis_cache_url: redis:6379

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,3 +2,5 @@ host_inventory_url: http://insights-inventory.platform-prod.svc:8080
 rbac_url: http://rbac.rbac-prod.svc.cluster.local:9002
 prometheus_exporter_host: compliance-prometheus-exporter.compliance-prod.svc
 prometheus_exporter_port: 9394
+redis_url: compliance-redis:6379
+redis_cache_url: compliance-redis:6379


### PR DESCRIPTION
For now we only have one redis instance, but this change would enable us to easily switch our cache to use an LRU-cache instead of the current persistent store. 