### PR TITLE
Fix readiness/liveness probes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,11 +13,6 @@ Rails.application.routes.draw do
         resources :rule_results, only: [:index]
         resources :systems, only: [:index, :destroy]
         resources :rules, only: [:index, :show]
-        mount Rswag::Api::Engine => '/',
-          as: "#{prefix}/#{ENV['APP_NAME']}/rswag_api"
-        mount Rswag::Ui::Engine => '/',
-          as: "#{prefix}/#{ENV['APP_NAME']}/rswag_ui"
-        get 'openapi' => 'application#openapi'
       end
       resources :benchmarks, controller: 'v1/benchmarks', only: [:index, :show]
       resources :profiles, controller: 'v1/profiles', only: [:index, :show] do


### PR DESCRIPTION
Probes are returning 401 on CI already because the v1 namespacing in routes.rb shouldn't include the openAPI endpoint as the openapi controller already has embedded 'v1', 'v2' or whatever version is needed