### PR TITLE
Add remaining DB uniqueness constraints to stable

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -20,6 +20,7 @@ class Host < ApplicationRecord
   has_many :profiles, through: :profile_hosts, source: :profile
 
   validates :name, presence: true
+  validates :account, presence: true
 
   class << self
     def filter_by_compliance(_filter, operator, value)

--- a/app/models/rule_identifier.rb
+++ b/app/models/rule_identifier.rb
@@ -4,8 +4,9 @@
 class RuleIdentifier < ApplicationRecord
   belongs_to :rule
 
-  validates :label, presence: true
-  validates :system, presence: true
+  validates :label, presence: true, uniqueness: { scope: %i[system rule_id] }
+  validates :system, presence: true, uniqueness: { scope: %i[label rule_id] }
+  validates :rule, presence: true, uniqueness: { scope: %i[label system] }
 
   def self.from_openscap_parser(op_rule_identifier, rule_id)
     if op_rule_identifier.label # rubocop:disable Style/GuardClause

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -9,9 +9,12 @@ class RuleResult < ApplicationRecord
   belongs_to :rule
   belongs_to :test_result
 
-  validates :test_result, presence: true
-  validates :host, presence: true
-  validates :rule, presence: true
+  validates :test_result, presence: true,
+                          uniqueness: { scope: %i[host_id rule_id] }
+  validates :host, presence: true,
+                   uniqueness: { scope: %i[test_result_id rule_id] }
+  validates :rule, presence: true,
+                   uniqueness: { scope: %i[test_result_id host_id] }
 
   POSSIBLE_RESULTS = %w[pass fail error unknown notapplicable notchecked
                         notselected informational fixed].freeze

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -9,8 +9,12 @@ class TestResult < ApplicationRecord
   has_many :rule_results, dependent: :delete_all
   has_many :rules, through: :rule_results
 
