### PR TITLE
Introduce Faraday::Retry, Benchmark docs to stable

### DIFF
--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -33,7 +33,7 @@ class ComplianceReportsConsumer < ApplicationConsumer
   def notify_payload_tracker(status, status_msg = '')
     PayloadTracker.deliver(
       account: @msg_value['account'], system_id: @msg_value['id'],
-      payload_id: @msg_value['request_id'], status: status,
+      request_id: @msg_value['request_id'], status: status,
       status_msg: status_msg
     )
   end
@@ -43,7 +43,7 @@ class ComplianceReportsConsumer < ApplicationConsumer
   end
 
   def message_id
-    @msg_value.fetch('request_id', @msg_value.dig('payload_id'))
+    @msg_value.fetch('request_id')
   end
 
   def download_file
@@ -82,7 +82,6 @@ class ComplianceReportsConsumer < ApplicationConsumer
 
   def validation_payload(request_id, result)
     {
-      'payload_id': request_id,
       'request_id': request_id,
       'service': 'compliance',
       'validation': result

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -42,7 +42,7 @@ class ParseReportJob
   def notify_payload_tracker(status, status_msg = '')
     PayloadTracker.deliver(
       account: @msg_value['account'], system_id: @msg_value['id'],
-      payload_id: @msg_value['request_id'], status: status,
+      request_id: @msg_value['request_id'], status: status,
       status_msg: status_msg
     )
   end

--- a/app/producers/payload_tracker.rb
+++ b/app/producers/payload_tracker.rb
@@ -9,15 +9,14 @@ class PayloadTracker < Kafka::Client
   SERVICE = 'compliance'
 
   class << self
-    def deliver(payload_id:, status:, account:, system_id:, status_msg: nil)
+    def deliver(request_id:, status:, account:, system_id:, status_msg: nil)
       # Inventory ID and system ID are identical because we match
       # system and inventory UUIDs in our database
       kafka&.deliver_message({
         date: DateTime.now.iso8601, service: SERVICE,
         account: account, system_id: system_id,
         source: ENV['APPLICATION_TYPE'], inventory_id: system_id,
-        payload_id: payload_id, status: status,
-        request_id: payload_id, status_msg: status_msg
+        status: status, request_id: request_id, status_msg: status_msg
       }.to_json, topic: TOPIC)
     rescue Kafka::DeliveryFailed => e
       logger.error("Payload tracker delivery failed: #{e}")

--- a/app/services/platform.rb
+++ b/app/services/platform.rb
@@ -4,9 +4,21 @@ require 'faraday'
 
 # Methods related to connecting to other platform services
 module Platform
+  RETRY_OPTIONS = {
+    max: 3,
+    interval: 0.05,
+    interval_randomness: 0.5,
+    backoff_factor: 2,
+    methods: %i[get],
+    exceptions: [
+      *Faraday::Request::Retry::DEFAULT_EXCEPTIONS, Faraday::ConnectionFailed
+    ]
+  }.freeze
+
   def self.connection
     faraday = Faraday.new do |f|
       f.response :raise_error
+      f.request :retry, RETRY_OPTIONS
       f.adapter Faraday.default_adapter # this must be the last middleware
       f.ssl[:verify] = Rails.env.production?
     end

--- a/spec/integration/benchmarks_spec.rb
+++ b/spec/integration/benchmarks_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'Benchmarks API' do
+  path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/benchmarks" do
+    get 'List all benchmarks' do
+      fixtures :benchmarks
+      tags 'benchmark'
+      description 'Lists all benchmarks requested'
+      operationId 'ListBenchmarks'
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
+
+      response '200', 'lists all benchmarks requested' do
+        let(:'X-RH-IDENTITY') { encoded_header }
+        schema type: :object,
+               properties: {
+                 meta: { '$ref' => '#/definitions/metadata' },
+                 links: { '$ref' => '#/definitions/links' },
+                 data: {
+                   type: :array,
+                   items: {
+                     properties: {
+                       type: { type: :string },
+                       id: { type: :string, format: :uuid },
+                       attributes: { '$ref' => '#/definitions/benchmark' }
+                     }
+                   }
+                 }
+               }
+        examples 'application/vnd.api+json' => {
+          meta: { filter:
+                  'ref_id=xccdf_org.ssgproject.content_benchmark_RHEL-7' },
+          data: [
+            {
+              type: 'benchmark',
+              id: '1b743185-361a-4b9a-bf48-a8efd7114093',
+              attributes: {
+                description: 'This guide presents ... which provides required '\
+                             'settings for US Department of Defense systems, '\
+                             'is one example of a baseline created from '\
+                             'this guidance.',
+                ref_id: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
+                title: 'Guide to the Secure Configuration of Red Hat '\
+                       'Enterprise Linux 7',
+                version: '0.1.46'
+              }
+            }
+          ]
+        }
+        run_test!
+      end
+    end
+  end
+
+  path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/benchmarks/{id}" do
+    get 'Retrieve a benchmark' do
+      fixtures :benchmarks
+      tags 'benchmark'
+      description 'Retrieves data for a benchmark'
+      operationId 'ShowBenchmark'
+
+      content_types
+      auth_header
+      pagination_params
+      search_params
+
+      parameter name: :id, in: :path, type: :string
+
+      response '404', 'benchmark not found' do
+        let(:id) { 'invalid' }
+        let(:'X-RH-IDENTITY') { encoded_header }
+        examples 'application/vnd.api+json' => {
+          errors: 'Resource not found'
+        }
+        run_test!
+      end
+
+      response '200', 'retrieves a benchmark' do
+        let(:'X-RH-IDENTITY') { encoded_header }
+        let(:id) { benchmarks(:one).id }
+        schema type: :object,
+               properties: {
+                 meta: { '$ref' => '#/definitions/metadata' },
+                 links: { '$ref' => '#/definitions/links' },
+                 data: {
+                   type: :object,
+                   properties: {
+                     type: { type: :string },
+                     id: { type: :string, format: :uuid },
+                     attributes: { '$ref' => '#/definitions/benchmark' }
+                   }
+                 }
+               }
+        examples 'application/vnd.api+json' => {
+          data: {
+            type: 'benchmark',
+            id: 'd9654ad0-7cb5-4f61-b57c-0d22e3341dcc',
+            attributes: {
+              description: 'This guide presents ... which provides required '\
+                           'settings for US Department of Defense systems, '\
+                           'is one example of a baseline created from '\
+                           'this guidance.',
+              ref_id: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
+              title: 'Guide to the Secure Configuration of Red Hat '\
+                     'Enterprise Linux 7',
+              version: '0.1.46'
+            }
+          }
+        }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -52,7 +52,6 @@ describe 'Profiles API' do
 
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/profiles/{id}" do
     get 'Retrieve a profile' do
-      set_fixture_class benchmarks: Xccdf::Benchmark
       fixtures :hosts, :benchmarks, :profiles
       tags 'profile'
       description 'Retrieves data for a profile'

--- a/spec/integration/rules_spec.rb
+++ b/spec/integration/rules_spec.rb
@@ -69,7 +69,6 @@ describe 'Rules API' do
 
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/rules/{id}" do
     get 'Retrieve a rule' do
-      set_fixture_class benchmarks: Xccdf::Benchmark
       fixtures :hosts, :benchmarks, :rules, :profiles
       tags 'rule'
       description 'Retrieves data for a rule'

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -89,6 +89,28 @@ RSpec.configure do |config|
             }
           }
         },
