### PR TITLE
[stable] Remove newrelic_rpm, tty-command, docker-api, attr_encrypted (#459)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,19 +8,8 @@ gem 'rails', '~> 5.2.1'
 gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.12'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.5'
-# Use Redis adapter to run Action Cable in production
+# Use Redis adapter to connect to Sidekiq
 gem 'redis', '~> 4.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
@@ -45,34 +34,32 @@ gem 'fast_jsonapi'
 gem 'graphql'
 gem 'graphql-batch'
 
-# Pundit
+# Pundit authorization system
 gem 'pundit'
 
+# Alarms and notifications
 gem 'exception_notification'
 gem 'slack-notifier'
 
-# Sidekiq
+# Sidekiq - use reliable-fetch by Gitlab
 gem 'sidekiq'
+gem 'gitlab-sidekiq-fetcher', require: 'sidekiq-reliable-fetch'
 
-gem 'tty-command'
-
-gem 'attr_encrypted'
-
-gem 'docker-api'
-
+# Faraday to make requests easier
 gem 'faraday'
+
+# Helpers for models, pagination, mass import
 gem 'friendly_id', '~> 5.2.4'
 gem 'scoped_search'
 gem 'will_paginate'
-gem 'prometheus_exporter', '>= 0.5'
-
-gem 'activerecord-import'
+gem 'activerecord-import' # Substitute on upgrade to Rails 6
 gem 'oj'
-gem 'newrelic_rpm'
-gem 'gitlab-sidekiq-fetcher', require: 'sidekiq-reliable-fetch'
-
 gem 'uuid'
 
+# Prometheus exporter
+gem 'prometheus_exporter', '>= 0.5'
+
+# Parsing OpenSCAP reports library
 gem 'openscap_parser', '~> 1.0.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,8 +49,6 @@ GEM
     ansi (1.5.0)
     arel (9.0.0)
     ast (2.4.0)
-    attr_encrypted (3.1.0)
-      encryptor (~> 3.0.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     brakeman (4.7.2)
@@ -76,9 +74,6 @@ GEM
     diff-lcs (1.3)
     digest-crc (0.4.1)
     docile (1.3.2)
-    docker-api (1.34.2)
-      excon (>= 0.47.0)
-      multi_json
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -120,13 +115,10 @@ GEM
       dry-equalizer (~> 0.2)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.0, >= 1.4.3)
-    encryptor (3.0.0)
-    equatable (0.6.1)
     erubi (1.9.0)
     exception_notification (4.4.0)
       actionmailer (>= 4.0, < 7)
       activesupport (>= 4.0, < 7)
-    excon (0.71.1)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     fast_jsonapi (1.5)
@@ -181,9 +173,7 @@ GEM
       ruby-progressbar
     mocha (1.11.2)
     msgpack (1.3.1)
-    multi_json (1.14.1)
     multipart-post (2.1.1)
-    newrelic_rpm (6.8.0.360)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -193,9 +183,6 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
-    pastel (0.7.3)
-      equatable (~> 0.6)
-      tty-color (~> 0.5)
     pg (1.2.1)
     prometheus_exporter (0.5.1)
     promise.rb (0.7.4)
@@ -329,9 +316,6 @@ GEM
     systemu (2.6.5)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tty-color (0.5.0)
-    tty-command (0.9.0)
-      pastel (~> 0.7.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -353,14 +337,12 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
-  attr_encrypted
   bootsnap (>= 1.1.0)
   brakeman
   bullet
   byebug
   codecov
   config
-  docker-api
   dotenv-rails
   exception_notification
   faraday
@@ -374,7 +356,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   minitest-reporters
   mocha
-  newrelic_rpm
   oj
   openscap_parser (~> 1.0.0)
   pg
@@ -403,7 +384,6 @@ DEPENDENCIES
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
-  tty-command
   tzinfo-data
   uuid
   webmock

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,5 @@
 host_inventory_url: https://insights-inventory-platform-ci.ask-on-slack-for-the-inventory-devel-url
 rbac_url: https://insights-inventory-platform-ci.ask-on-slack-for-the-rbac-devel-url
-openshift_tokens_secret: MTwXl7kVp4inTho3N6aiw/7fr8iBJv49HwodiPHIdaw=
 #prometheus_exporter_host: prometheus
 #prometheus_exporter_port: 9394
 redis_url: redis:6379

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,2 @@
 host_inventory_url: http://test-host-inventory:8000
 rbac_url: http://test-rbac-url:9002
-openshift_tokens_secret: MTwXl7kVp4inTho3N6aiw/7fr8iBJv49HwodiPHIdaw=

--- a/openshift/Jenkins/slave_pod_template.yaml
+++ b/openshift/Jenkins/slave_pod_template.yaml
@@ -55,8 +55,6 @@ spec:
       value: db_admin_password
     - name: POSTGRESQL_DATABASE
       value: compliance
-    - name: SECRET_KEY_BASE
-      value: secret_key_base
     - name: RAILS_ENV
       value: test
     - name: QMAKE


### PR DESCRIPTION
These gems are currently loaded and installed with the image when they
are just cruft from when we had the requirement of scanning ImageStreams
from an Openshift cluster.

A PR in e2e will follow which removes these. Also, the Gemfile is
reorganized a bit better.