### PR TITLE
[stable] Resolve rule_results to AR relation if it's empty

### DIFF
--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -20,7 +20,9 @@ module RulesPreload
   end
 
   def latest_rule_results_batch(latest_test_result)
-    return Promise.resolve([]) if latest_test_result.blank?
+    if latest_test_result.blank?
+      return Promise.resolve(::RuleResult.where('1=0'))
+    end
 
     ::CollectionLoader.for(::TestResult, :rule_results).load(latest_test_result)
   end


### PR DESCRIPTION
rule_results should be an AR relation at all times, as even if it's
empty, we call methods like 'select' on it.
