### PR TITLE
Add Faraday::Retry middleware

### DIFF
--- a/app/services/platform.rb
+++ b/app/services/platform.rb
@@ -9,9 +9,9 @@ module Platform
     interval: 0.05,
     interval_randomness: 0.5,
     backoff_factor: 2,
+    methods: %i[get],
     exceptions: [
-      Faraday::ConnectionFailed, Faraday::TimeoutError, Errno::ETIMEDOUT,
-      Timeout::Error, Error::TimeoutError
+      *Faraday::Request::Retry::DEFAULT_EXCEPTIONS, Faraday::ConnectionFailed
     ]
   }.freeze
 

--- a/app/services/platform.rb
+++ b/app/services/platform.rb
@@ -13,7 +13,7 @@ module Platform
       Faraday::ConnectionFailed, Faraday::TimeoutError, Errno::ETIMEDOUT,
       Timeout::Error, Error::TimeoutError
     ]
-  }
+  }.freeze
 
   def self.connection
     faraday = Faraday.new do |f|

--- a/app/services/platform.rb
+++ b/app/services/platform.rb
@@ -4,9 +4,21 @@ require 'faraday'
 
 # Methods related to connecting to other platform services
 module Platform
+  RETRY_OPTIONS = {
+    max: 3,
+    interval: 0.05,
+    interval_randomness: 0.5,
+    backoff_factor: 2,
+    exceptions: [
+      Faraday::ConnectionFailed, Faraday::TimeoutError, Errno::ETIMEDOUT,
+      Timeout::Error, Error::TimeoutError
+    ]
+  }
+
   def self.connection
     faraday = Faraday.new do |f|
       f.response :raise_error
+      f.request :retry, RETRY_OPTIONS
       f.adapter Faraday.default_adapter # this must be the last middleware
       f.ssl[:verify] = Rails.env.production?
     end


### PR DESCRIPTION
This should retry 3 times if it finds any of the expected exceptions. Unfortunately we are hitting sometimes remediations or RBAC when the pods are restarting or similar, you can see the #alerts-cloudservices-apps for an example of this. It should go:

1. Try request between 0.05+0.025 seconds
2. Try request between 0.1+0.05 seconds
3. Try request between 0.2+0.1 seconds

The goal is to have less "false alarms" in the channel and actually succeed with some requests that shouldn't fail. 