### PR TITLE
[stable] Remove millions of duplicates from RuleReferencesRule

### DIFF
--- a/db/migrate/20200428143250_add_primary_key_to_rules_references.rb
+++ b/db/migrate/20200428143250_add_primary_key_to_rules_references.rb
@@ -1,0 +1,5 @@
+class AddPrimaryKeyToRulesReferences < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rule_references_rules, :id, :primary_key
+  end
+end

--- a/db/migrate/20200428205535_uniqueness_rule_references_rule_index.rb
+++ b/db/migrate/20200428205535_uniqueness_rule_references_rule_index.rb
@@ -1,0 +1,28 @@
+class UniquenessRuleReferencesRuleIndex < ActiveRecord::Migration[5.2]
+  class NewRuleReferencesRule < ApplicationRecord; end
+
+  def up
+    ids_to_keep = RuleReferencesRule.group(
+      'rule_id, rule_reference_id'
+    ).having('count(id) > 1').select(Arel.sql('MIN(id)'))
+    create_table :new_rule_references_rules, id: false do |t|
+      t.references :rule, type: :uuid, index: true, null: false
+      t.references :rule_reference, type: :uuid, index: true, null: false
+    end
+    columns = [:rule_id, :rule_reference_id]
+    batch_size = 10000
+    to_keep = RuleReferencesRule.where(id: ids_to_keep)
+    batches_to_run = to_keep.count/batch_size
+    to_keep.in_batches(of: batch_size).each_with_index do |batch, index|
+      puts "Inserting RRR batch, #{index} out of #{batches_to_run}"
+      NewRuleReferencesRule.import!(
+        columns,
+        batch.pluck(:rule_id, :rule_reference_id)
+      )
+    end
+    drop_table :rule_references_rules
+    rename_table :new_rule_references_rules, :rule_references_rules
+    add_index :rule_references_rules, %i[rule_id rule_reference_id],
+      unique: true
+  end
+end


### PR DESCRIPTION
This commit removes around 63M rows from RuleReferencesRule. Even though
there is a soft-validation in ActiveRecord on rule_id/reference_id, it's
completely skipped at the only place where we insert these records (in
the parser).

This greatly speeds up the SystemDetails page query, as we need to load
all RuleReferences for all rules there. The query, a simple SELECT *
from rule_references_rules WHERE rule_id IN (list of 1600 rules) goes
from 8 seconds to miliseconds. It also allows us to remove the
"DISTINCT" from the query, which was making us lose nearly 3s
sorting the records first.

As for the code itself:

1. I *must* add a primary key in order to identify the duplicate keys.
   Otherwise, you can identify them, but you cannot remove them (what
   are you even removing in that case)? It takes a while to add a
   primary key to 63M records but it's bearable (~5m)

(255122.1ms)  SELECT MIN(id) FROM "rule_references_rules" GROUP BY
rule_id, rule_reference_id
=> 456040
[4] pry(main)> ids = RuleReferencesRule.count
(1503.3ms)  SELECT COUNT(*) FROM "rule_references_rules"
=> 63694827

2. Removing the records directly, whether in batches or directly, is
   simply too slow. It would take around 160 hours to do it. Even after
   removing all indices from the table (which slow down the DELETE),
   it's too much.
   Each batch of 1000 records takes ~8s to delete, so
   (63238787/1000)*8/60/60 -> 140h!!!

   Instead, a usual method to solve this issue is to:
     1. Find all rows you want to keep.
     2. Build a new_rule_references_rules table
     3. Insert all of the records found on 1 in 2.
     4. Drop the original rule_references_rules table
     5. Rename the new_rule_references_rules
     6. Add an uniqueness index so this doesn't happen again.

   This takes around 21 minutes to run.
   == 20200428205535 UniquenessRuleReferencesRuleIndex: migrated
   (1300.7111s) ====

Before:
![Screenshot from 2020-04-28 16-44-52](https://user-images.githubusercontent.com/598891/80601548-40e37a80-8a2e-11ea-84c7-05e44e253c89.png)
![Screenshot from 2020-04-28 23-14-40](https://user-images.githubusercontent.com/598891/80601621-58226800-8a2e-11ea-9013-eb731b73a84c.png)
![Screenshot from 2020-04-28 23-15-10](https://user-images.githubusercontent.com/598891/80601628-59539500-8a2e-11ea-9b9b-3d484d166540.png)
After:
![Screenshot from 2020-04-29 15-28-41](https://user-images.githubusercontent.com/598891/80601467-24dfd900-8a2e-11ea-9bcb-059bcf591e0c.png)
![Screenshot from 2020-04-29 15-39-40](https://user-images.githubusercontent.com/598891/80602811-e21f0080-8a2f-11ea-8b2f-d664fbc07404.png)

:warning: If these rules were added through the mass INSERT ignoring soft-validations, it's likely now that will raise an error, so we might have to adapt the parser to that.

:heavy_check_mark: This *greatly* improves finding references, so the query to find RuleReferences in the system details view should be way faster.