### PR TITLE
RHICOMPL-650 - Delete cached latest_supported_rhel benchmarks

### DIFF
--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -8,6 +8,7 @@ namespace :ssg do
   task import_rhel: [:environment, 'ssg:sync_rhel'] do
     # DATASTREAM_FILENAMES from openscap_parser's ssg:sync_rhel
     begin
+      Rails.cache.delete('latest_supported_benchmarks')
       DATASTREAM_FILENAMES.flatten.each do |filename|
         start = Time.zone.now
         puts "Importing #{filename} at #{start}"
@@ -27,6 +28,7 @@ namespace :ssg do
   task import_rhel_supported: [:environment] do
     # DATASTREAM_FILENAMES from openscap_parser's ssg:sync
     begin
+      Rails.cache.delete('latest_supported_benchmarks')
       ENV['DATASTREAMS'] = ::Xccdf::Benchmark::
         LATEST_SUPPORTED_VERSIONS.map do |ref_id, version|
         "v#{version}:rhel#{ref_id[/\d+$/]}"


### PR DESCRIPTION
There's a cached field called 'latest_supported_benchmarks' to avoid
making the same SQL call always to show the latest benchmarks in the
Create Policy wizard. Notice this will NOT affect customers unless we
change the LATEST_SUPPORTED_VERSIONS. This was visible on CI because the
import-job failed (killed OOM or something), so I'm going to clear the
field before the import-latest-rhel-supported job starts.