### PR TITLE
Fix an intermittently failing associate_profiles test

### DIFF
--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -70,7 +70,8 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     )['data']['associateProfiles']['system']
 
     assert_not_nil(new_host = Host.find_by(id: NEW_ID))
-    assert_equal new_host.profiles, [profiles(:one), profiles(:two)]
+    assert_equal Set.new(new_host.profiles),
+                 Set.new([profiles(:one), profiles(:two)])
   end
 
   test 'external profiles are kept after associating internal profiles' do


### PR DESCRIPTION
Another array comparison issue - if the arrays aren't in the same order, the test fails. There is no order for a `Set`.

Failure seen here: https://jenkins-jenkins.5a9f.insights-dev.openshiftapps.com/blue/organizations/jenkins/compliance-backend/detail/PR-477/3/pipeline/

Signed-off-by: Andrew Kofink <akofink@redhat.com>