### PR TITLE
Only delete policy_profiles for non-canonical profiles

### DIFF
--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -16,6 +16,8 @@ module ProfilePolicyAssociation
     end
 
     def policy_profiles
+      return Profile.none if account_id.nil?
+
       Profile.includes(:benchmark)
              .where(account: account_id, ref_id: ref_id,
                     benchmarks: { ref_id: benchmark.ref_id })

--- a/db/migrate/20200106134953_add_unique_index_to_benchmarks.rb
+++ b/db/migrate/20200106134953_add_unique_index_to_benchmarks.rb
@@ -1,4 +1,12 @@
+require 'profile'
+
 class AddUniqueIndexToBenchmarks < ActiveRecord::Migration[5.2]
+  class ::Profile < ApplicationRecord
+    def destroy_policy_test_results
+      DestroyProfilesJob.new.perform(policy_profiles.pluck(:id))
+    end
+  end
+
   def up
     DuplicateBenchmarkResolver.run!
 

--- a/db/migrate/20200325185540_add_unique_index_to_profiles.rb
+++ b/db/migrate/20200325185540_add_unique_index_to_profiles.rb
@@ -1,4 +1,12 @@
+require 'profile'
+
 class AddUniqueIndexToProfiles < ActiveRecord::Migration[5.2]
+  class ::Profile < ApplicationRecord
+    def destroy_policy_test_results
+      DestroyProfilesJob.new.perform(policy_profiles.pluck(:id))
+    end
+  end
+
   def up
     DuplicateProfileResolver.run!
 


### PR DESCRIPTION
- Inline the sidekiq jobs for this migration
- Only delete profile_policies for non-canonical (account_id != nil) profiles

```
$ d-c exec rails bundle exec rake db:migrate                                                                         
2020-04-28T15:40:22.087Z 101 TID-go3cbv1r5 INFO: GitLab reliable fetch activated!                                                                                                             
**************************************************                                                                                                                                            
⛔️ WARNING: Sidekiq testing API enabled, but this is not the test environment.  Your jobs will not go to Redis.                                                                               
**************************************************                                                                                                                                            
== 20200325185540 AddUniqueIndexToProfiles: migrating =========================                                                                                                               
-- add_index(:profiles, [:ref_id, :account_id, :benchmark_id], {:unique=>true})                                                                                                               
   -> 0.0095s                                                                                                                                                                                 
== 20200325185540 AddUniqueIndexToProfiles: migrated (0.1736s) ================
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>