### PR TITLE
RHICOMPL-695 - Fix 'undefined method id' error on SystemDetails

### DIFF
--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -12,8 +12,8 @@ module RulesPreload
     latest_test_result_batch(args).then do |latest_test_result|
       latest_rule_results_batch(latest_test_result).then do |rule_results|
         rules_for_rule_results_batch(rule_results).then do |rules|
-          initialize_rules_context(rules, rule_results, args)
-          rules
+          initialize_rules_context(rules.compact, rule_results, args)
+          rules.compact
         end
       end
     end


### PR DESCRIPTION
We keep on getting an alert on "undefined method 'id' for nil:NilClass"
on the #alerts-cloudservices-apps.

After investigating, this alert happens because the system details page
is visited. We try to retrieve the latest Test Results for the profiles
for the System, and some RuleResults don't have a correct rule_id FK -
they're pointing to unknown rule_ids.

> irb(main):013:0> rule_ids.count
> => 4405
> irb(main):014:0> rule_ids = RuleResult.select(:rule_id).distinct.pluck(:rule_id); rule_ids.count
> => 4405
> irb(main):015:0> Rule.where(id: rule_ids).count
> => 3283

In our GQL API code, when we try to get the results for these
rules, they're showing up as "nil" and therefore they fail to
load.