### PR TITLE
RHICOMPL-641 - Keep external profiles on associateProfiles

### DIFF
--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -12,8 +12,9 @@ module Mutations
 
       def resolve(args = {})
         host = find_hosts([args[:id]]).first
-        profiles = find_profiles(args[:profile_ids])
-        host.update(profiles: profiles)
+        external_profiles = host.profiles.where(external: true)
+        internal_profiles = find_profiles(args[:profile_ids])
+        host.update(profiles: internal_profiles + external_profiles)
         { system: host }
       end
 

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -108,6 +108,6 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     )['data']['associateProfiles']['system']
 
     expected_profiles = [external_profile, profiles(:one), profiles(:two)]
-    assert_equal expected_profiles, hosts(:one).reload.profiles
+    assert_equal expected_profiles.sort, hosts(:one).reload.profiles.to_a.sort
   end
 end


### PR DESCRIPTION
Currently if you associate profiles to a host, it removes the associations to external profiles. Those associations shouldn't be removed. 