-  validates :host_id, presence: true
-  validates :profile_id, presence: true
+  validates :host, presence: true,
+                   uniqueness: { scope: %i[profile_id end_time] }
+  validates :profile, presence: true,
+                      uniqueness: { scope: %i[host_id end_time] }
+  validates :end_time, presence: true,
+                       uniqueness: { scope: %i[host_id profile_id] }
 
   scope :latest, lambda {
     joins("JOIN (#{latest_without_ids.to_sql}) as tr on "\

--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate Xccdf::Benchmark objects
+class DuplicateBenchmarkResolver
+  class << self
+    def run!
+      each_benchmark do |bm|
+        if benchmarks[[bm.ref_id, bm.version]]
+          migrate_benchmark(benchmarks[[bm.ref_id, bm.version]], bm)
+        else
+          benchmarks[[bm.ref_id, bm.version]] = bm
+        end
+      end
+    end
+
+    private
+
+    def migrate_benchmark(existing_bm, duplicate_bm)
+      migrate_rules(existing_bm, duplicate_bm)
+      migrate_profiles(existing_bm, duplicate_bm)
+      duplicate_bm.destroy! # profiles, rules
+    end
+
+    def each_benchmark
+      Xccdf::Benchmark.transaction do
+        Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
+          yield bm
+        end
+      end
+    end
+
+    def benchmarks
+      @benchmarks ||= {}
+    end
+
+    def migrate_rules(existing_bm, duplicate_bm)
+      duplicate_bm.rules.find_each do |rule|
+        if existing_bm.rules.pluck(:ref_id).include?(rule.ref_id)
+          migrate_rule(existing_bm.rules.find_by(ref_id: rule.ref_id), rule)
+        else
+          rule.update!(benchmark_id: existing_bm.id)
+        end
+      end
+    end
+
+    def migrate_rule(existing_rule, duplicate_rule)
+      duplicate_rule.rule_results.update(rule_id: existing_rule.id)
+      duplicate_rule
+        .destroy # profile_rules, rule_references_rules, rule_identifier
+    end
+
+    def migrate_profiles(existing_bm, duplicate_bm)
+      duplicate_bm.profiles.find_each do |profile|
+        if existing_bm.profiles.pluck(:ref_id, :account_id)
+                      .include?([profile.ref_id, profile.account_id])
+          migrate_profile(existing_bm.profiles.find_by(ref_id: profile.ref_id),
+                          profile)
+        else
+          profile.update!(benchmark_id: existing_bm.id)
+        end
+      end
+    end
+
+    def migrate_profile(existing_profile, duplicate_profile)
+      duplicate_profile.profile_hosts.update(
+        profile_id: existing_profile.id
+      )
+      duplicate_profile.destroy # profile_rules, profile_hosts
+    end
+  end
+end

--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -16,6 +16,9 @@ class DuplicateBenchmarkResolver
     private
 
     def migrate_benchmark(existing_bm, duplicate_bm)
+      logger.info(
+        "Duplicate benchmark found for #{existing_bm.id} - #{duplicate_bm.id}"
+      )
       migrate_rules(existing_bm, duplicate_bm)
       migrate_profiles(existing_bm, duplicate_bm)
       duplicate_bm.delete
@@ -37,13 +40,23 @@ class DuplicateBenchmarkResolver
     # we expect validations to fail due to nonunique rules/profiles
     # accept duplicate rules for now
     def migrate_rules(existing_bm, duplicate_bm)
+      logger.info(
+        "Migrating rules for #{existing_bm.id} - #{duplicate_bm.id}..."
+      )
       duplicate_bm.rules.update_all(benchmark_id: existing_bm.id)
     end
 
     # accept duplicate profiles for now
     def migrate_profiles(existing_bm, duplicate_bm)
+      logger.info(
+        "Migrating profiles for #{existing_bm.id} - #{duplicate_bm.ref_id}..."
+      )
       duplicate_bm.profiles.update_all(benchmark_id: existing_bm.id)
     end
     # rubocop:enable Rails/SkipsModelValidations
+
+    def logger
+      Rails.logger
+    end
   end
 end

--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -18,12 +18,12 @@ class DuplicateBenchmarkResolver
     def migrate_benchmark(existing_bm, duplicate_bm)
       migrate_rules(existing_bm, duplicate_bm)
       migrate_profiles(existing_bm, duplicate_bm)
-      duplicate_bm.destroy! # profiles, rules
+      duplicate_bm.delete
     end
 
     def each_benchmark
-      Xccdf::Benchmark.transaction do
-        Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
+      Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
+        Xccdf::Benchmark.transaction do
           yield bm
         end
       end
@@ -33,39 +33,17 @@ class DuplicateBenchmarkResolver
       @benchmarks ||= {}
     end
 
+    # rubocop:disable Rails/SkipsModelValidations
+    # we expect validations to fail due to nonunique rules/profiles
+    # accept duplicate rules for now
     def migrate_rules(existing_bm, duplicate_bm)
-      duplicate_bm.rules.find_each do |rule|
-        if existing_bm.rules.pluck(:ref_id).include?(rule.ref_id)
-          migrate_rule(existing_bm.rules.find_by(ref_id: rule.ref_id), rule)
-        else
-          rule.update!(benchmark_id: existing_bm.id)
-        end
-      end
+      duplicate_bm.rules.update_all(benchmark_id: existing_bm.id)
     end
 
-    def migrate_rule(existing_rule, duplicate_rule)
-      duplicate_rule.rule_results.update(rule_id: existing_rule.id)
-      duplicate_rule
-        .destroy # profile_rules, rule_references_rules, rule_identifier
-    end
-
+    # accept duplicate profiles for now
     def migrate_profiles(existing_bm, duplicate_bm)
-      duplicate_bm.profiles.find_each do |profile|
-        if existing_bm.profiles.pluck(:ref_id, :account_id)
-                      .include?([profile.ref_id, profile.account_id])
-          migrate_profile(existing_bm.profiles.find_by(ref_id: profile.ref_id),
-                          profile)
-        else
-          profile.update!(benchmark_id: existing_bm.id)
-        end
-      end
+      duplicate_bm.profiles.update_all(benchmark_id: existing_bm.id)
     end
-
-    def migrate_profile(existing_profile, duplicate_profile)
-      duplicate_profile.profile_hosts.update(
-        profile_id: existing_profile.id
-      )
-      duplicate_profile.destroy # profile_rules, profile_hosts
-    end
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/app/services/duplicate_benchmark_resolver.rb
+++ b/app/services/duplicate_benchmark_resolver.rb
@@ -4,54 +4,89 @@
 class DuplicateBenchmarkResolver
   class << self
     def run!
-      each_benchmark do |bm|
-        if benchmarks[[bm.ref_id, bm.version]]
-          migrate_benchmark(benchmarks[[bm.ref_id, bm.version]], bm)
+      @benchmarks = nil
+      duplicate_benchmarks.find_each do |bm|
+        if existing_benchmark(bm)
+          migrate_benchmark(existing_benchmark(bm), bm)
         else
-          benchmarks[[bm.ref_id, bm.version]] = bm
+          self.existing_benchmark = bm
         end
       end
     end
 
     private
 
-    def migrate_benchmark(existing_bm, duplicate_bm)
-      logger.info(
-        "Duplicate benchmark found for #{existing_bm.id} - #{duplicate_bm.id}"
-      )
-      migrate_rules(existing_bm, duplicate_bm)
-      migrate_profiles(existing_bm, duplicate_bm)
-      duplicate_bm.delete
+    def existing_benchmark(benchmark)
+      benchmarks[[benchmark.ref_id, benchmark.version]]
     end
 
-    def each_benchmark
-      Xccdf::Benchmark.includes(:rules, :profiles).find_each do |bm|
-        Xccdf::Benchmark.transaction do
-          yield bm
-        end
-      end
+    def existing_benchmark=(benchmark)
+      benchmarks[[benchmark.ref_id, benchmark.version]] = benchmark
     end
 
     def benchmarks
       @benchmarks ||= {}
     end
 
+    def duplicate_benchmarks
+      Xccdf::Benchmark.joins(
+        "JOIN (#{grouped_nonunique_benchmark_tuples.to_sql}) as bm on "\
+        'benchmarks.ref_id = bm.ref_id AND '\
+        'benchmarks.version = bm.version'
+      )
+    end
+
+    def grouped_nonunique_benchmark_tuples
+      Xccdf::Benchmark.select(:ref_id, :version)
+                      .group(:ref_id, :version)
+                      .having('COUNT(id) > 1')
+    end
+
+    def migrate_benchmark(existing_bm, duplicate_bm)
+      logger.info(
+        "Duplicate benchmark found for #{existing_bm.id} - #{duplicate_bm.id}"
+      )
+      migrate_rules(existing_bm, duplicate_bm)
+      migrate_parent_profiles(existing_bm, duplicate_bm)
+      migrate_profiles(existing_bm, duplicate_bm)
+      remove_remaining_parent_profiles(duplicate_bm)
+      duplicate_bm.destroy # Rules, Profiles
+    end
+
     # rubocop:disable Rails/SkipsModelValidations
-    # we expect validations to fail due to nonunique rules/profiles
-    # accept duplicate rules for now
     def migrate_rules(existing_bm, duplicate_bm)
       logger.info(
         "Migrating rules for #{existing_bm.id} - #{duplicate_bm.id}..."
       )
-      duplicate_bm.rules.update_all(benchmark_id: existing_bm.id)
+      duplicate_bm.rules.where.not(ref_id: existing_bm.rules.select(:ref_id))
+                  .update_all(benchmark_id: existing_bm.id)
     end
 
-    # accept duplicate profiles for now
+    def migrate_parent_profiles(existing_bm, duplicate_bm)
+      duplicate_bm.profiles.where.not(
+        ref_id: existing_bm.profiles.select(:ref_id),
+        parent_profile_id: nil
+      ).find_each do |profile|
+        profile.update!(
+          parent_profile: existing_bm.profiles.canonical.find_by!(
+            ref_id: profile.parent_profile.ref_id
+          )
+        )
+      end
+    end
+
+    def remove_remaining_parent_profiles(duplicate_bm)
+      duplicate_bm.profiles.where.not(parent_profile_id: nil)
+                  .update_all(parent_profile_id: nil)
+    end
+
     def migrate_profiles(existing_bm, duplicate_bm)
       logger.info(
         "Migrating profiles for #{existing_bm.id} - #{duplicate_bm.ref_id}..."
       )
-      duplicate_bm.profiles.update_all(benchmark_id: existing_bm.id)
+      duplicate_bm.profiles.where.not(
+        ref_id: existing_bm.profiles.select(:ref_id)
+      ).update_all(benchmark_id: existing_bm.id)
     end
     # rubocop:enable Rails/SkipsModelValidations
 

--- a/app/services/duplicate_profile_resolver.rb
+++ b/app/services/duplicate_profile_resolver.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate Profile objects
+class DuplicateProfileResolver
+  class << self
+    def run!
+      @profiles = nil
+      duplicate_profiles.find_each do |profile|
+        if existing_profile(profile)
+          migrate_profile(existing_profile(profile), profile)
+        else
+          self.existing_profile = profile
+        end
+      end
+    end
+
+    private
+
+    def existing_profile(profile)
+      profiles[[profile.ref_id, profile.account_id, profile.benchmark_id]]
+    end
+
+    def existing_profile=(profile)
+      profiles[[profile.ref_id,
+                profile.account_id,
+                profile.benchmark_id]] = profile
+    end
+
+    def profiles
+      @profiles ||= {}
+    end
+
+    def migrate_profile(existing_p, duplicate_p)
+      migrate_profile_hosts(existing_p, duplicate_p)
+      migrate_test_results(existing_p, duplicate_p)
+      migrate_child_profiles(existing_p, duplicate_p)
+      duplicate_p.destroy # BusinessObjectives, ProfileRules
+    end
+
+    def duplicate_profiles
+      Profile.joins(
+        "JOIN (#{grouped_nonunique_profile_tuples.to_sql}) as p on "\
+        'profiles.ref_id = p.ref_id AND '\
+        'profiles.account_id is not distinct from p.account_id AND '\
+        'profiles.benchmark_id = p.benchmark_id'
+      )
+    end
+
+    def grouped_nonunique_profile_tuples
+      Profile.select(:ref_id, :account_id, :benchmark_id)
+             .group(:ref_id, :account_id, :benchmark_id)
+             .having('COUNT(id) > 1')
+    end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def migrate_profile_hosts(existing_p, duplicate_p)
+      duplicate_p.profile_hosts.where.not(host: existing_p.hosts)
+                 .update_all(profile_id: existing_p.id)
+    end
+
+    def migrate_test_results(existing_p, duplicate_p)
+      duplicate_p.test_results.update_all(profile_id: existing_p.id)
+    end
+
+    def migrate_child_profiles(existing_p, duplicate_p)
+      Profile.where(parent_profile: duplicate_p)
+             .update_all(parent_profile_id: existing_p.id)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/app/services/duplicate_rule_reference_resolver.rb
+++ b/app/services/duplicate_rule_reference_resolver.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate RuleReference objects
+class DuplicateRuleReferenceResolver
+  class << self
+    def run!
+      @rule_references = nil
+      duplicate_rule_references.find_each do |rule_reference|
+        if existing_rule_reference(rule_reference)
+          migrate_rule_reference(existing_rule_reference(rule_reference),
+                                 rule_reference)
+        else
+          self.existing_rule_reference = rule_reference
+        end
+      end
+    end
+
+    private
+
+    def existing_rule_reference(rule_reference)
+      rule_references[[rule_reference.href, rule_reference.label]]
+    end
+
+    def existing_rule_reference=(rule_reference)
+      rule_references[[rule_reference.href,
+                       rule_reference.label]] = rule_reference
+    end
+
+    def rule_references
+      @rule_references ||= {}
+    end
+
+    def duplicate_rule_references
+      RuleReference.joins(
+        "JOIN (#{grouped_nonunique_rule_reference_tuples.to_sql}) as rr on "\
+        'rule_references.href = rr.href AND '\
+        'rule_references.label = rr.label'
+      )
+    end
+
+    def grouped_nonunique_rule_reference_tuples
+      RuleReference.select(:href, :label).group(:href, :label)
+                   .having('COUNT(id) > 1')
+    end
+
+    def migrate_rule_reference(existing_rr, duplicate_rr)
+      migrate_rule_reference_rules(existing_rr, duplicate_rr)
+      duplicate_rr.destroy
+    end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def migrate_rule_reference_rules(existing_rr, duplicate_rr)
+      RuleReferencesRule.where(rule_reference: duplicate_rr.id)
+                        .where.not(rule: existing_rr.rules)
+                        .update_all(rule_reference_id: existing_rr.id)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/app/services/duplicate_rule_resolver.rb
+++ b/app/services/duplicate_rule_resolver.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate Rule objects
+class DuplicateRuleResolver
+  class << self
+    def run!
+      @rules = nil
+      duplicate_rules.find_each do |rule|
+        if existing_rule(rule)
+          migrate_rule(existing_rule(rule), rule)
+        else
+          self.existing_rule = rule
+        end
+      end
+    end
+
+    private
+
+    def existing_rule(rule)
+      rules[[rule.ref_id, rule.benchmark_id]]
+    end
+
+    def existing_rule=(rule)
+      rules[[rule.ref_id, rule.benchmark_id]] = rule
+    end
+
+    def rules
+      @rules ||= {}
+    end
+
+    def migrate_rule(existing_r, duplicate_r)
+      migrate_profile_rules(existing_r, duplicate_r)
+      migrate_rule_results(existing_r, duplicate_r)
+      duplicate_r.destroy # RuleResults, RuleReferenceRules, RuleIdentifier
+    end
+
+    def duplicate_rules
+      Rule.joins(
+        "JOIN (#{grouped_nonunique_rule_tuples.to_sql}) as r on "\
+        'rules.ref_id = r.ref_id AND '\
+        'rules.benchmark_id = r.benchmark_id'
+      )
+    end
+
+    def grouped_nonunique_rule_tuples
+      Rule.select(:ref_id, :benchmark_id)
+          .group(:ref_id, :benchmark_id)
+          .having('COUNT(id) > 1')
+    end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def migrate_profile_rules(existing_r, duplicate_r)
+      duplicate_r.profile_rules.where.not(profile: existing_r.profiles)
+                 .update_all(rule_id: existing_r.id)
+    end
+
+    def migrate_rule_results(existing_r, duplicate_r)
+      duplicate_r.rule_results.update_all(rule_id: existing_r.id)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/app/services/duplicate_rule_result_resolver.rb
+++ b/app/services/duplicate_rule_result_resolver.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate RuleResult objects
+class DuplicateRuleResultResolver
+  class << self
+    def run!
+      @rule_results = nil
+      duplicate_rule_results.find_each do |rule_result|
+        if existing_rule_result(rule_result)
+          migrate_rule_result(existing_rule_result(rule_result), rule_result)
+        else
+          self.existing_rule_result = rule_result
+        end
+      end
+    end
+
+    private
+
+    def existing_rule_result(rule_result)
+      rule_results[[rule_result.host_id, rule_result.rule_id,
+                    rule_result.test_result_id]]
+    end
+
+    def existing_rule_result=(rule_result)
+      rule_results[[rule_result.host_id, rule_result.rule_id,
+                    rule_result.test_result_id]] = rule_result
+    end
+
+    def rule_results
+      @rule_results ||= {}
+    end
+
+    def duplicate_rule_results
+      RuleResult.joins(
+        "JOIN (#{grouped_nonunique_rule_result_tuples.to_sql}) as rr on "\
+        'rule_results.host_id = rr.host_id AND '\
+        'rule_results.rule_id = rr.rule_id AND '\
+        'rule_results.test_result_id = rr.test_result_id'
+      )
+    end
+
+    def grouped_nonunique_rule_result_tuples
+      RuleResult.select(:host_id, :rule_id, :test_result_id)
+                .group(:host_id, :rule_id, :test_result_id)
+                .having('COUNT(id) > 1')
+    end
+
+    def migrate_rule_result(_existing_rr, duplicate_rr)
+      duplicate_rr.destroy
+    end
+  end
+end

--- a/app/services/duplicate_test_result_resolver.rb
+++ b/app/services/duplicate_test_result_resolver.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# A service class to merge duplicate TestResult objects
+class DuplicateTestResultResolver
+  class << self
+    def run!
+      @test_results = nil
+      duplicate_test_results.find_each do |test_result|
+        if existing_test_result(test_result)
+          migrate_test_result(existing_test_result(test_result),
+                              test_result)
+        else
+          self.existing_test_result = test_result
+        end
+      end
+    end
+
+    private
+
+    def existing_test_result(test_result)
+      test_results[[test_result.host_id, test_result.profile_id,
+                    test_result.end_time]]
+    end
+
+    def existing_test_result=(test_result)
+      test_results[[test_result.host_id, test_result.profile_id,
+                    test_result.end_time]] = test_result
+    end
+
+    def test_results
+      @test_results ||= {}
+    end
+
+    def duplicate_test_results
+      TestResult.joins(
+        "JOIN (#{grouped_nonunique_test_result_tuples.to_sql}) as tr on "\
+        'test_results.host_id = tr.host_id AND '\
+        'test_results.profile_id = tr.profile_id AND '\
+        'test_results.end_time = tr.end_time'
+      )
+    end
+
+    def grouped_nonunique_test_result_tuples
+      TestResult.select(:host_id, :profile_id, :end_time)
+                .group(:host_id, :profile_id, :end_time)
+                .having('COUNT(id) > 1')
+    end
+
+    def migrate_test_result(existing_tr, duplicate_tr)
+      migrate_rule_results(existing_tr, duplicate_tr)
+      duplicate_tr.destroy
+    end
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def migrate_rule_results(existing_tr, duplicate_tr)
+      duplicate_tr.rule_results.where.not(host_id: existing_tr.host_id).or(
+        duplicate_tr.rule_results.where.not(
+          rule_id: existing_tr.rule_results.select(:rule_id)
+        )
+      ).update_all(test_result_id: existing_tr.id)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
+++ b/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintToProfileByAccount < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:profiles , %i[account_id ref_id benchmark_id], unique: true)
+  end
+end

--- a/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
+++ b/db/migrate/20191017185340_add_unique_constraint_to_profile_by_account.rb
@@ -1,5 +1,0 @@
-class AddUniqueConstraintToProfileByAccount < ActiveRecord::Migration[5.2]
-  def change
-    add_index(:profiles , %i[account_id ref_id benchmark_id], unique: true)
-  end
-end

--- a/db/migrate/20200106134953_add_unique_index_to_benchmarks.rb
+++ b/db/migrate/20200106134953_add_unique_index_to_benchmarks.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToBenchmarks < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateBenchmarkResolver.run!
+
+    add_index(:benchmarks, %i[ref_id version], unique: true)
+  end
+
+  def down
+    remove_index(:benchmarks, %i[ref_id version])
+  end
+end

--- a/db/migrate/20200325185540_add_unique_index_to_profiles.rb
+++ b/db/migrate/20200325185540_add_unique_index_to_profiles.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToProfiles < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateProfileResolver.run!
+
+    add_index(:profiles, %i[ref_id account_id benchmark_id], unique: true)
+  end
+
+  def down
+    remove_index(:profiles, %i[ref_id account_id benchmark_id])
+  end
+end

--- a/db/migrate/20200415201445_add_unique_index_to_rules.rb
+++ b/db/migrate/20200415201445_add_unique_index_to_rules.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToRules < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateRuleResolver.run!
+
+    add_index(:rules, %i[ref_id benchmark_id], unique: true)
+  end
+
+  def down
+    remove_index(:rules, %i[ref_id benchmark_id])
+  end
+end

--- a/db/migrate/20200417174053_add_unique_index_to_business_objectives.rb
+++ b/db/migrate/20200417174053_add_unique_index_to_business_objectives.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToBusinessObjectives < ActiveRecord::Migration[5.2]
+  def change
+    add_index :business_objectives, :title
+  end
+end

--- a/db/migrate/20200417174651_add_unique_index_to_rule_identifiers.rb
+++ b/db/migrate/20200417174651_add_unique_index_to_rule_identifiers.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToRuleIdentifiers < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:rule_identifiers, %i[label system rule_id], unique: true)
+  end
+end

