### PR TITLE
Use sets to determine equality in profile mutation test

### DIFF
--- a/test/graphql/mutations/create_profile_mutation_test.rb
+++ b/test/graphql/mutations/create_profile_mutation_test.rb
@@ -60,7 +60,8 @@ class CreateProfileMutationTest < ActiveSupport::TestCase
     cloned_profile = ::Profile.find(result['id'])
     assert cloned_profile.ref_id, 'xccdf-customized'
     assert_not_equal cloned_profile.rules, @original_profile.rules
-    assert_equal cloned_profile.rules, Rule.where(ref_id: tailored_rules)
+    assert_equal Set.new(cloned_profile.rules),
+                 Set.new(Rule.where(ref_id: tailored_rules))
     assert_equal cloned_profile.parent_profile, @original_profile
   end
 end


### PR DESCRIPTION
They are just (rarely) sometimes out of order

```rb
[1] pry(main)> [3, 5] == [5, 3]
=> false
[2] pry(main)> Set.new([3, 5]) == Set.new([5, 3])
=> true
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>