### PR TITLE
Bump prometheus_exporter to >= 0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'faraday'
 gem 'friendly_id', '~> 5.2.4'
 gem 'scoped_search'
 gem 'will_paginate'
-gem 'prometheus_exporter'
+gem 'prometheus_exporter', '>= 0.5'
 
 gem 'activerecord-import'
 gem 'oj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       equatable (~> 0.6)
       tty-color (~> 0.5)
     pg (1.2.1)
-    prometheus_exporter (0.4.16)
+    prometheus_exporter (0.5.1)
     promise.rb (0.7.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -378,7 +378,7 @@ DEPENDENCIES
   oj
   openscap_parser (~> 1.0.0)
   pg
-  prometheus_exporter
+  prometheus_exporter (>= 0.5)
   pry-byebug
   pry-rails
   pry-remote


### PR DESCRIPTION
The -b (bind to address) option in prometheus_exporter was introduced in version 0.5.0. The current docker-compose.yml is broken because we have it locked at 0.4.16.

Signed-off-by: Andrew Kofink <akofink@redhat.com>