### PR TITLE
RHICOMPL-598 - Resolve rule_ids before querying references (#430)

### DIFF
--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -51,10 +51,9 @@ module RulesPreload
   end
 
   def initialize_rule_references_context(rule_results)
-    grouped_rules_references = ::RuleReferencesRule.select(
-      :rule_id, :rule_reference_id
-    ).distinct.where(
-      rule_id: rule_results.select(:rule_id)
+    rule_ids = rule_results.pluck(:rule_id)
+    grouped_rules_references = ::RuleReferencesRule.distinct.where(
+      rule_id: rule_ids
     ).group_by(&:rule_id)
     grouped_rules_references.each do |rule_id, references|
       context[:"rule_references_#{rule_id}"] =


### PR DESCRIPTION
Resolving the query for all Rule ids before trying to get all of the
RuleReferencesRules results in a massive performance improvement.

There's a penalty on running subqueries like "IN (SELECT
"rule_results"."rule_id" FROM "rule_results" WHERE
"rule_results"."test_result_id" = $1)" - versus just resolving the call
and passing the array of rule IDs.

In this example, we have already resolved the rule_ids in line 40, on
initialize_rules_context, so using a subquery is suboptimal when the
data is already in memory.