### PR TITLE
Remove unused gql fields

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -482,12 +482,6 @@ interface RulesPreload {
 A System registered in Insights Compliance
 """
 type System implements Node {
-  compliant(
-    """
-    Filter results by profile ID
-    """
-    profileId: String
-  ): Boolean!
   globalId: ID!
   id: ID!
   lastScanned(
@@ -517,13 +511,7 @@ type System implements Node {
     """
     ids: [ID!]!
   ): [Node]!
-  profileNames: String!
   profiles: [Profile!]
-
-  """
-  Rules failed by a system
-  """
-  ruleObjectsFailed: [Rule!]
   rulesFailed(
     """
     Filter results by profile ID

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -51,7 +51,6 @@ module Xccdf
       private
 
       def invalidate_cache
-        Rails.cache.delete("#{@host&.id}/failed_rule_objects_result")
         Rails.cache.delete("#{@new_host_profile&.id}/#{@host&.id}/results")
         @host_profile.rules.each do |rule|
           Rails.cache.delete("#{rule.id}/#{@host&.id}/compliant")

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -47,45 +47,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     end
   end
 
-  test 'some host attributes can be queried without profileId arguments' do
-    query = <<-GRAPHQL
-    {
-        systems(limit: 50, offset: 1) {
-          edges {
-            node {
-              id
-              name
-              profileNames
-              compliant
-              rulesPassed
-              rulesFailed
-              lastScanned
-            }
-          }
-        }
-    }
-    GRAPHQL
-
-    profiles(:one).rules << rules(:one)
-    profiles(:two).rules << rules(:two)
-    hosts(:one).profiles << profiles(:one)
-    hosts(:one).profiles << profiles(:two)
-    test_results(:one).update(profile: profiles(:one), host: hosts(:one))
-    test_results(:two).update(profile: profiles(:two), host: hosts(:one))
-
-    result = Schema.execute(
-      query,
-      variables: {},
-      context: { current_user: users(:test) }
-    )
-
-    assert_equal(
-      "#{profiles(:one).name}, #{profiles(:two).name}",
-      result['data']['systems']['edges'].first['node']['profileNames']
-    )
-    assert_not result['data']['systems']['edges'].first['node']['compliant']
-  end
-
   test 'query attributes with profileId arguments' do
     query = <<-GRAPHQL
     query getSystems($search: String) {


### PR DESCRIPTION
Please double-check first, but these fields are not used anywhere in our frontend I believe, and some are just wrong - e.g: there's no concept of "Compliant" system, profile-names should be extracted from `profiles { name }` and same goes for rule objects failed.