--- a/db/migrate/20200417174948_add_unique_index_to_rule_references.rb
+++ b/db/migrate/20200417174948_add_unique_index_to_rule_references.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToRuleReferences < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateRuleReferenceResolver.run!
+
+    add_index(:rule_references, %i[href label], unique: true)
+  end
+
+  def down
+    remove_index(:rule_references, %i[href label])
+  end
+end

--- a/db/migrate/20200417175851_add_unique_index_to_rule_results.rb
+++ b/db/migrate/20200417175851_add_unique_index_to_rule_results.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToRuleResults < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateRuleResultResolver.run!
+
+    add_index(:rule_results, %i[host_id rule_id test_result_id], unique: true)
+  end
+
+  def down
+    remove_index(:rule_results, %i[host_id rule_id test_result_id])
+  end
+end

--- a/db/migrate/20200417180344_add_unique_index_to_test_results.rb
+++ b/db/migrate/20200417180344_add_unique_index_to_test_results.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToTestResults < ActiveRecord::Migration[5.2]
+  def up
+    DuplicateTestResultResolver.run!
+
+    add_index(:test_results, %i[host_id profile_id end_time], unique: true)
+  end
+
+  def down
+    remove_index(:test_results, %i[host_id profile_id end_time])
+  end
+end

