### PR TITLE
[stable] External files fixes & RBAC fail returns 403

### DIFF
--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -12,8 +12,9 @@ module Mutations
 
       def resolve(args = {})
         host = find_hosts([args[:id]]).first
-        profiles = find_profiles(args[:profile_ids])
-        host.update(profiles: profiles)
+        external_profiles = host.profiles.where(external: true)
+        internal_profiles = find_profiles(args[:profile_ids])
+        host.update(profiles: internal_profiles + external_profiles)
         { system: host }
       end
 

--- a/app/graphql/mutations/test_result/delete.rb
+++ b/app/graphql/mutations/test_result/delete.rb
@@ -15,6 +15,7 @@ module Mutations
       def resolve(args = {})
         profile = scoped_profiles.find(args[:profile_id])
         test_results = scoped_test_results(args).destroy_all
+        profile.destroy! if profile.external
 
         { profile: profile, test_results: test_results }
       end

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -57,7 +57,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     end
 
     should 'missing RBAC access for compliance' do
-      RbacApi.any_instance.expects(:check_user).returns(false)
+      RbacApi.any_instance.expects(:check_user)
       encoded_header = Base64.encode64(
         {
           'identity': {
@@ -72,7 +72,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
         }.to_json
       )
       get profiles_url, headers: { 'X-RH-IDENTITY': encoded_header }
-      assert_response :unauthorized
+      assert_response :forbidden
       assert_not User.current
     end
   end

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -72,4 +72,42 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     assert_not_nil(new_host = Host.find_by(id: NEW_ID))
     assert_equal new_host.profiles, [profiles(:one), profiles(:two)]
   end
+
+  test 'external profiles are kept after associating internal profiles' do
+    query = <<-GRAPHQL
+       mutation associateProfiles($input: associateProfilesInput!) {
+          associateProfiles(input: $input) {
+             system {
+                 id
+                 name
+             }
+          }
+       }
+    GRAPHQL
+    users(:test).update account: accounts(:test)
+    profiles(:one).update account: accounts(:test)
+    profiles(:two).update account: accounts(:test)
+    hosts(:one).update account: accounts(:test)
+
+    external_profile = Profile.create(
+      name: 'external',
+      ref_id: 'external',
+      benchmark: benchmarks(:one),
+      account: accounts(:test),
+      hosts: [hosts(:one)],
+      external: true
+    )
+
+    Schema.execute(
+      query,
+      variables: { input: {
+        id: hosts(:one).id,
+        profileIds: [profiles(:one).id, profiles(:two).id]
+      } },
+      context: { current_user: users(:test) }
+    )['data']['associateProfiles']['system']
+
+    expected_profiles = [external_profile, profiles(:one), profiles(:two)]
+    assert_equal expected_profiles.sort, hosts(:one).reload.profiles.to_a.sort
+  end
 end

--- a/test/graphql/mutations/delete_test_result_mutation_test.rb
+++ b/test/graphql/mutations/delete_test_result_mutation_test.rb
@@ -21,22 +21,46 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
 
   setup do
     users(:test).update! account: accounts(:test)
-    profiles(:one).update! account: accounts(:test)
+    profiles(:one).update! account: accounts(:test), hosts: [hosts(:one)]
     hosts(:one).update! account: accounts(:test)
     test_results(:one).update! host: hosts(:one), profile: profiles(:one)
   end
 
-  test 'delete a test result provided a profile ID' do
+  test 'delete a test result keeps the profile if not-external' do
+    profiles(:one).update(external: false)
     assert_difference('TestResult.count', -1) do
-      result = Schema.execute(
-        QUERY,
-        variables: { input: {
-          profileId: profiles(:one).id
-        } },
-        context: { current_user: users(:test) }
-      ).dig('data', 'deleteTestResults')
-      assert_equal profiles(:one).id, result.dig('profile', 'id')
-      assert_equal test_results(:one).id, result.dig('testResults', 0, 'id')
+      assert_difference('Profile.count', 0) do
+        assert_difference('ProfileHost.count', 0) do
+          result = Schema.execute(
+            QUERY,
+            variables: { input: {
+              profileId: profiles(:one).id
+            } },
+            context: { current_user: users(:test) }
+          ).dig('data', 'deleteTestResults')
+          assert_equal profiles(:one).id, result.dig('profile', 'id')
+          assert_equal test_results(:one).id, result.dig('testResults', 0, 'id')
+        end
+      end
+    end
+  end
+
+  test 'deleting results for external policy removes profile and profilehost' do
+    profiles(:one).update(external: true)
+    assert_difference('TestResult.count', -1) do
+      assert_difference('Profile.count', -1) do
+        assert_difference('ProfileHost.count', -1) do
+          result = Schema.execute(
+            QUERY,
+            variables: { input: {
+              profileId: profiles(:one).id
+            } },
+            context: { current_user: users(:test) }
+          ).dig('data', 'deleteTestResults')
+          assert_equal profiles(:one).id, result.dig('profile', 'id')
+          assert_equal test_results(:one).id, result.dig('testResults', 0, 'id')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/RedHatInsights/compliance-backend/pull/446, as it's failing smoke tests due to the removed GQL fields. 