### PR TITLE
RHICOMPL-586 - Don't preload rule_results on profiles GQL

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -98,8 +98,7 @@ module Types
         ::TestResult,
         column: :profile_id,
         where: { host_id: system_id(args) },
-        order: 'created_at DESC',
-        includes: [:rule_results]
+        order: 'created_at DESC'
       ).load(object.id)
     end
   end


### PR DESCRIPTION
This should make all of the calls to this endpoint faster, according to experimentation - it reduces the allocation of RuleResults by more than 10x. It's most visible on the Reports by System page.
 
Before (7.5s, 3.5M allocations):
![Screenshot from 2020-04-27 19-54-08](https://user-images.githubusercontent.com/598891/80405969-9f401a00-88c3-11ea-8df8-f6da2cfb393d.png) 

After (1.2s, 143k allocations):
![Screenshot from 2020-04-27 19-54-23](https://user-images.githubusercontent.com/598891/80405962-9e0eed00-88c3-11ea-9545-a57a1ca67547.png)
 