### PR TITLE
Implement profiles#destroy endpoint

### DIFF
--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -12,6 +12,11 @@ module V1
       render_json profile
     end
 
+    def destroy
+      authorize profile
+      render_json profile.destroy, status: :accepted
+    end
+
     def tailoring_file
       return unless profile.tailored?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     scope "#{prefix}/#{ENV['APP_NAME']}" do
       namespace :v1 do
         resources :benchmarks, only: [:index, :show]
-        resources :profiles, only: [:index, :show] do
+        resources :profiles, only: [:index, :show, :destroy] do
           member do
             get 'tailoring_file'
           end
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         resources :rules, only: [:index, :show]
       end
       resources :benchmarks, controller: 'v1/benchmarks', only: [:index, :show]
-      resources :profiles, controller: 'v1/profiles', only: [:index, :show] do
+      resources :profiles, controller: 'v1/profiles', only: [:index, :show, :destroy] do
         member do
           get 'tailoring_file'
         end

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -415,7 +415,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "6a888174-88fd-4e80-a100-25550e5f77e6",
+                        "id": "56f767cf-6e55-475b-a8ec-016dd7e48863",
                         "type": "account"
                       }
                     },
@@ -507,6 +507,139 @@
                             "attributes": {
                               "$ref": "#/components/schemas/benchmark"
                             }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Destroy a profile",
