### PR TITLE
[stable] RHICOMPL-695 - Fix 'undefined method id' error on SystemDetails

### DIFF
--- a/app/graphql/types/interfaces/rules_preload.rb
+++ b/app/graphql/types/interfaces/rules_preload.rb
@@ -12,8 +12,8 @@ module RulesPreload
     latest_test_result_batch(args).then do |latest_test_result|
       latest_rule_results_batch(latest_test_result).then do |rule_results|
         rules_for_rule_results_batch(rule_results).then do |rules|
-          initialize_rules_context(rules, rule_results, args)
-          rules
+          initialize_rules_context(rules.compact, rule_results, args)
+          rules.compact
         end
       end
     end

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -262,6 +262,53 @@ class SystemQueryTest < ActiveSupport::TestCase
     assert graphql_host.profiles.pluck(:id).include?(profiles(:one).id)
   end
 
+  test 'query system rules when results contain wrong rule_ids' do
+    query = <<-GRAPHQL
+    query System($systemId: String!){
+        system(id: $systemId) {
+	    profiles {
+		id
+		name
+		totalHostCount
+		compliantHostCount
+		rules {
+		    title
+		    severity
+		    rationale
+		    refId
+		    description
+		    compliant
+		    remediationAvailable
+		    references
+		    identifier
+		}
+	    }
+	}
+    }
+    GRAPHQL
+    hosts(:one).profiles << profiles(:one)
+    test_results(:one).update(profile: profiles(:one), host: hosts(:one))
+    rule_results(:one).update(
+      host: hosts(:one), rule: rules(:one), test_result: test_results(:one)
+    )
+    rule_results(:two).update(
+      host: hosts(:one), rule: rules(:two), test_result: test_results(:one)
+    )
+    rules(:one).delete
+
+    assert_nothing_raised do
+      result = Schema.execute(
+        query,
+        variables: { systemId: hosts(:one).id },
+        context: { current_user: users(:test) }
+      )
+      response_rules = result['data']['system']['profiles'][0]['rules']
+
+      assert_equal 1, response_rules.length
+      assert_equal rules(:two).ref_id, response_rules[0]['refId']
+    end
+  end
+
   private
 
   # rubocop:disable AbcSize


### PR DESCRIPTION
We keep on getting an alert on "undefined method 'id' for nil:NilClass"
on the #alerts-cloudservices-apps.

After investigating, this alert happens because the system details page
is visited. We try to retrieve the latest Test Results for the profiles
for the System, and some RuleResults don't have a correct rule_id FK -
they're pointing to unknown rule_ids.

> irb(main):013:0> rule_ids.count
> => 4405
> irb(main):014:0> rule_ids = RuleResult.select(:rule_id).distinct.pluck(:rule_id); rule_ids.count
> => 4405
> irb(main):015:0> Rule.where(id: rule_ids).count
> => 3283

In our GQL API code, when we try to get the results for these
rules, they're showing up as "nil" and therefore they fail to
load.

*update*:

From this data, the rule results without a matching rule_id are all very old. I think we can safely go ahead and just delete these.
```
[43] pry(main)> unfound_rule_results.max_by(&:created_at)
=> #<RuleResult:0x000055f2be789630
 id: "0c945c41-6122-422d-952a-c12c373284d6",
 host_id: "b4166156-a04e-4afd-90b0-d8d6df31cfe4",
 rule_id: "001982c1-0c73-4ac1-bba4-f6339595a9b0",
 result: "notselected",
 created_at: Fri, 29 Nov 2019 10:01:30 UTC +00:00,
 updated_at: Fri, 29 Nov 2019 10:01:30 UTC +00:00,
 test_result_id: nil>
[44] pry(main)> unfound_rule_results.min_by(&:created_at)
=> #<RuleResult:0x000055f2af0ab638
 id: "8d8938b2-0f82-4d52-bac7-64024aa9531e",
 host_id: "2566a863-7052-4045-abbe-056ddc9277ad",
 rule_id: "2a5ade52-b818-4261-a9da-fa479484489b",
 result: "notselected",
 created_at: Tue, 12 Feb 2019 19:06:49 UTC +00:00,
 updated_at: Sun, 05 May 2019 16:04:13 UTC +00:00,
 test_result_id: nil>
```
