### PR TITLE
Version API spec to V1, refactor schema into files

### DIFF
--- a/spec/api/v1/openapi.rb
+++ b/spec/api/v1/openapi.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require './spec/api/v1/schemas'
+
+module Api
+  module V1
+    class Openapi
+      include Api::V1::Schemas
+
+      def self.doc
+        new.doc
+      end
+
+      def doc
+        {
+          openapi: '3.0.3',
+          info: info,
+          paths: {},
+          components: {
+            schemas: SCHEMAS
+          }
+        }
+      end
+
+      def info
+        {
+          title: 'Cloud Services for RHEL Compliance API V1',
+          version: 'v1',
+          description: description
+        }
+      end
+
+      def description
+        'This is the API for Cloud Services for RHEL Compliance. '\
+          'You can find out more about Red Hat Cloud Services for RHEL at '\
+          '[https://cloud.redhat.com/]'\
+          '(https://cloud.redhat.com/)'
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas.rb
+++ b/spec/api/v1/schemas.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require './spec/api/v1/schemas/types'
+require './spec/api/v1/schemas/errors'
+require './spec/api/v1/schemas/metadata'
+require './spec/api/v1/schemas/hosts'
+require './spec/api/v1/schemas/benchmarks'
+require './spec/api/v1/schemas/profiles'
+require './spec/api/v1/schemas/rule_results'
+require './spec/api/v1/schemas/rules'
+
+module Api
+  module V1
+    module Schemas
+      include Types
+      include Errors
+      include Metadata
+      include Hosts
+      include Benchmarks
+      include Profiles
+      include RuleResults
+      include Rules
+
+      SCHEMAS = {
+        uuid: UUID,
+        relationship: RELATIONSHIP,
+        error: ERROR,
+        metadata: METADATA,
+        host: HOST,
+        links: LINKS,
+        benchmark: BENCHMARK,
+        profile: PROFILE,
+        rule_result: RULE_RESULT,
+        rule: RULE
+      }.freeze
+    end
+  end
+end

