### PR TITLE
RHICOMPL-622 - Deleting external profiles deletes Profile

### DIFF
--- a/app/controllers/concerns/exception_notifier_custom_data.rb
+++ b/app/controllers/concerns/exception_notifier_custom_data.rb
@@ -14,7 +14,7 @@ module ExceptionNotifierCustomData
     request.env[
       'exception_notifier.exception_data'
     ] = OpenshiftEnvironment.summary.merge(
-      current_user: current_user.account.account_number
+      current_user: current_user&.account&.account_number
     )
   end
 end

--- a/app/graphql/mutations/test_result/delete.rb
+++ b/app/graphql/mutations/test_result/delete.rb
@@ -15,6 +15,7 @@ module Mutations
       def resolve(args = {})
         profile = scoped_profiles.find(args[:profile_id])
         test_results = scoped_test_results(args).destroy_all
+        profile.destroy! if profile.external
 
         { profile: profile, test_results: test_results }
       end

--- a/test/graphql/mutations/delete_test_result_mutation_test.rb
+++ b/test/graphql/mutations/delete_test_result_mutation_test.rb
@@ -21,22 +21,46 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
 
   setup do
     users(:test).update! account: accounts(:test)
-    profiles(:one).update! account: accounts(:test)
+    profiles(:one).update! account: accounts(:test), hosts: [hosts(:one)]
     hosts(:one).update! account: accounts(:test)
     test_results(:one).update! host: hosts(:one), profile: profiles(:one)
   end
 
-  test 'delete a test result provided a profile ID' do
+  test 'delete a test result keeps the profile if not-external' do
+    profiles(:one).update(external: false)
     assert_difference('TestResult.count', -1) do
-      result = Schema.execute(
-        QUERY,
-        variables: { input: {
-          profileId: profiles(:one).id
-        } },
-        context: { current_user: users(:test) }
-      ).dig('data', 'deleteTestResults')
-      assert_equal profiles(:one).id, result.dig('profile', 'id')
-      assert_equal test_results(:one).id, result.dig('testResults', 0, 'id')
+      assert_difference('Profile.count', 0) do
+        assert_difference('ProfileHost.count', 0) do
+          result = Schema.execute(
+            QUERY,
+            variables: { input: {
+              profileId: profiles(:one).id
+            } },
+            context: { current_user: users(:test) }
+          ).dig('data', 'deleteTestResults')
+          assert_equal profiles(:one).id, result.dig('profile', 'id')
+          assert_equal test_results(:one).id, result.dig('testResults', 0, 'id')
+        end
+      end
+    end
+  end
+
+  test 'deleting results for external policy removes profile and profilehost' do
+    profiles(:one).update(external: true)
+    assert_difference('TestResult.count', -1) do
+      assert_difference('Profile.count', -1) do
+        assert_difference('ProfileHost.count', -1) do
+          result = Schema.execute(
+            QUERY,
+            variables: { input: {
+              profileId: profiles(:one).id
+            } },
+            context: { current_user: users(:test) }
+          ).dig('data', 'deleteTestResults')
+          assert_equal profiles(:one).id, result.dig('profile', 'id')
+          assert_equal test_results(:one).id, result.dig('testResults', 0, 'id')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Before this change, if you deleted a Report in the UI, external profiles
are still kept in the database. This doesn't make sense, as those
reports are only meant to exist to hold the definition of the profile
for the Report, so if the report goes away, so does the profile and the
profile host associations.

This is visible through the API but also on the UI, after removing an
external Report, the SystemsTable shows the Host still linked to the
external profile.