### PR TITLE
[stable] Find RuleReferencesRule if they're present in the db (#456)

### DIFF
--- a/app/services/concerns/xccdf/rule_references_rules.rb
+++ b/app/services/concerns/xccdf/rule_references_rules.rb
@@ -9,7 +9,8 @@ module Xccdf
       def save_rule_references_rules
         @rule_references_rules ||= @op_rules.flat_map do |op_rule|
           rule_references_for(op_rule: op_rule).map do |reference|
-            ::RuleReferencesRule.new(rule_reference_id: reference.id,
+            ::RuleReferencesRule
+              .find_or_initialize_by(rule_reference_id: reference.id,
                                      rule_id: rule_for(ref_id: op_rule.id).id)
           end
         end

--- a/test/services/concerns/xccdf/rule_references_rules_test.rb
+++ b/test/services/concerns/xccdf/rule_references_rules_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/rule_references'
+
+# A class to test saving RuleReferencesRules from OpenscapParser
+class RuleReferencesRulesTest < ActiveSupport::TestCase
+  include Xccdf::RuleReferencesRules
+
+  test 'only new rule references rules are saved' do
+    @rules = [rules(:one), rules(:two)]
+    @rule_references = [rule_references(:one), rule_references(:two)]
+    @op_rules = [
+      OpenStruct.new(id: rules(:one).ref_id,
+                     rule_references: [rule_references(:one)])
+    ]
+
+    assert_difference('RuleReferencesRule.count', 1) do
+      save_rule_references_rules
+    end
+
+    @rule_references_rules = nil # un-cache it from ||=
+    @op_rules = [
+      OpenStruct.new(id: rules(:one).ref_id,
+                     rule_references: [rule_references(:one)]),
+      OpenStruct.new(id: rules(:two).ref_id,
+                     rule_references: [rule_references(:two)])
+    ]
+
+    assert_difference('RuleReferencesRule.count', 1) do
+      save_rule_references_rules
+    end
+
+    assert_difference('RuleReferencesRule.count', 0) do
+      save_rule_references_rules
+    end
+  end
+end


### PR DESCRIPTION
This enables uploads for unknown SSG OS/versions again, right now the uniqueness constraint will break them as they'll try to introduce RRR duplicates. 