### PR TITLE
RHICOMPL-598 - Resolve rule_ids before querying references

### DIFF
--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -51,10 +51,9 @@ module RulesPreload
   end
 
   def initialize_rule_references_context(rule_results)
-    grouped_rules_references = ::RuleReferencesRule.select(
-      :rule_id, :rule_reference_id
-    ).distinct.where(
-      rule_id: rule_results.select(:rule_id)
+    rule_ids = rule_results.pluck(:rule_id)
+    grouped_rules_references = ::RuleReferencesRule.distinct.where(
+      rule_id: rule_ids
     ).group_by(&:rule_id)
     grouped_rules_references.each do |rule_id, references|
       context[:"rule_references_#{rule_id}"] =


### PR DESCRIPTION
Resolving the query for all Rule ids before trying to get all of the
RuleReferencesRules results in a massive performance improvement.

There's a penalty on running subqueries like "IN (SELECT
"rule_results"."rule_id" FROM "rule_results" WHERE
"rule_results"."test_result_id" = $1)" - versus just resolving the call
and passing the array of rule IDs.

In this example, we have already resolved the rule_ids in line 40, on
initialize_rules_context, so using a subquery is suboptimal when the
data is already in memory.

You can see the difference on these [slow](https://gist.github.com/dLobatog/d4d4ff0e012d36a11dd372402bed3b4f) vs [fast](https://gist.github.com/dLobatog/d7c8e057a600b4dc195149e7b293b5da).

Particularly the lines to notice are:

```
 RuleReferencesRule Load (9662.4ms)  SELECT DISTINCT "rule_references_rules".* FROM "...
 Completed 200 OK in 35150ms (Views: 202.9ms | ActiveRecord: 30403.0ms)
```
vs 
```
 RuleReferencesRule Load (693.2ms)  SELECT DISTINCT "rule_references_rules".* FROM "....
 Completed 200 OK in 5876ms (Views: 45.0ms | ActiveRecord: 1791.7ms)
```
Slow
![Screenshot from 2020-04-27 13-39-30](https://user-images.githubusercontent.com/598891/80368158-91bb6d80-888c-11ea-93b5-606034d0ece7.png)
Fast
![Screenshot from 2020-04-27 13-38-43](https://user-images.githubusercontent.com/598891/80368161-92ec9a80-888c-11ea-8339-11174ebd603d.png)
