### PR TITLE
RHICOMPL-631 - Update hostnames based on 'update' message

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -9,9 +9,12 @@ class InventoryEventsConsumer < ApplicationConsumer
     msg_value = JSON.parse(message.value)
     logger.info "Received message, enqueueing: #{message.value}"
 
-    return unless msg_value['type'] == 'delete'
-
-    DeleteHost.perform_async(msg_value)
+    case msg_value['type']
+    when 'delete'
+      DeleteHost.perform_async(msg_value)
+    when 'updated'
+      InventoryHostUpdatedJob.perform_async(msg_value)
+    end
   end
 
   private

--- a/app/controllers/concerns/exception_notifier_custom_data.rb
+++ b/app/controllers/concerns/exception_notifier_custom_data.rb
@@ -14,7 +14,7 @@ module ExceptionNotifierCustomData
     request.env[
       'exception_notifier.exception_data'
     ] = OpenshiftEnvironment.summary.merge(
-      current_user: current_user.account.account_number
+      current_user: current_user&.account&.account_number
     )
   end
 end

--- a/app/jobs/concerns/record_not_found.rb
+++ b/app/jobs/concerns/record_not_found.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Module to handle RecordNotFound on jobs
+module RecordNotFound
+  def rescue_not_found
+    yield
+  rescue ActiveRecord::RecordNotFound => e
+    Sidekiq.logger.info(
+      "#{e.message} (#{e.class}) "\
+      '- this host ID was not registered in Compliance'
+    )
+  end
+end

--- a/app/jobs/delete_host.rb
+++ b/app/jobs/delete_host.rb
@@ -9,7 +9,7 @@ class DeleteHost
     Host.transaction do
       RuleResult.where(host_id: message['id']).delete_all
       rescue_not_found do
-        Host.find_by!(id: message['id'])&.destroy
+        Host.find_by!(id: message['id']).destroy
       end
     end
   end

--- a/app/jobs/delete_host.rb
+++ b/app/jobs/delete_host.rb
@@ -3,16 +3,14 @@
 # Job meant to delete hosts and associated objects asynchronously
 class DeleteHost
   include Sidekiq::Worker
+  include RecordNotFound
 
   def perform(message)
     Host.transaction do
       RuleResult.where(host_id: message['id']).delete_all
-      Host.find_by(id: message['id'])&.destroy
+      rescue_not_found do
+        Host.find_by!(id: message['id'])&.destroy
+      end
     end
-  rescue ActiveRecord::RecordNotFound => e
-    Sidekiq.logger.info(
-      "#{e.message} (#{e.class}) "\
-      '- this host ID was not registered in Compliance'
-    )
   end
 end

--- a/app/jobs/inventory_host_updated_job.rb
+++ b/app/jobs/inventory_host_updated_job.rb
@@ -11,7 +11,7 @@ class InventoryHostUpdatedJob
     rescue_not_found do
       Host.find_by!(
         id: message['host']['id']
-      ).update(name: message['host']['display_name'])
+      ).update!(name: message['host']['display_name'])
     end
   end
 

--- a/app/jobs/inventory_host_updated_job.rb
+++ b/app/jobs/inventory_host_updated_job.rb
@@ -6,15 +6,17 @@ class InventoryHostUpdatedJob
   include RecordNotFound
 
   def perform(message)
-    if message['host'] && message['host']['display_name']
-      rescue_not_found do
-        Host.find_by!(
-          id: message['host']['id']
-        )&.update(name: message['host']['display_name'])
-      end
-    else
-      wrong_format_warning(message)
+    return wrong_format_warning(message) unless valid_message_format(message)
+
+    rescue_not_found do
+      Host.find_by!(
+        id: message['host']['id']
+      ).update(name: message['host']['display_name'])
     end
+  end
+
+  def valid_message_format(message)
+    message.dig('host', 'display_name') && message.dig('host', 'id')
   end
 
   def wrong_format_warning(message)

--- a/app/jobs/inventory_host_updated_job.rb
+++ b/app/jobs/inventory_host_updated_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Updates the host according to the inventory definition
+class InventoryHostUpdatedJob
+  include Sidekiq::Worker
+  include RecordNotFound
+
+  def perform(message)
+    if message['host'] && message['host']['display_name']
+      rescue_not_found do
+        Host.find_by!(
+          id: message['host']['id']
+        )&.update(name: message['host']['display_name'])
+      end
+    else
+      wrong_format_warning(message)
+    end
+  end
+
+  def wrong_format_warning(message)
+    Sidekiq.logger.warn(
+      'Received a message to update a hostname but message '\
+      "doesn't have the expected format - #{message}"
+    )
+  end
+end

