### PR TITLE
Update local dev to require redis for rails

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     depends_on:
       - db
       - prometheus
+      - redis
   reports-consumer:
     image: compliance-backend-rails
     restart: on-failure


### PR DESCRIPTION
Rails needs redis now for async tasks in Sidekiq. Now that we have a
redis_url set, without redis we get constant errors about not being able
to connect.

Signed-off-by: Andrew Kofink <akofink@redhat.com>