--- a/spec/api/v1/schemas/benchmarks.rb
+++ b/spec/api/v1/schemas/benchmarks.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module Benchmarks
+        BENCHMARK = {
+          type: 'object',
+          required: %w[ref_id title version],
+          properties: {
+            ref_id: {
+              type: 'string',
+              example: 'xccdf_org.ssgproject.content_benchmark_RHEL-7'
+            },
+            title: {
+              type: 'string',
+              example: 'Guide to the Secure Configuration of Red Hat '\
+              'Enterprise Linux 7'
+            },
+            version: {
+              type: 'string',
+              example: '0.1.46'
+            },
+            description: {
+              type: 'string'
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/errors.rb
+++ b/spec/api/v1/schemas/errors.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module Errors
+        ERROR = {
+          type: 'object',
+          required: %w[code detail status title],
+          properties: {
+            status: {
+              type: 'integer',
+              description: 'the HTTP status code applicable to this '\
+              'problem, expressed as a string value.',
+              minimum: 100,
+              maximum: 600
+            },
+            code: {
+              type: 'string',
+              description: 'an application-specific error code, expressed '\
+              'as a string value.'
+            },
+            title: {
+              type: 'string',
+              description: 'a short, human-readable summary of the problem '\
+              'that SHOULD NOT change from occurrence to occurrence of the '\
+              'problem, except for purposes of localization.'
+            },
+            detail: {
+              type: 'string',
+              description: 'a human-readable explanation specific to this '\
+              'occurrence of the problem. Like title, this field’s value '\
+              'can be localized.'
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/hosts.rb
+++ b/spec/api/v1/schemas/hosts.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module Hosts
+        HOST = {
+          type: 'object',
+          required: %w[name account_id],
+          properties: {
+            name: {
+              type: 'string',
+              example: 'cloud.redhat.com'
+            },
+            account_id: {
+              type: 'string',
+              example: '649cf080-ccce-4c02-ba60-21d046983c7f'
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/metadata.rb
+++ b/spec/api/v1/schemas/metadata.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module Metadata
+        METADATA = {
+          type: 'object',
+          properties: {
+            filter: {
+              type: 'string',
+              example: "name='Standard System Security Profile for Fedora'"
+            }
+          }
+        }.freeze
+
+        LINKS = {
+          type: 'object',
+          properties: {
+            self: {
+              type: 'string',
+              example: 'https://compliance.insights.openshift.org/profiles'
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/profiles.rb
+++ b/spec/api/v1/schemas/profiles.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module Profiles
+        PROFILE = {
+          type: 'object',
+          required: %w[name ref_id],
+          properties: {
+            parent_profile_id: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '0105a0f0-7379-4897-a891-f95cfb9ddf9c'
+            },
+            parent_profile_ref_id: {
+              type: 'string',
+              nullable: true,
+              example: 'xccdf_org.ssgproject.content_profile_standard'
+            },
+            description: {
+              type: 'string',
+              nullable: true,
+              example: 'This profile contains rules to ensure standard '\
+              'security baseline\nof a Red Hat Enterprise Linux 7 '\
+              'system. Regardless of your system\'s workload\nall '\
+              'of these checks should pass.'
+            },
+            compliance_threshold: {
+              type: 'number',
+              example: 95.0
+            },
+            score: {
+              type: 'number',
+              example: 63.154762
+            },
+            business_objective: {
+              type: 'string',
+              example: 'APAC Expansion',
+              nullable: true
+            },
+            canonical: {
+              type: 'boolean',
+              example: true
+            },
+            compliant_host_count: {
+              type: 'integer',
+              example: 3
+            },
+            external: {
+              type: 'boolean',
+              example: false
+            },
+            tailored: {
+              type: 'boolean',
+              example: false
+            },
+            total_host_count: {
+              type: 'integer',
+              example: 5
+            },
+            os_major_version: {
+              type: 'string',
+              example: '7'
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/rule_results.rb
+++ b/spec/api/v1/schemas/rule_results.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module RuleResults
+        RULE_RESULT = {
+          type: 'object',
+          required: %w[result],
+          properties: {
+            result: {
+              type: 'string',
+              example: 'passed'
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/rules.rb
+++ b/spec/api/v1/schemas/rules.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module Rules
+        RULE = {
+          type: 'object',
+          required: %w[title ref_id],
+          properties: {
+            title: {
+              type: 'string',
+              example: 'Record Access Events to Audit Log directory'
+            },
+            ref_id: {
+              type: 'string',
+              example: 'xccdf_org.ssgproject.content_rule_directory_access_'\
+              'var_log_audit'
+            },
+            severity: {
+              type: 'string',
+              example: 'Low'
+            },
+            description: {
+              type: 'string',
+              example: 'The audit system should collect access '\
+              'audit log directory.\nThe following audit rule will assure '\
+              'that access to audit log directory are\ncollected.\n-a '\
+              'always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000'\
+              '-F auid!=unset -F key=access-audit-trail\nIf the'\
+              'is configured to use the augenrules\nprogram to read audit'\
+              ' rules during daemon startup (the default), add the\nrule to'\
+              ' a file with suffix .rules in the directory\n'\
+              '/etc/audit/rules.d.\nIf the auditd daemon is to use'\
+              ' the auditctl\nutility to read audit rules during daemon '\
+              'startup, add the rule to\n/etc/audit/audit.rules file.'
+            },
+            rationale: {
+              type: 'string',
+              example: 'Attempts to read the logs should be recorded,'\
+              ' suspicious access to audit log files could be an indicator'\
+              ' of malicious activity on a system.\nAuditing these events'\
+              ' could serve as evidence of potential system compromise.'
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/types.rb
+++ b/spec/api/v1/schemas/types.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require './spec/api/v1/schemas/util'
+
+module Api
+  module V1
+    module Schemas
+      module Types
+        extend Util
+
+        UUID = { type: :string, format: :uuid }.freeze
+
+        RELATIONSHIP = {
+          data: {
+            id: ref_schema('uuid'),
+            type: :string
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas/util.rb
+++ b/spec/api/v1/schemas/util.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Schemas
+      module Util
+        def ref_schema(label)
+          { '$ref' => "#/components/schemas/#{label}" }
+        end
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -2,8 +2,10 @@
 
 require 'rails_helper'
 require 'webmock/rspec'
+require './spec/api/v1/openapi'
+require './spec/api/v1/schemas/util'
 
-SCHEMAS = '#/components/schemas'
+include Api::V1::Schemas::Util # rubocop:disable Style/MixinUsage
 
 RSpec.configure do |config|
   config.swagger_root = Rails.root.to_s + '/swagger'
@@ -15,230 +17,7 @@ RSpec.configure do |config|
   end
 
   config.swagger_docs = {
-    'v1/openapi.json' => {
-      openapi: '3.0.3',
-      info: {
-        title: 'Cloud Services for RHEL Compliance API V1',
-        version: 'v1',
-        description: 'This is the API for Cloud Services for RHEL Compliance. '\
-        'You can find out more about Red Hat Cloud Services for RHEL at '\
-        '[https://cloud.redhat.com/]'\
-        '(https://cloud.redhat.com/)'
-      },
-      paths: {},
-      components: {
-        schemas: {
-          uuid: {
-            type: :string,
-            format: :uuid
-          },
-          relationship: {
-            data: {
-              id: { '$ref' => '#/components/schemas/uuid' },
-              type: :string
-            }
-          },
-          error: {
-            type: 'object',
-            required: %w[code detail status title],
-            properties: {
-              status: {
-                type: 'integer',
-                description: 'the HTTP status code applicable to this '\
-                'problem, expressed as a string value.',
-                minimum: 100,
-                maximum: 600
-              },
-              code: {
-                type: 'string',
-                description: 'an application-specific error code, expressed '\
-                'as a string value.'
-              },
-              title: {
-                type: 'string',
-                description: 'a short, human-readable summary of the problem '\
-                'that SHOULD NOT change from occurrence to occurrence of the '\
-                'problem, except for purposes of localization.'
-              },
-              detail: {
-                type: 'string',
-                description: 'a human-readable explanation specific to this '\
-                'occurrence of the problem. Like title, this field’s value '\
-                'can be localized.'
-              }
-            }
-          },
-          metadata:
-          {
-            type: 'object',
-            properties: {
-              filter: {
-                type: 'string',
-                example: "name='Standard System Security Profile for Fedora'"
-              }
-            }
-          },
-          host: {
-            type: 'object',
-            required: %w[name account_id],
-            properties: {
-              name: {
-                type: 'string',
-                example: 'cloud.redhat.com'
-              },
-              account_id: {
-                type: 'string',
-                example: '649cf080-ccce-4c02-ba60-21d046983c7f'
-              }
-            }
-          },
-          links:
-          {
-            type: 'object',
-            properties: {
-              self: {
-                type: 'string',
-                example: 'https://compliance.insights.openshift.org/profiles'
-              }
-            }
-          },
-          benchmark: {
-            type: 'object',
-            required: %w[ref_id title version],
-            properties: {
-              ref_id: {
-                type: 'string',
-                example: 'xccdf_org.ssgproject.content_benchmark_RHEL-7'
-              },
-              title: {
-                type: 'string',
-                example: 'Guide to the Secure Configuration of Red Hat '\
-                         'Enterprise Linux 7'
-              },
-              version: {
-                type: 'string',
-                example: '0.1.46'
-              },
-              description: {
-                type: 'string'
-              }
-            }
-          },
-          profile: {
-            type: 'object',
-            required: %w[name ref_id],
-            properties: {
-              parent_profile_id: {
-                type: 'string',
-                format: 'uuid',
-                nullable: true,
-                example: '0105a0f0-7379-4897-a891-f95cfb9ddf9c'
-              },
-              parent_profile_ref_id: {
-                type: 'string',
-                nullable: true,
-                example: 'xccdf_org.ssgproject.content_profile_standard'
-              },
-              description: {
-                type: 'string',
-                nullable: true,
-                example: 'This profile contains rules to ensure standard '\
-                         'security baseline\nof a Red Hat Enterprise Linux 7 '\
-                         'system. Regardless of your system\'s workload\nall '\
-                         'of these checks should pass.'
-              },
-              compliance_threshold: {
-                type: 'number',
-                example: 95.0
-              },
-              score: {
-                type: 'number',
-                example: 63.154762
-              },
-              business_objective: {
-                type: 'string',
-                example: 'APAC Expansion',
-                nullable: true
-              },
-              canonical: {
-                type: 'boolean',
-                example: true
-              },
-              compliant_host_count: {
-                type: 'integer',
-                example: 3
-              },
-              external: {
-                type: 'boolean',
-                example: false
-              },
-              tailored: {
-                type: 'boolean',
-                example: false
-              },
-              total_host_count: {
-                type: 'integer',
-                example: 5
-              },
-              os_major_version: {
-                type: 'string',
-                example: '7'
-              }
-            }
-          },
-          rule_result: {
-            type: 'object',
-            required: %w[result],
-            properties: {
-              result: {
-                type: 'string',
-                example: 'passed'
-              }
-            }
-          },
-          rule: {
-            type: 'object',
-            required: %w[title ref_id],
-            properties: {
-              title: {
-                type: 'string',
-                example: 'Record Access Events to Audit Log directory'
-              },
-              ref_id: {
-                type: 'string',
-                example: 'xccdf_org.ssgproject.content_rule_directory_access_'\
-                'var_log_audit'
-              },
-              severity: {
-                type: 'string',
-                example: 'Low'
-              },
-              description: {
-                type: 'string',
-                example: 'The audit system should collect access '\
-                'audit log directory.\nThe following audit rule will assure '\
-                'that access to audit log directory are\ncollected.\n-a '\
-                'always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000'\
-                '-F auid!=unset -F key=access-audit-trail\nIf the'\
-                'is configured to use the augenrules\nprogram to read audit'\
-                ' rules during daemon startup (the default), add the\nrule to'\
-                ' a file with suffix .rules in the directory\n'\
-                '/etc/audit/rules.d.\nIf the auditd daemon is to use'\
-                ' the auditctl\nutility to read audit rules during daemon '\
-                'startup, add the rule to\n/etc/audit/audit.rules file.'
-              },
-              rationale: {
-                type: 'string',
-                example: 'Attempts to read the logs should be recorded,'\
-                ' suspicious access to audit log files could be an indicator'\
-                ' of malicious activity on a system.\nAuditing these events'\
-                ' could serve as evidence of potential system compromise.'
-              }
-            }
-          }
-        }
-      }
-    }
+    'v1/openapi.json' => Api::V1::Openapi.doc
   }
 end
 
@@ -247,10 +26,6 @@ def autogenerate_examples(example)
     'application/vnd.api+json' => JSON.parse(response.body,
                                              symbolize_names: true)
   }
-end
-
-def ref_schema(label)
-  { '$ref' => "#{SCHEMAS}/#{label}" }
 end
 
 def encoded_header(account = nil)

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -415,7 +415,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "cf8ae1be-2626-4c7b-8134-bda1c78946c6",
+                        "id": "6a888174-88fd-4e80-a100-25550e5f77e6",
                         "type": "account"
                       }
                     },


### PR DESCRIPTION
This should make the API specs much easier to maintain, especially as we
create new API versions. The entire API spec exists under spec/api/vX;
openapi schemas are separated into files depending on resource; utility
functions related to API schemas are separated into their own util
class. Note that this is just a refactoring and does not change the
openapi.json (other than some example ID for some reason).

Signed-off-by: Andrew Kofink <akofink@redhat.com>