### PR TITLE
Add account_number to Openshift info

### DIFF
--- a/app/controllers/concerns/exception_notifier_custom_data.rb
+++ b/app/controllers/concerns/exception_notifier_custom_data.rb
@@ -14,7 +14,7 @@ module ExceptionNotifierCustomData
     request.env[
       'exception_notifier.exception_data'
     ] = OpenshiftEnvironment.summary.merge(
-      current_user: current_user
+      current_user: current_user.account.account_number
     )
   end
 end

--- a/app/services/openshift_environment.rb
+++ b/app/services/openshift_environment.rb
@@ -19,12 +19,17 @@ module OpenshiftEnvironment
       ENV['OPENSHIFT_BUILD_NAME']
     end
 
+    def namespace
+      ENV['NAMESPACE']
+    end
+
     def summary
       {
         environment: environment,
         application: application,
         pod: pod,
-        build: build
+        build: build,
+        namespace: namespace
       }
     end
   end

--- a/test/controllers/concerns/exception_notifier_custom_data_test.rb
+++ b/test/controllers/concerns/exception_notifier_custom_data_test.rb
@@ -10,11 +10,11 @@ class MocksController < ActionController::API
   def index; end
 
   def current_user
-    OpenStruct.new(:account => account)
+    OpenStruct.new(account: account)
   end
 
   def account
-    OpenStruct.new(:account_number => '12312931')
+    OpenStruct.new(account_number: '12312931')
   end
 end
 

--- a/test/controllers/concerns/exception_notifier_custom_data_test.rb
+++ b/test/controllers/concerns/exception_notifier_custom_data_test.rb
@@ -10,7 +10,11 @@ class MocksController < ActionController::API
   def index; end
 
   def current_user
-    :current_user
+    OpenStruct.new(:account => account)
+  end
+
+  def account
+    OpenStruct.new(:account_number => '12312931')
   end
 end
 
@@ -27,7 +31,7 @@ class ExceptionNotifierCustomDataTest < ActionDispatch::IntegrationTest
     get mocks_path
     assert_response :success
     assert_equal(
-      :current_user,
+      '12312931',
       response.request.env.dig(
         'exception_notifier.exception_data', :current_user
       )


### PR DESCRIPTION
Currently, the notifications we are getting contain the User object,
which is useless. Instead, we should get the account number to
help us understand better under which circumstances the exception
happened.