### PR TITLE
Check auth_type directly in the identity to determine cert auth

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -61,13 +61,9 @@ module Authentication
   private
 
   def skip_rbac_for_cert_based_auth?
-    cert_based_auth? &&
+    identity_header.cert_based? &&
       ALLOWED_CERT_BASED_RBAC_ACTIONS.include?(controller: controller_name,
                                                action: action_name)
-  end
-
-  def cert_based_auth?
-    identity_header.identity.dig('user').nil?
   end
 
   def identity_header

--- a/app/models/identity_header.rb
+++ b/app/models/identity_header.rb
@@ -4,6 +4,8 @@ require 'base64'
 
 # Helpers to handle the b64 identity header.
 class IdentityHeader
+  CERT_AUTH = 'cert-auth'
+
   def initialize(b64_identity)
     @b64_identity = b64_identity
   end
@@ -28,5 +30,13 @@ class IdentityHeader
 
   def entitled?
     entitlements&.dig('insights', 'is_entitled')
+  end
+
+  def auth_type
+    identity&.dig('auth_type')
+  end
+
+  def cert_based?
+    auth_type == CERT_AUTH
   end
 end

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -212,7 +212,8 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': '1234'
+            'account_number': '1234',
+            'auth_type': IdentityHeader::CERT_AUTH
           },
           'entitlements':
           {
@@ -232,7 +233,8 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': accounts(:one).account_number
+            'account_number': accounts(:one).account_number,
+            'auth_type': IdentityHeader::CERT_AUTH
           },
           'entitlements':
           {
@@ -254,7 +256,8 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': accounts(:one).account_number
+            'account_number': accounts(:one).account_number,
+            'auth_type': IdentityHeader::CERT_AUTH
           },
           'entitlements':
           {

--- a/test/models/identity_header_test.rb
+++ b/test/models/identity_header_test.rb
@@ -11,7 +11,9 @@ class IdentityHeaderTest < ActiveSupport::TestCase
         }
       },
       'identity': {
-        'account_number': '293912'
+        'user': {},
+        'account_number': '293912',
+        'auth_type': 'basic-auth'
       }
     }
   end
@@ -27,5 +29,16 @@ class IdentityHeaderTest < ActiveSupport::TestCase
     assert_not IdentityHeader.new(
       Base64.strict_encode64(@b64_identity.to_json)
     ).valid?
+  end
+
+  test 'properly detects cert-based auth from the auth_type' do
+    assert_not IdentityHeader.new(
+      Base64.strict_encode64(@b64_identity.to_json)
+    ).cert_based?
+
+    @b64_identity[:identity][:auth_type] = IdentityHeader::CERT_AUTH
+    assert IdentityHeader.new(
+      Base64.strict_encode64(@b64_identity.to_json)
+    ).cert_based?
   end
 end


### PR DESCRIPTION
From [this doc](https://docs.google.com/document/d/1PAzJqcUXlxg7t5cX1lsPsQtBPT_95bZbyB9Iiv_ekGM/edit#):

> The shape of the x-rh-identity object is as such:

```
{
   "identity" : {
       "account_number": String,
       "type": String, // User or System
       "auth_type": String, // cert-auth, basic-auth or jwt-auth
       "user": {}, // optional if User
       "system": {}, // optional if System
       "internal": {},
   }
}
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>