### PR TITLE
[stable] RHICOMPL-586 - Don't preload rule_results on profiles GQL (#434)

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -98,8 +98,7 @@ module Types
         ::TestResult,
         column: :profile_id,
         where: { host_id: system_id(args) },
-        order: 'created_at DESC',
-        includes: [:rule_results]
+        order: 'created_at DESC'
       ).load(object.id)
     end
   end


### PR DESCRIPTION
This should make all of the calls to this endpoint faster, according to
the results. See https://github.com/RedHatInsights/compliance-backend/pull/434 for more details