--- a/spec/integration/rules_spec.rb
+++ b/spec/integration/rules_spec.rb
@@ -98,8 +98,9 @@ describe 'Rules API' do
           )
           user = User.from_x_rh_identity(x_rh_identity[:identity])
           user.save
-          profiles(:one).update(account: user.account, hosts: [hosts(:one)])
-          rules(:one).update(profiles: [profiles(:one)])
+          profiles(:one).update!(account: user.account, hosts: [hosts(:one)])
+          rules(:one).rule_results.destroy_all
+          rules(:one).update!(profiles: [profiles(:one)])
           rules(:one).id
         end
         schema type: :object,

--- a/test/fixtures/hosts.yml
+++ b/test/fixtures/hosts.yml
@@ -6,3 +6,4 @@ one:
 
 two:
   name: MyStringtwo
+  account: two

--- a/test/fixtures/rule_results.yml
+++ b/test/fixtures/rule_results.yml
@@ -1,11 +1,13 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  host_id: one
-  rule_id: one
+  host: one
+  rule: one
+  test_result: one
   result: pass
 
 two:
-  host_id: two
-  rule_id: two
+  host: two
+  rule: two
+  test_result: two
   result: fail

--- a/test/fixtures/test_results.yml
+++ b/test/fixtures/test_results.yml
@@ -1,11 +1,11 @@
 one:
-  host_id: one
-  profile_id: one
+  host: one
+  profile: one
   score: 98
   end_time: 2020-03-25T14:51:17+00:00
 
 two:
-  host_id: two
-  profile_id: two
+  host: two
+  profile: two
   score: 98
   end_time: 2020-03-25T14:52:39+00:00

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class HostTest < ActiveSupport::TestCase
   should validate_presence_of :name
+  should validate_presence_of :account
 
   test 'compliant returns a hash with all compliance statuses' do
     host = hosts(:one)
@@ -63,6 +64,7 @@ class HostTest < ActiveSupport::TestCase
     end
 
     should 'be able to filter by "has test results"' do
+      hosts(:two).test_results.destroy_all
       assert hosts(:one).test_results.present?
       assert hosts(:two).test_results.empty?
       assert_includes Host.search_for('has_test_results = true'), hosts(:one)

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -144,6 +144,7 @@ class ProfileTest < ActiveSupport::TestCase
 
   test 'has_test_results filters by test results available' do
     test_results(:one).update profile: profiles(:one), host: hosts(:one)
+    profiles(:two).test_results.destroy_all
     assert profiles(:one).test_results.present?
     assert profiles(:two).test_results.empty?
     assert_includes(Profile.search_for('has_test_results = true'),

--- a/test/models/rule_identifier_test.rb
+++ b/test/models/rule_identifier_test.rb
@@ -6,6 +6,9 @@ require 'test_helper'
 class RuleIdentifierTest < ActiveSupport::TestCase
   should validate_presence_of(:label)
   should validate_presence_of(:system)
+  should validate_presence_of(:rule)
+  should validate_uniqueness_of(:label).scoped_to(%i[system rule_id])
+  should validate_uniqueness_of(:system).scoped_to(%i[label rule_id])
   should belong_to(:rule)
 
   OP_RULE_IDENTIFIER = OpenStruct.new(system: 'http://redhat.com',

--- a/test/models/rule_result_test.rb
+++ b/test/models/rule_result_test.rb
@@ -5,4 +5,5 @@ require 'test_helper'
 class RuleResultTest < ActiveSupport::TestCase
   should validate_presence_of :rule
   should validate_presence_of :host
+  should validate_presence_of :test_result
 end

--- a/test/models/test_result_test.rb
+++ b/test/models/test_result_test.rb
@@ -7,6 +7,8 @@ class TestResultTest < ActiveSupport::TestCase
   should have_many(:rule_results).dependent(:delete_all)
   should belong_to(:profile)
   should belong_to(:host)
-  should validate_presence_of(:host_id)
-  should validate_presence_of(:profile_id)
+  should validate_presence_of(:host)
+  should validate_presence_of(:profile)
+  should validate_presence_of(:end_time)
+  should validate_uniqueness_of(:end_time).scoped_to(%i[host_id profile_id])
 end

--- a/test/services/duplicate_benchmark_resolver_test.rb
+++ b/test/services/duplicate_benchmark_resolver_test.rb
@@ -41,8 +41,8 @@ class DuplicateBenchmarkResolverTest < ActiveSupport::TestCase
   test 'resolves identical benchmarks' do
     assert_difference(
       'Xccdf::Benchmark.count' => -1,
-      'Profile.count' => -2,
-      'Rule.count' => -2,
+      'Profile.count' => 0,
+      'Rule.count' => 0,
       'RuleResult.count' => 0,
       'TestResult.count' => 0,
       'RuleReference.count' => 0,

--- a/test/services/duplicate_benchmark_resolver_test.rb
+++ b/test/services/duplicate_benchmark_resolver_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200106134953_add_unique_index_to_benchmarks'
+
+class DuplicateBenchmarkResolverTest < ActiveSupport::TestCase
+  setup do
+    @migration = AddUniqueIndexToBenchmarks.new
+    @migration.down # remove db constraint
+
+    (@dupe_bm = benchmarks(:one).dup).save(validate: false)
+
+    @dupe_rules = rules.map do |r|
+      dupe_r = r.dup
+      dupe_r.benchmark = @dupe_bm
+      dupe_r.save(validate: false)
+      dupe_r
+    end
+
+    @dupe_profiles = profiles.map do |p|
+      dupe_p = p.dup
+      dupe_p.benchmark = @dupe_bm
+      dupe_p.rules = [@dupe_rules.first]
+      dupe_p.save(validate: false)
+      dupe_p
+    end
+
+    @dupe_test_results = test_results.map do |tr|
+      dupe_tr = tr.dup
+      dupe_tr.save(validate: false)
+      dupe_tr
+    end
+
+    @dupe_rule_results = rule_results.map do |rr|
+      dupe_rr = rr.dup
+      dupe_rr.test_result = @dupe_test_results.sample
+      dupe_rr
+    end
+  end
+
+  test 'resolves identical benchmarks' do
+    assert_difference(
+      'Xccdf::Benchmark.count' => -1,
+      'Profile.count' => -2,
+      'Rule.count' => -2,
+      'RuleResult.count' => 0,
+      'TestResult.count' => 0,
+      'RuleReference.count' => 0,
+      'Host.count' => 0,
+      'ProfileHost.count' => 0
+    ) do
+      @migration.up
+    end
+  end
+end

--- a/test/services/duplicate_profile_resolver_test.rb
+++ b/test/services/duplicate_profile_resolver_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200325185540_add_unique_index_to_profiles'
+
+class DuplicateProfileResolverTest < ActiveSupport::TestCase
+  setup do
+    # rubocop:disable Lint/SuppressedException
+    begin
+      AddUniqueIndexToProfiles.new.down
+    rescue ArgumentError # if index doesn't exist
+    end
+    # rubocop:enable Lint/SuppressedException
+
+    assert_difference('Profile.count' => 1) do
+      (@dup_profile = profiles(:one).dup).save(validate: false)
+    end
+  end
+
+  test 'resolves identical profiles' do
+    assert_difference('Profile.count' => -1) do
+      DuplicateProfileResolver.run!
+    end
+  end
+
+  test 'resolves profile_hosts from a duplicate profile with the different '\
+       'hosts' do
+    assert_difference('ProfileHost.count' => 2) do
+      profiles(:one).hosts << hosts(:one)
+      @dup_profile.hosts << hosts(:two)
+    end
+
+    assert_difference('ProfileHost.count' => 0) do
+      DuplicateProfileResolver.run!
+    end
+  end
+
+  test 'resolves profile_hosts from a duplicate profile with the same hosts' do
+    assert_difference('ProfileHost.count' => 2) do
+      profiles(:one).hosts << hosts(:one)
+      @dup_profile.hosts << hosts(:one)
+    end
+
+    assert_difference('ProfileHost.count' => -1) do
+      DuplicateProfileResolver.run!
+    end
+  end
+
+  test 'resolves children profiles' do
+    profiles(:two).update!(parent_profile: @dup_profile)
+
+    assert_difference('Profile.count' => -1) do
+      DuplicateProfileResolver.run!
+    end
+
+    assert_equal Profile.find_by(ref_id: profiles(:one).ref_id),
+                 profiles(:two).reload.parent_profile
+  end
+end

--- a/test/services/duplicate_rule_reference_resolver_test.rb
+++ b/test/services/duplicate_rule_reference_resolver_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200417174948_add_unique_index_to_rule_references'
+require 'sidekiq/testing'
+
+class DuplicateRuleReferenceResolverTest < ActiveSupport::TestCase
+  setup do
+    # rubocop:disable Lint/SuppressedException
+    begin
+      AddUniqueIndexToRuleReferences.new.down
+    rescue ArgumentError # if index doesn't exist
+    end
+    # rubocop:enable Lint/SuppressedException
+
+    assert_difference('RuleReference.count' => 1) do
+      (@dup_reference = rule_references(:one).dup).save(validate: false)
+    end
+  end
+
+  test 'resolves identical references' do
+    assert_difference('RuleReference.count' => -1) do
+      DuplicateRuleReferenceResolver.run!
+    end
+  end
+
+  test 'resolves identical rules of identical references' do
+    assert_difference('RuleReferencesRule.count' => 2) do
+      rule_references(:one).rules << rules(:one)
+      @dup_reference.rules << rules(:one)
+    end
+
+    assert_difference('RuleReferencesRule.count' => -1) do
+      DuplicateRuleReferenceResolver.run!
+    end
+  end
+
+  test 'resolves different rules of identical references' do
+    assert_difference('RuleReferencesRule.count' => 2) do
+      rule_references(:one).rules << rules(:one)
+      @dup_reference.rules << rules(:two)
+    end
+
+    assert_difference('RuleReferencesRule.count' => 0) do
+      DuplicateRuleReferenceResolver.run!
+    end
+  end
+end

--- a/test/services/duplicate_rule_resolver_test.rb
+++ b/test/services/duplicate_rule_resolver_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200415201445_add_unique_index_to_rules.rb'
+
+class DuplicateRuleResolverTest < ActiveSupport::TestCase
+  setup do
+    # rubocop:disable Lint/SuppressedException
+    begin
+      AddUniqueIndexToRules.new.down
+    rescue ArgumentError # if index doesn't exist
+    end
+    # rubocop:enable Lint/SuppressedException
+
+    assert_difference('Rule.count' => 1) do
+      (@dup_rule = rules(:one).dup).save(validate: false)
+    end
+  end
+
+  test 'resolves identical rules' do
+    assert_difference('Rule.count' => -1) do
+      DuplicateRuleResolver.run!
+    end
+  end
+
+  test 'resolves profile_rules from a duplicate rule with '\
+       'different profiles' do
+    assert_difference('ProfileRule.count' => 2) do
+      rules(:one).profiles << profiles(:one)
+      @dup_rule.profiles << profiles(:two)
+    end
+
+    assert_difference('ProfileRule.count' => 0) do
+      DuplicateRuleResolver.run!
+    end
+  end
+
+  test 'resolves profile_rules from a duplicate rule with '\
+       'the same profiles' do
+    assert_difference('ProfileRule.count' => 2) do
+      rules(:one).profiles << profiles(:two)
+      @dup_rule.profiles << profiles(:two)
+    end
+
+    assert_difference('ProfileRule.count' => -1) do
+      DuplicateRuleResolver.run!
+    end
+  end
+
+  test 'resolves rule_results from a duplicate rule' do
+    assert_difference('RuleResult.count' => 2) do
+      (rr = rule_results(:one).dup).save(validate: false)
+      (rr2 = rule_results(:one).dup).save(validate: false)
+      rules(:one).rule_results << rr
+      @dup_rule.rule_results << rr2
+    end
+
+    assert_difference('RuleResult.count' => 0) do
+      DuplicateRuleResolver.run!
+    end
+  end
+end

--- a/test/services/duplicate_rule_resolver_test.rb
+++ b/test/services/duplicate_rule_resolver_test.rb
@@ -49,10 +49,9 @@ class DuplicateRuleResolverTest < ActiveSupport::TestCase
 
   test 'resolves rule_results from a duplicate rule' do
     assert_difference('RuleResult.count' => 2) do
-      (rr = rule_results(:one).dup).save(validate: false)
-      (rr2 = rule_results(:one).dup).save(validate: false)
-      rules(:one).rule_results << rr
-      @dup_rule.rule_results << rr2
+      rule_results(:one).dup.update!(rule: rules(:one), host: hosts(:two),
+                                     test_result: test_results(:two))
+      rule_results(:one).dup.update!(rule: @dup_rule, host: hosts(:two))
     end
 
     assert_difference('RuleResult.count' => 0) do

--- a/test/services/duplicate_rule_result_resolver_test.rb
+++ b/test/services/duplicate_rule_result_resolver_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200417175851_add_unique_index_to_rule_results'
+require 'sidekiq/testing'
+
+class DuplicateRuleResultResolverTest < ActiveSupport::TestCase
+  setup do
+    # rubocop:disable Lint/SuppressedException
+    begin
+      AddUniqueIndexToRuleResults.new.down
+    rescue ArgumentError # if index doesn't exist
+    end
+    # rubocop:enable Lint/SuppressedException
+
+    assert_difference('RuleResult.count' => 1) do
+      (@dup_result = rule_results(:one).dup).save(validate: false)
+    end
+  end
+
+  test 'resolves identical rule results' do
+    assert_difference('RuleResult.count' => -1) do
+      DuplicateRuleResultResolver.run!
+    end
+  end
+end

--- a/test/services/duplicate_test_result_resolver_test.rb
+++ b/test/services/duplicate_test_result_resolver_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './db/migrate/20200417180344_add_unique_index_to_test_results'
+require 'sidekiq/testing'
+
+class DuplicateTestResultResolverTest < ActiveSupport::TestCase
+  setup do
+    # rubocop:disable Lint/SuppressedException
+    begin
+      AddUniqueIndexToTestResults.new.down
+    rescue ArgumentError # if index doesn't exist
+    end
+    # rubocop:enable Lint/SuppressedException
+
+    assert_difference('TestResult.count' => 1) do
+      (@dup_result = test_results(:one).dup).save(validate: false)
+    end
+  end
+
+  test 'resolves identical test results' do
+    assert_difference('TestResult.count' => -1) do
+      DuplicateTestResultResolver.run!
+    end
+  end
+
+  test 'resolves identical rule results of identical test results' do
+    assert_difference('RuleResult.count' => 1) do
+      rule_results(:one).dup.update!(test_result: @dup_result)
+    end
+
+    assert_difference('RuleResult.count' => -1) do
+      DuplicateTestResultResolver.run!
+    end
+  end
+
+  test 'resolves different rule results of identical test results' do
+    assert_difference('RuleResult.count' => 1) do
+      rule_results(:two).dup.update!(test_result: @dup_result)
+    end
+
+    assert_difference('RuleResult.count' => 0) do
+      DuplicateTestResultResolver.run!
+    end
+  end
+end

--- a/test/services/xccdf_report_migration_test.rb
+++ b/test/services/xccdf_report_migration_test.rb
@@ -55,7 +55,7 @@ class XCCDFReportMigrationTest < ActiveSupport::TestCase
     conflict_profile = Profile.create!(
       account: accounts(:test),
       hosts: [hosts(:one)],
-      name: 'footitle2',
+      name: 'footitle',
       benchmark: benchmarks(:one),
       ref_id: "xccdf_org.ssgproject.content_profile_#{@profile.ref_id}"
     )

--- a/test/services/xccdf_report_migration_test.rb
+++ b/test/services/xccdf_report_migration_test.rb
@@ -55,7 +55,7 @@ class XCCDFReportMigrationTest < ActiveSupport::TestCase
     conflict_profile = Profile.create!(
       account: accounts(:test),
       hosts: [hosts(:one)],
-      name: 'footitle',
+      name: 'footitle2',
       benchmark: benchmarks(:one),
       ref_id: "xccdf_org.ssgproject.content_profile_#{@profile.ref_id}"
     )

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -276,6 +276,9 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         hosts: [hosts(:two)]
       )
 
+      assert profile1.persisted?
+      assert profile2.persisted?
+
       assert_difference(
         -> { profile1.reload.rules.count } => 0,
         -> { profile2.reload.rules.count } => 74


### PR DESCRIPTION
This should be everything remaining for https://projects.engineering.redhat.com/browse/RHICOMPL-459 :no_smoking: 

Please double check me here. I looked at the history for db/migrate on master to inform which commits and in which order to cherry-pick them: https://github.com/RedHatInsights/compliance-backend/commits/master/db/migrate