+        benchmark: {
+          type: 'object',
+          required: %w[ref_id title version],
+          properties: {
+            ref_id: {
+              type: 'string',
+              example: 'xccdf_org.ssgproject.content_benchmark_RHEL-7'
+            },
+            title: {
+              type: 'string',
+              example: 'Guide to the Secure Configuration of Red Hat '\
+                       'Enterprise Linux 7'
+            },
+            version: {
+              type: 'string',
+              example: '0.1.46'
+            },
+            description: {
+              type: 'string'
+            }
+          }
+        },
         profile: {
           type: 'object',
           required: %w[name ref_id],

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -6,6 +6,233 @@
     "description": "This is the API for Cloud Services for RHEL Compliance. You can find out more about Red Hat Cloud Services for RHEL at [https://cloud.redhat.com/](https://cloud.redhat.com/)"
   },
   "paths": {
+    "/api/compliance/benchmarks": {
+      "get": {
+        "summary": "List all benchmarks",
+        "tags": [
+          "benchmark"
+        ],
+        "description": "Lists all benchmarks requested",
+        "operationId": "ListBenchmarks",
+        "consumes": [
+          "application/vnd.api+json"
+        ],
+        "produces": [
+          "application/vnd.api+json"
+        ],
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "lists all benchmarks requested",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "$ref": "#/definitions/metadata"
+                },
+                "links": {
+                  "$ref": "#/definitions/links"
+                },
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "attributes": {
+                        "$ref": "#/definitions/benchmark"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "examples": {
+              "application/vnd.api+json": {
+                "meta": {
+                  "filter": "ref_id=xccdf_org.ssgproject.content_benchmark_RHEL-7"
+                },
+                "data": [
+                  {
+                    "type": "benchmark",
+                    "id": "1b743185-361a-4b9a-bf48-a8efd7114093",
+                    "attributes": {
+                      "description": "This guide presents a catalog of security-relevant configuration settings for Red Hat Enterprise Linux 7. It is a rendering of content structured in the eXtensible Configuration Checklist Description Format (XCCDF) in order to support security automation.  The SCAP content is is available in the scap-security-guide package which is developed at     https://www.open-scap.org/security-policies/scap-security-guide. Providing system administrators with such guidance informs them how to securely configure systems under their control in a variety of network roles. Policy makers and baseline creators can use this catalog of settings, with its associated references to higher-level security control catalogs, in order to assist them in security baseline creation. This guide is a catalog, not a checklist, and satisfaction of every item is not likely to be possible or sensible in many operational scenarios. However, the XCCDF format enables granular selection and adjustment of settings, and their association with OVAL and OCIL content provides an automated checking capability. Transformations of this document, and its associated automated checking content, are capable of providing baselines that meet a diverse set of policy objectives. Some example XCCDF Profiles, which are selections of items that form checklists and can be used as baselines, are available with this guide. They can be processed, in an automated fashion, with tools that support the Security Content Automation Protocol (SCAP). The DISA STIG, which provides required settings for US Department of Defense systems, is one example of a baseline created from this guidance.",
+                      "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                      "title": "Guide to the Secure Configuration of Red Hat Enterprise Linux 7",
+                      "version": "0.1.46"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/compliance/benchmarks/{id}": {
+      "get": {
+        "summary": "Retrieve a benchmark",
+        "tags": [
+          "benchmark"
+        ],
+        "description": "Retrieves data for a benchmark",
+        "operationId": "ShowBenchmark",
+        "consumes": [
+          "application/vnd.api+json"
+        ],
+        "produces": [
+          "application/vnd.api+json"
+        ],
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to skip before starting to collect the result set",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "benchmark not found",
+            "examples": {
+              "application/vnd.api+json": {
+                "errors": "Resource not found"
+              }
+            }
+          },
+          "200": {
+            "description": "retrieves a benchmark",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "meta": {
+                  "$ref": "#/definitions/metadata"
+                },
+                "links": {
+                  "$ref": "#/definitions/links"
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "attributes": {
+                      "$ref": "#/definitions/benchmark"
+                    }
+                  }
+                }
+              }
+            },
+            "examples": {
+              "application/vnd.api+json": {
+                "data": {
+                  "type": "benchmark",
+                  "id": "d9654ad0-7cb5-4f61-b57c-0d22e3341dcc",
+                  "attributes": {
+                    "description": "This guide presents a catalog of security-relevant configuration settings for Red Hat Enterprise Linux 7. It is a rendering of content structured in the eXtensible Configuration Checklist Description Format (XCCDF) in order to support security automation.  The SCAP content is is available in the scap-security-guide package which is developed at     https://www.open-scap.org/security-policies/scap-security-guide. Providing system administrators with such guidance informs them how to securely configure systems under their control in a variety of network roles. Policy makers and baseline creators can use this catalog of settings, with its associated references to higher-level security control catalogs, in order to assist them in security baseline creation. This guide is a catalog, not a checklist, and satisfaction of every item is not likely to be possible or sensible in many operational scenarios. However, the XCCDF format enables granular selection and adjustment of settings, and their association with OVAL and OCIL content provides an automated checking capability. Transformations of this document, and its associated automated checking content, are capable of providing baselines that meet a diverse set of policy objectives. Some example XCCDF Profiles, which are selections of items that form checklists and can be used as baselines, are available with this guide. They can be processed, in an automated fashion, with tools that support the Security Content Automation Protocol (SCAP). The DISA STIG, which provides required settings for US Department of Defense systems, is one example of a baseline created from this guidance.",
+                    "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                    "title": "Guide to the Secure Configuration of Red Hat Enterprise Linux 7",
+                    "version": "0.1.46"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/compliance/profiles": {
       "get": {
         "summary": "List all profiles",
@@ -423,7 +650,7 @@
                   "$ref": "#/definitions/links"
                 },
                 "data": {
-                  "type": "object",
+                  "type": "array",
                   "items": {
                     "properties": {
                       "type": {
@@ -751,6 +978,31 @@
         "self": {
           "type": "string",
           "example": "https://compliance.insights.openshift.org/profiles"
+        }
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "required": [
+        "ref_id",
+        "title",
+        "version"
+      ],
+      "properties": {
+        "ref_id": {
+          "type": "string",
+          "example": "xccdf_org.ssgproject.content_benchmark_RHEL-7"
+        },
+        "title": {
+          "type": "string",
+          "example": "Guide to the Secure Configuration of Red Hat Enterprise Linux 7"
+        },
+        "version": {
+          "type": "string",
+          "example": "0.1.46"
+        },
+        "description": {
+          "type": "string"
         }
       }
     },

--- a/test/consumers/compliance_reports_consumer_test.rb
+++ b/test/consumers/compliance_reports_consumer_test.rb
@@ -24,33 +24,6 @@ class ComplianceReportsConsumerTest < ActiveSupport::TestCase
       @consumer.expects(:validation_message).returns('success')
       @consumer.expects(:produce).with(
         {
-          'payload_id': '036738d6f4e541c4aa8cfc9f46f5a140',
-          'request_id': '036738d6f4e541c4aa8cfc9f46f5a140',
-          'service': 'compliance',
-          'validation': 'success'
-        }.to_json,
-        topic: Settings.platform_kafka_validation_topic
-      )
-      @consumer.process(@message)
-      assert_equal 1, ParseReportJob.jobs.size
-    end
-  end
-
-  test 'report message is parsed and job is enqueued with payload_id' do
-    SafeDownloader.expects(:download).returns(['report'])
-    @consumer.expects(:identity).returns(OpenStruct.new(valid?: true))
-             .at_least_once
-    @message.expects(:value).returns(
-      '{"account": "000001", "principal": "default_principal", '\
-      '"validation":1,"payload_id":"036738d6f4e541c4aa8cfc9f46f5a140",'\
-      '"size": 327, "service": "compliance", "url": "/tmp/uploads'\
-      '/insights-upload-quarantine/036738d6f4e541c4aa8cfc9f46f5a140"}'
-    ).at_least_once
-    begin
-      @consumer.expects(:validation_message).returns('success')
-      @consumer.expects(:produce).with(
-        {
-          'payload_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'request_id': '036738d6f4e541c4aa8cfc9f46f5a140',
           'service': 'compliance',
           'validation': 'success'

--- a/test/fixtures/benchmarks.yml
+++ b/test/fixtures/benchmarks.yml
@@ -1,5 +1,6 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
+_fixture:
+  model_class: Xccdf::Benchmark
 one:
   ref_id: xccdf_org.ssgproject.content_benchmark_RHEL-7
   title: Benchmark One

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class ParseReportJobTest < ActiveSupport::TestCase
   setup do
-    @msg_value = { 'id': '', 'account': '', 'payload_id': '' }
+    @msg_value = { 'id': '', 'account': '', 'request_id': '' }
     @parse_report_job = ParseReportJob.new
     @file = file_fixture('report.tar.gz').read
     @parser = mock('XccdfReportParser')

--- a/test/producers/payload_tracker_test.rb
+++ b/test/producers/payload_tracker_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class PayloadTrackerTest < ActiveSupport::TestCase
   test 'handles missing kafka config' do
-    assert_nil PayloadTracker.deliver(payload_id: 'foo', status: 'received',
+    assert_nil PayloadTracker.deliver(request_id: 'foo', status: 'received',
                                       account: '000001', system_id: 'foo')
   end
 
@@ -12,7 +12,7 @@ class PayloadTrackerTest < ActiveSupport::TestCase
     kafka = mock('kafka')
     PayloadTracker.stubs(:kafka).returns(kafka)
     kafka.expects(:deliver_message)
-    PayloadTracker.deliver(payload_id: 'foo', status: 'received',
+    PayloadTracker.deliver(request_id: 'foo', status: 'received',
                            account: '000001', system_id: 'foo')
   end
 
@@ -23,7 +23,7 @@ class PayloadTrackerTest < ActiveSupport::TestCase
     kafka.expects(:deliver_message).raises(Kafka::DeliveryFailed.new(nil, nil))
 
     assert_nothing_raised do
-      PayloadTracker.deliver(payload_id: 'foo', status: 'received',
+      PayloadTracker.deliver(request_id: 'foo', status: 'received',
                              account: '000001', system_id: 'foo')
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,6 @@ unless Rails.env.production?
 
   module ActiveSupport
     class TestCase
-      set_fixture_class benchmarks: Xccdf::Benchmark
       fixtures :all
       self.use_transactional_tests = true
     end


### PR DESCRIPTION
This PR contains the following changes:

* Adds Faraday::Retry to our middleware to make GET requests to different services. This should reduce the amount of false alerts we get for services we try to contact and are temporarily down.
* Changes PayloadTracker to use `request_id` instead of `payload_id`, as the latter is deprecated.
* Adds Benchmark REST API docs to Swagger