### PR TITLE
Adjust rule result pass/fail determination

### DIFF
--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -16,9 +16,12 @@ class RuleResult < ApplicationRecord
   validates :rule, presence: true,
                    uniqueness: { scope: %i[test_result_id host_id] }
 
-  SELECTED = %w[pass fail notapplicable error unknown].freeze
-  FAIL = %w[fail error unknown notchecked].freeze
+  POSSIBLE_RESULTS = %w[pass fail error unknown notapplicable notchecked
+                        notselected informational fixed].freeze
+  NOT_SELECTED = %w[notapplicable notchecked informational notselected].freeze
+  SELECTED = (POSSIBLE_RESULTS - NOT_SELECTED).freeze
   PASSED = %w[pass].freeze
+  FAIL = (SELECTED - PASSED).freeze
 
   scope :passed, -> { where(result: PASSED) }
   scope :selected, -> { where(result: SELECTED) }

--- a/app/services/concerns/xccdf/rule_results.rb
+++ b/app/services/concerns/xccdf/rule_results.rb
@@ -17,7 +17,7 @@ module Xccdf
 
     def selected_op_rule_results
       @op_rule_results.reject do |rule_result|
-        rule_result.result == 'notselected'
+        ::RuleResult::NOT_SELECTED.include? rule_result.result
       end
     end
 

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -151,12 +151,12 @@ class XccdfReportParserTest < ActiveSupport::TestCase
 
   context 'rule results' do
     should 'save them, associate them with a rule and a host' do
-      assert_difference('RuleResult.count', 74) do
+      assert_difference('RuleResult.count', 59) do
         @report_parser.save_all
         rule_results = @report_parser.rule_results
         op_rule_results = @report_parser.op_rule_results
         selected_op_rule_results = op_rule_results.reject do |rr|
-          rr.result == 'notselected'
+          RuleResult::NOT_SELECTED.include? rr.result
         end
 
         assert_equal @report_parser.test_result_file.test_result.host,


### PR DESCRIPTION
From the XCCDF 1.2 spec:

![image](https://user-images.githubusercontent.com/761923/81012756-17f52800-8e28-11ea-83f9-57d1674c6a4e.png)

![Screenshot from 2020-05-04 12-04-08](https://user-images.githubusercontent.com/761923/81012710-04e25800-8e28-11ea-86a6-384c2fb53c59.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>