### PR TITLE
Ignore coverage in lib for simplecov and codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,3 @@
-ignore:
-  - 'lib'
 coverage:
   status:
     project:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ unless Rails.env.production?
     # API responses, no code (https://github.com/Netflix/fast_jsonapi)
     add_filter 'app/serializers'
     # empty class that has to be there for prometheus integration
-    add_filter 'lib/graphql_collector.rb'
+    add_filter 'lib/'
   end
 
   if ENV['CODECOV_TOKEN']


### PR DESCRIPTION
When running tests locally, the .codecov.yml is not honored because
coverage is using simplecov without the codecov formatter.

Note that the coverage doesn't change for codecov reported on this PR.

Signed-off-by: Andrew Kofink <akofink@redhat.com>