### PR TITLE
Add tests for openapi.json endpoints

### DIFF
--- a/test/controllers/v1/openapi_endpoint_test.rb
+++ b/test/controllers/v1/openapi_endpoint_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module V1
+  class OpenapiEndpointTest < ActionDispatch::IntegrationTest
+    test 'openapi v1 success' do
+      User.current = nil
+      assert_nil User.current
+      get '/api/compliance/v1/openapi.json'
+      assert_response :success
+    end
+  end
+end


### PR DESCRIPTION
`api/compliance/v1/openapi.json` test works fine.

Signed-off-by: Andrew Kofink <akofink@redhat.com>