### PR TITLE
Remove useless RuleResult records

### DIFF
--- a/db/migrate/20200518145454_remove_useless_rule_results.rb
+++ b/db/migrate/20200518145454_remove_useless_rule_results.rb
@@ -1,0 +1,20 @@
+# This migration is meant to remove all of the rule results which are errors.
+# These are a byproduct of previous states of the application, and
+# in production they are all very old RuleResults.
+class RemoveUselessRuleResults < ActiveRecord::Migration[5.2]
+  def up
+    RuleResult.where(test_result_id: nil).delete_all
+
+    rule_ids = RuleResult.select(:rule_id).distinct.pluck(:rule_id)
+    found_rule_ids = Rule.where(id: rule_ids).pluck(:id)
+
+    unfound_rule_ids = rule_ids - found_rule_ids
+    RuleResult.where(rule_id: unfound_rule_ids).delete_all
+
+    host_ids = RuleResult.select(:host_id).distinct.pluck(:host_id)
+    found_host_ids = Host.where(id: host_ids).pluck(:id)
+
+    unfound_host_ids = host_ids - found_host_ids
+    RuleResult.where(host_id: unfound_host_ids).delete_all
+  end
+end


### PR DESCRIPTION
Many *old* records (6m+ old) in RuleResult are simply unused
(test_result_id is nil), or broken (rule_id isn't pointing to a real Rule).
These records should be removed from the database.
```
[43] pry(main)> unfound_rule_results.max_by(&:created_at)
	=> #<RuleResult:0x000055f2be789630
	id: "0c945c41-6122-422d-952a-c12c373284d6",
	host_id: "b4166156-a04e-4afd-90b0-d8d6df31cfe4",
	rule_id: "001982c1-0c73-4ac1-bba4-f6339595a9b0",
	result: "notselected",
	created_at: Fri, 29 Nov 2019 10:01:30 UTC +00:00,
	updated_at: Fri, 29 Nov 2019 10:01:30 UTC +00:00,
	test_result_id: nil>
[44] pry(main)> unfound_rule_results.min_by(&:created_at)
	=> #<RuleResult:0x000055f2af0ab638
	id: "8d8938b2-0f82-4d52-bac7-64024aa9531e",
	host_id: "2566a863-7052-4045-abbe-056ddc9277ad",
	rule_id: "2a5ade52-b818-4261-a9da-fa479484489b",
	result: "notselected",
	created_at: Tue, 12 Feb 2019 19:06:49 UTC +00:00,
	updated_at: Sun, 05 May 2019 16:04:13 UTC +00:00,
	test_result_id: nil>
```