### PR TITLE
Use request_id instead of payload_id

### DIFF
--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -33,7 +33,7 @@ class ComplianceReportsConsumer < ApplicationConsumer
   def notify_payload_tracker(status, status_msg = '')
     PayloadTracker.deliver(
       account: @msg_value['account'], system_id: @msg_value['id'],
-      payload_id: @msg_value['request_id'], status: status,
+      request_id: @msg_value['request_id'], status: status,
       status_msg: status_msg
     )
   end
@@ -43,7 +43,7 @@ class ComplianceReportsConsumer < ApplicationConsumer
   end
 
   def message_id
-    @msg_value.fetch('request_id', @msg_value.dig('payload_id'))
+    @msg_value.fetch('request_id')
   end
 
   def download_file
@@ -82,7 +82,6 @@ class ComplianceReportsConsumer < ApplicationConsumer
 
   def validation_payload(request_id, result)
     {
-      'payload_id': request_id,
       'request_id': request_id,
       'service': 'compliance',
       'validation': result

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -42,7 +42,7 @@ class ParseReportJob
   def notify_payload_tracker(status, status_msg = '')
     PayloadTracker.deliver(
       account: @msg_value['account'], system_id: @msg_value['id'],
-      payload_id: @msg_value['request_id'], status: status,
+      request_id: @msg_value['request_id'], status: status,
       status_msg: status_msg
     )
   end

--- a/app/producers/payload_tracker.rb
+++ b/app/producers/payload_tracker.rb
@@ -9,15 +9,14 @@ class PayloadTracker < Kafka::Client
   SERVICE = 'compliance'
 
   class << self
-    def deliver(payload_id:, status:, account:, system_id:, status_msg: nil)
+    def deliver(request_id:, status:, account:, system_id:, status_msg: nil)
       # Inventory ID and system ID are identical because we match
       # system and inventory UUIDs in our database
       kafka&.deliver_message({
         date: DateTime.now.iso8601, service: SERVICE,
         account: account, system_id: system_id,
         source: ENV['APPLICATION_TYPE'], inventory_id: system_id,
-        payload_id: payload_id, status: status,
-        request_id: payload_id, status_msg: status_msg
+        status: status, request_id: request_id, status_msg: status_msg
       }.to_json, topic: TOPIC)
     rescue Kafka::DeliveryFailed => e
       logger.error("Payload tracker delivery failed: #{e}")

--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -35,31 +35,6 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
     end
   end
 
-  test 'report message is parsed and job is enqueued with request_id' do
-    SafeDownloader.expects(:download).returns(['report'])
-    @consumer.expects(:identity).returns(OpenStruct.new(valid?: true))
-             .at_least_once
-    @message.expects(:value).returns(
-      '{"account": "000001", "principal": "default_principal", '\
-      '"validation":1,"request_id":"036738d6f4e541c4aa8cfc9f46f5a140",'\
-      '"size": 327, "service": "compliance", "url": "/tmp/uploads'\
-      '/insights-upload-quarantine/036738d6f4e541c4aa8cfc9f46f5a140"}'
-    ).at_least_once
-    begin
-      @consumer.expects(:validation_message).returns('success')
-      @consumer.expects(:produce).with(
-        {
-          'request_id': '036738d6f4e541c4aa8cfc9f46f5a140',
-          'service': 'compliance',
-          'validation': 'success'
-        }.to_json,
-        topic: Settings.platform_kafka_validation_topic
-      )
-      @consumer.process(@message)
-      assert_equal 1, ParseReportJob.jobs.size
-    end
-  end
-
   test 'file is deleted even when validation fails' do
     SafeDownloader.expects(:download).returns(['report'])
     @consumer.expects(:identity).returns(OpenStruct.new(valid?: true))

--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -24,7 +24,6 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
       @consumer.expects(:validation_message).returns('success')
       @consumer.expects(:produce).with(
         {
-          'payload_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'request_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'service': 'compliance',
           'validation': 'success'
@@ -36,13 +35,13 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
     end
   end
 
-  test 'report message is parsed and job is enqueued with payload_id' do
+  test 'report message is parsed and job is enqueued with request_id' do
     SafeDownloader.expects(:download).returns(['report'])
     @consumer.expects(:identity).returns(OpenStruct.new(valid?: true))
              .at_least_once
     @message.expects(:value).returns(
       '{"account": "000001", "principal": "default_principal", '\
-      '"validation":1,"payload_id":"036738d6f4e541c4aa8cfc9f46f5a140",'\
+      '"validation":1,"request_id":"036738d6f4e541c4aa8cfc9f46f5a140",'\
       '"size": 327, "service": "compliance", "url": "/tmp/uploads'\
       '/insights-upload-quarantine/036738d6f4e541c4aa8cfc9f46f5a140"}'
     ).at_least_once
@@ -50,7 +49,6 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
       @consumer.expects(:validation_message).returns('success')
       @consumer.expects(:produce).with(
         {
-          'payload_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'request_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'service': 'compliance',
           'validation': 'success'

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class ParseReportJobTest < ActiveSupport::TestCase
   setup do
-    @msg_value = { 'id': '', 'account': '', 'payload_id': '' }
+    @msg_value = { 'id': '', 'account': '', 'request_id': '' }
     @parse_report_job = ParseReportJob.new
     @file = file_fixture('report.tar.gz').read
     @parser = mock('XccdfReportParser')

--- a/test/producers/payload_tracker_test.rb
+++ b/test/producers/payload_tracker_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class PayloadTrackerTest < ActiveSupport::TestCase
   test 'handles missing kafka config' do
-    assert_nil PayloadTracker.deliver(payload_id: 'foo', status: 'received',
+    assert_nil PayloadTracker.deliver(request_id: 'foo', status: 'received',
                                       account: '000001', system_id: 'foo')
   end
 
@@ -12,7 +12,7 @@ class PayloadTrackerTest < ActiveSupport::TestCase
     kafka = mock('kafka')
     PayloadTracker.stubs(:kafka).returns(kafka)
     kafka.expects(:deliver_message)
-    PayloadTracker.deliver(payload_id: 'foo', status: 'received',
+    PayloadTracker.deliver(request_id: 'foo', status: 'received',
                            account: '000001', system_id: 'foo')
   end
 
@@ -23,7 +23,7 @@ class PayloadTrackerTest < ActiveSupport::TestCase
     kafka.expects(:deliver_message).raises(Kafka::DeliveryFailed.new(nil, nil))
 
     assert_nothing_raised do
-      PayloadTracker.deliver(payload_id: 'foo', status: 'received',
+      PayloadTracker.deliver(request_id: 'foo', status: 'received',
                              account: '000001', system_id: 'foo')
     end
   end


### PR DESCRIPTION
The Payload Tracker is transitioning to using the new "request_id" terminology instead of the legacy "payload_id." This renames that field.