### PR TITLE
Do not initialize Sidekiq client or prometheus_exporter from prometheus-exporter

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,4 +1,4 @@
-if Rails.env != "test"
+if Rails.env != "test" && !$0.include?('prometheus_exporter')
   require 'prometheus_exporter/client'
   require 'prometheus_exporter/metric'
   require 'prometheus_exporter/middleware'

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -20,6 +20,8 @@ sidekiq_config = lambda do |config|
   end
 end
 
+return if $0.include?('prometheus_exporter')
+
 if $0.include?('sidekiq')
   Sidekiq.configure_server(&sidekiq_config)
 end


### PR DESCRIPTION
From prometheus_exporter, it doesn't make sense a lot of sense
to send metrics to itself. Similarly initializing sidekiq is also
useless from prometheus_exporter.