### PR TITLE
Delete old test results when new ones are saved

### DIFF
--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -11,6 +11,16 @@ module Xccdf
         start_time: @op_test_result.start_time.in_time_zone,
         end_time: @op_test_result.end_time.in_time_zone
       )
+
+      delete_old_test_results if @test_result.persisted?
+
+      @test_result
+    end
+
+    def delete_old_test_results
+      ::TestResult.where(host: @host, profile: @host_profile)
+                  .where.not(id: @test_result.id)
+                  .destroy_all
     end
   end
 end

--- a/test/services/concerns/xccdf/test_result_test.rb
+++ b/test/services/concerns/xccdf/test_result_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/test_result'
+
+class TestResultTest < ActiveSupport::TestCase
+  class Mock
+    include Xccdf::TestResult
+
+    attr_accessor :host, :host_profile, :op_test_result
+  end
+
+  setup do
+    ProfileHost.create!(host: hosts(:one), profile: profiles(:one))
+    @end_time = DateTime.now
+    @mock = Mock.new
+    @mock.host = hosts(:one)
+    @mock.host_profile = profiles(:one)
+    @mock.op_test_result = OpenStruct.new(score: 30,
+                                          start_time: @end_time - 2.minutes,
+                                          end_time: @end_time)
+  end
+
+  test 'old test results are destroyed and replaced by the new test result' do
+    TestResult.where(host: hosts(:one), profile: profiles(:one)).destroy_all
+
+    assert_difference('TestResult.count' => 2) do
+      TestResult.create!(host: hosts(:one),
+                         profile: profiles(:one),
+                         end_time: @end_time - 3.minutes)
+
+      TestResult.create!(host: hosts(:one),
+                         profile: profiles(:one),
+                         end_time: @end_time - 8.minutes)
+    end
+
+    assert_difference('TestResult.count' => -1) do
+      @mock.save_test_result
+    end
+  end
+end


### PR DESCRIPTION
This should help keep our DB lean until we need to implement historical results. At that point, this code should be very easily reversed. From prod:

```rb
irb(main):001:0> [TestResult.count, TestResult.latest.count]
=> [4088, 1521]
```

Fixes https://projects.engineering.redhat.com/browse/RHICOMPL-634

Signed-off-by: Andrew Kofink <akofink@redhat.com>