### PR TITLE
RHICOMPL-622 - Delete hosts when they become orphaned

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,7 +14,7 @@ class Profile < ApplicationRecord
 
   has_many :profile_rules, dependent: :delete_all
   has_many :rules, through: :profile_rules, source: :rule
-  has_many :profile_hosts, dependent: :delete_all
+  has_many :profile_hosts, dependent: :destroy
   has_many :hosts, through: :profile_hosts, source: :host
   has_many :test_results, dependent: :destroy
   belongs_to :account, optional: true

--- a/app/models/profile_host.rb
+++ b/app/models/profile_host.rb
@@ -12,6 +12,12 @@ class ProfileHost < ApplicationRecord
   after_destroy :destroy_orphaned_host
 
   def destroy_orphaned_host
-    DeleteHost.perform_async(id: host.id) if host.profiles.empty?
+    return unless host.profiles.empty?
+
+    if Settings.async
+      DeleteHost.perform_async(id: host.id)
+    else
+      DeleteHost.new.perform(id: host.id)
+    end
   end
 end

--- a/app/models/profile_host.rb
+++ b/app/models/profile_host.rb
@@ -8,4 +8,10 @@ class ProfileHost < ApplicationRecord
 
   validates :profile, presence: true
   validates :host, presence: true, uniqueness: { scope: :profile }
+
+  after_destroy :destroy_orphaned_host
+
+  def destroy_orphaned_host
+    DeleteHost.perform_async(id: host.id) if host.profiles.empty?
+  end
 end

--- a/test/models/profile_host_test.rb
+++ b/test/models/profile_host_test.rb
@@ -1,11 +1,27 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'sidekiq/testing'
 
 class ProfileHostTest < ActiveSupport::TestCase
   setup do
     @profile = profiles(:one)
     @host = hosts(:one)
     @profile_host = ProfileHost.new(profile: @profile, host: @host)
+  end
+
+  test 'destroys associated hosts if host has no more policies assigned' do
+    profile = Profile.create(name: 'foo', benchmark: benchmarks(:one),
+                          ref_id: 'foo')
+    host = Host.create(profiles: [profile], name: 'bar',
+                       account: accounts(:one))
+    assert_equal 0, DeleteHost.jobs.size
+    profile.destroy
+    assert_equal 1, DeleteHost.jobs.size
+    assert_difference('Host.count', -1) do
+      DeleteHost.drain
+    end
+    assert_empty Host.where(id: host.id)
+    assert_equal 0, DeleteHost.jobs.size
   end
 end

--- a/test/models/profile_host_test.rb
+++ b/test/models/profile_host_test.rb
@@ -5,14 +5,12 @@ require 'sidekiq/testing'
 
 class ProfileHostTest < ActiveSupport::TestCase
   setup do
-    @profile = profiles(:one)
-    @host = hosts(:one)
-    @profile_host = ProfileHost.new(profile: @profile, host: @host)
+    DeleteHost.clear
   end
 
   test 'destroys associated hosts if host has no more policies assigned' do
     profile = Profile.create(name: 'foo', benchmark: benchmarks(:one),
-                          ref_id: 'foo')
+                             ref_id: 'foo')
     host = Host.create(profiles: [profile], name: 'bar',
                        account: accounts(:one))
     assert_equal 0, DeleteHost.jobs.size


### PR DESCRIPTION
I still need to test this actually on the UI, but in theory this is all that's needed not to leave orphaned hosts around in our database when they no longer have any profile assigned. 