--- a/test/consumers/inventory_events_consumer_test.rb
+++ b/test/consumers/inventory_events_consumer_test.rb
@@ -8,6 +8,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
     @message = stub(:message)
     @consumer = InventoryEventsConsumer.new
     DeleteHost.clear
+    InventoryHostUpdatedJob.clear
   end
 
   test 'if message is delete, host is enqueued for deletion' do

--- a/test/jobs/delete_host_test.rb
+++ b/test/jobs/delete_host_test.rb
@@ -9,6 +9,7 @@ class DeleteHostTest < ActiveSupport::TestCase
       'id': hosts(:one).id,
       'type': 'delete'
     }
+    DeleteHost.clear
   end
 
   test 'deletes a host if the passed ID is found' do

--- a/test/jobs/delete_host_test.rb
+++ b/test/jobs/delete_host_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'sidekiq/testing'
+
+class DeleteHostTest < ActiveSupport::TestCase
+  setup do
+    @message = {
+      'id': hosts(:one).id,
+      'type': 'delete'
+    }
+  end
+
+  test 'deletes a host if the passed ID is found' do
+    DeleteHost.perform_async(@message)
+    assert_equal 1, DeleteHost.jobs.size
+    assert_difference('Host.count', -1) do
+      DeleteHost.drain
+    end
+  end
+
+  test 'logs if message contains an ID not found ' do
+    DeleteHost.perform_async(@message.merge('id': 'notfound'))
+    assert_equal 1, DeleteHost.jobs.size
+    Sidekiq.logger.expects(:info)
+    assert_difference('Host.count', 0) do
+      DeleteHost.drain
+    end
+  end
+end

--- a/test/jobs/inventory_host_updated_job_test.rb
+++ b/test/jobs/inventory_host_updated_job_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'sidekiq/testing'
+
+class InventoryHostUpdatedJobTest < ActiveSupport::TestCase
+  setup do
+    @message = {
+      'type': 'updated',
+      'host': {
+        'id': hosts(:one).id,
+        'display_name': 'updated_display_name'
+      }
+    }
+  end
+
+  test 'updates a hostname if the passed ID is found' do
+    InventoryHostUpdatedJob.perform_async(@message)
+    assert_equal 1, InventoryHostUpdatedJob.jobs.size
+    InventoryHostUpdatedJob.drain
+    assert_equal @message[:host][:display_name], hosts(:one).reload.name
+  end
+
+  test 'warns if the message is in an unexpected format' do
+    InventoryHostUpdatedJob.perform_async('unexpected': 'format')
+    assert_equal 1, InventoryHostUpdatedJob.jobs.size
+    Sidekiq.logger.expects(:warn)
+    InventoryHostUpdatedJob.drain
+  end
+
+  test 'logs if message contains an ID not found ' do
+    InventoryHostUpdatedJob.perform_async(
+      'host': { 'id': 'notfound', 'display_name': 'abc' }
+    )
+    assert_equal 1, InventoryHostUpdatedJob.jobs.size
+    Sidekiq.logger.expects(:info)
+    InventoryHostUpdatedJob.drain
+  end
+end

--- a/test/jobs/inventory_host_updated_job_test.rb
+++ b/test/jobs/inventory_host_updated_job_test.rb
@@ -12,6 +12,7 @@ class InventoryHostUpdatedJobTest < ActiveSupport::TestCase
         'display_name': 'updated_display_name'
       }
     }
+    InventoryHostUpdatedJob.clear
   end
 
   test 'updates a hostname if the passed ID is found' do


### PR DESCRIPTION


On Apr 28th, there will be a new event to tell apps to update hostnames if the inventory hostname changed. On the UI, this shouldn't affect us as we already always display the inventory hostname (unless the host is unsynced for whichever reason and is only on compliance, this should not happen in prod though).

On the API, this would be visible as we don't contact the inventory for anything there. So we should update the names according to the message to serve the right name.

https://platform-docs.cloud.paas.psi.redhat.com/backend/inventory.html#host-patching for more info on the message format