+        "tags": [
+          "profile"
+        ],
+        "description": "Destroys a profile",
+        "operationId": "DestroyProfile",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "profile not found",
+            "examples": {
+              "application/vnd.api+json": {
+                "errors": "Resource not found"
+              }
+            },
+            "content": {}
+          },
+          "202": {
+            "description": "destroys a profile",
+            "examples": {
+              "application/vnd.api+json": {
+                "data": {
+                  "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                  "type": "profile",
+                  "attributes": {
+                    "name": "profile1",
+                    "ref_id": "xccdf_org.ssgproject.profile1",
+                    "description": null,
+                    "score": 0,
+                    "parent_profile_id": null,
+                    "external": false,
+                    "compliance_threshold": 100.0,
+                    "os_major_version": "7",
+                    "parent_profile_ref_id": null,
+                    "canonical": true,
+                    "tailored": false,
+                    "total_host_count": 0,
+                    "compliant_host_count": 0,
+                    "business_objective": null
+                  },
+                  "relationships": {
+                    "account": {
+                      "data": {
+                        "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                        "type": "account"
+                      }
+                    },
+                    "benchmark": {
+                      "data": {
+                        "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                        "type": "benchmark"
+                      }
+                    },
+                    "business_objective": {
+                      "data": null
+                    },
+                    "parent_profile": {
+                      "data": null
+                    }
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "$ref": "#/components/schemas/uuid"
+                        },
+                        "attributes": {
+                          "$ref": "#/components/schemas/profile"
+                        },
+                        "relationships": {
+                          "account": {
+                            "$ref": "#/components/schemas/relationship"
+                          },
+                          "benchmark": {
+                            "$ref": "#/components/schemas/relationship"
+                          },
+                          "parent_profile": {
+                            "$ref": "#/components/schemas/relationship"
                           }
                         }
                       }

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -11,28 +11,74 @@ module V1
       profiles(:one).update! account: accounts(:test)
     end
 
-    test 'tailoring_file with a canonical profile returns no content' do
-      profiles(:one).update! rules: [rules(:one)]
-      get tailoring_file_v1_profile_url(profiles(:one).id)
-      assert_response :no_content
+    class TailoringFileTest < ProfilesControllerTest
+      test 'tailoring_file with a canonical profile returns no content' do
+        profiles(:one).update! rules: [rules(:one)]
+        get tailoring_file_v1_profile_url(profiles(:one).id)
+        assert_response :no_content
+      end
+
+      test 'tailoring_file with a noncanonical profile matching its parent'\
+        'returns no content' do
+        profiles(:two).update!(rules: [rules(:one)])
+        profiles(:one).update!(parent_profile: profiles(:two),
+                               rules: [rules(:one)])
+        get tailoring_file_v1_profile_url(profiles(:one).id)
+        assert_response :no_content
+      end
+
+      test 'tailoring_file with a noncanonical profile '\
+           'returns tailoring file' do
+        profiles(:two).update!(rules: [rules(:one), rules(:two)])
+        profiles(:one).update!(parent_profile: profiles(:two),
+                               rules: [rules(:one)])
+        get tailoring_file_v1_profile_url(profiles(:one).id)
+        assert_response :success
+        assert_equal Mime[:xml].to_s, @response.content_type
+      end
     end
 
-    test 'tailoring_file with a noncanonical profile matching its parent'\
-      'returns no content' do
-      profiles(:two).update!(rules: [rules(:one)])
-      profiles(:one).update!(parent_profile: profiles(:two),
-                             rules: [rules(:one)])
-      get tailoring_file_v1_profile_url(profiles(:one).id)
-      assert_response :no_content
-    end
+    class DestroyTest < ProfilesControllerTest
+      require 'sidekiq/testing'
+      Sidekiq::Testing.inline!
 
-    test 'tailoring_file with a noncanonical profile returns tailoring file' do
-      profiles(:two).update!(rules: [rules(:one), rules(:two)])
-      profiles(:one).update!(parent_profile: profiles(:two),
-                             rules: [rules(:one)])
-      get tailoring_file_v1_profile_url(profiles(:one).id)
-      assert_response :success
-      assert_equal Mime[:xml].to_s, @response.content_type
+      test 'destroy an existing, accessible profile' do
+        profile_id = profiles(:one).id
+        assert_difference('Profile.count' => -1) do
+          delete profile_path(profile_id)
+        end
+        assert_response :success
+        assert_equal 202, response.status, 'Response should be 202 accepted'
+        assert_equal profile_id, JSON.parse(response.body).dig('data', 'id'),
+                     'Profile ID did not match deleted profile'
+      end
+
+      test 'v1 destroy an existing, accessible profile' do
+        profile_id = profiles(:one).id
+        assert_difference('Profile.count' => -1) do
+          delete v1_profile_path(profile_id)
+        end
+        assert_response :success
+        assert_equal 202, response.status, 'Response should be 202 accepted'
+        assert_equal profile_id, JSON.parse(response.body).dig('data', 'id'),
+                     'Profile ID did not match deleted profile'
+      end
+
+      test 'destroy a non-existant profile' do
+        profile_id = profiles(:one).id
+        profiles(:one).destroy
+        assert_difference('Profile.count' => 0) do
+          delete v1_profile_path(profile_id)
+        end
+        assert_response :not_found
+      end
+
+      test 'destroy an existing, not accessible profile' do
+        assert_difference('Profile.count' => 0) do
+          delete v1_profile_path(profiles(:two).id)
+        end
+        assert_response :not_found
+      end
     end
   end
 end


### PR DESCRIPTION
A user may destroy any profile that is associated to their account, both
internal or external. Destroying a profile also removes associated test
results.

Towards https://projects.engineering.redhat.com/browse/RHICOMPL-595

```json
$ http DELETE https://ci.foo.redhat.com:1337/api/compliance/profiles/e8c1675a-49a0-4ac6-aa60-b58508a5c0d6
HTTP/1.1 202 Accepted
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: X-Requested-With,content-type
Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, PATCH, DELETE
Access-Control-Allow-Origin: *
cache-control: no-cache
connection: close
content-type: application/vnd.api+json
date: Mon, 08 Jun 2020 18:26:30 GMT
transfer-encoding: chunked
vary: Origin
x-request-id: be4cec94-709f-4864-a7d5-650cfadeac89
x-runtime: 0.260293

{
    "data": {
        "attributes": {
            "business_objective": null,
            "canonical": false,
            "compliance_threshold": 100.0,
            "compliant_host_count": 0,
            "description": "The HIPAA Security Rule establishes U.S. national standards to protect individuals’\nelectronic personal health information that is created, received, used, or\nmaintained by a covered entity. The Security Rule requires appropriate\nadministrative, physical and technical safeguards to ensure the\nconfidentiality, integrity, and security of electronic protected health\ninformation.\n\nThis profile configures Red Hat Enterprise Linux 7 to the HIPAA Security\nRule identified for securing of electronic protected health information.",
            "external": true,
            "name": "Health Insurance Portability and Accountability Act (HIPAA)",
            "os_major_version": "7",
            "parent_profile_id": "74fc0c7f-2f2d-4e4e-8688-76a8406b57ee",
            "parent_profile_ref_id": "xccdf_org.ssgproject.content_profile_hipaa",
            "ref_id": "xccdf_org.ssgproject.content_profile_hipaa",
            "score": 0,
            "tailored": true,
            "total_host_count": 0
        },
        "id": "e8c1675a-49a0-4ac6-aa60-b58508a5c0d6",
        "relationships": {
            "account": {
                "data": {
                    "id": "8c926d2a-17d6-4398-8895-2652971113c1",
                    "type": "account"
                }
            },
            "benchmark": {
                "data": {
                    "id": "3401d042-81a9-4155-b63a-5a114cfe702e",
                    "type": "benchmark"
                }
            },
            "business_objective": {
                "data": null
            },
            "parent_profile": {
                "data": {
                    "id": "74fc0c7f-2f2d-4e4e-8688-76a8406b57ee",
                    "type": "profile"
                }
            }
        },
        "type": "profile"
    }
}
```

CC @Victoremepunto 

Signed-off-by: Andrew Kofink <akofink@redhat.com>