### PR TITLE
Users may view/search for canonical profiles

### DIFF
--- a/app/policies/profile_policy.rb
+++ b/app/policies/profile_policy.rb
@@ -23,7 +23,7 @@ class ProfilePolicy < ApplicationPolicy
     def resolve
       return scope.where('1=0') if user&.account_id.blank?
 
-      scope.where(account_id: user.account_id)
+      scope.where(account_id: user.account_id).or(scope.canonical)
     end
   end
 end

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -74,10 +74,19 @@ module V1
       end
 
       test 'destroy an existing, not accessible profile' do
+        profiles(:two).update! parent_profile: profiles(:one)
         assert_difference('Profile.count' => 0) do
           delete v1_profile_path(profiles(:two).id)
         end
         assert_response :not_found
+      end
+
+      test 'destroy an existing, accessible profile that is not authorized '\
+           'to be deleted' do
+        assert_difference('Profile.count' => 0) do
+          delete v1_profile_path(profiles(:two).id)
+        end
+        assert_response :forbidden
       end
     end
   end

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -83,8 +83,11 @@ class ProfileQueryTest < ActiveSupport::TestCase
       context: { current_user: users(:test) }
     )
 
-    assert_equal 2, result['data']['allProfiles'].first['totalHostCount']
-    assert_equal 1, result['data']['allProfiles'].first['compliantHostCount']
-    assert_not result['data']['allProfiles'].first['businessObjective']
+    profile1_result = result['data']['allProfiles'].find do |h|
+      h['name'] == 'profile1'
+    end
+    assert_equal 2, profile1_result['totalHostCount']
+    assert_equal 1, profile1_result['compliantHostCount']
+    assert_not profile1_result['businessObjective']
   end
 end

--- a/test/policies/profile_policy_test.rb
+++ b/test/policies/profile_policy_test.rb
@@ -3,7 +3,10 @@
 require 'test_helper'
 
 class ProfilePolicyTest < ActiveSupport::TestCase
-  test 'only profiles within the account are accessible' do
+  test 'only noncanonical profiles within the account and '\
+       'canonical profiles are accessible' do
+    profiles(:two).update!(parent_profile: profiles(:one))
+    assert_not profiles(:two).reload.canonical?
     assert_empty Pundit.policy_scope(users(:test), Profile)
     users(:test).account = accounts(:test)
     profiles(:one).account_id = accounts(:test).id

--- a/test/policies/test_result_policy_test.rb
+++ b/test/policies/test_result_policy_test.rb
@@ -10,6 +10,8 @@ class TestResultPolicyTest < ActiveSupport::TestCase
   end
 
   test 'only test results within visible profiles are accessible' do
+    profiles(:two).update!(parent_profile: profiles(:one))
+    assert_not test_results(:two).profile.canonical?
     profiles(:one).account = accounts(:test)
     profiles(:one).save
     assert_includes Pundit.policy_scope(users(:test), Profile), profiles(:one)
@@ -29,6 +31,8 @@ class TestResultPolicyTest < ActiveSupport::TestCase
   end
 
   test 'only test results within visible hosts are accessible' do
+    profiles(:two).update!(parent_profile: profiles(:one))
+    assert_not test_results(:two).profile.canonical?
     hosts(:one).account = accounts(:test)
     hosts(:one).save
     assert_includes Pundit.policy_scope(users(:test), Host), hosts(:one)


### PR DESCRIPTION
This updates the pundit policy for profiles to allow users to see
canonical profiles when searching or listing profiles

Canonical profiles must be visible to any user in order to pick a parent
profile during policy creation via the API or UI.
Note: Currently the UI does not use this pundit policy to limit the scope of
profiles visible to the user.

Requires frontend changes to add `canonical = false` to profile queries:
- https://github.com/RedHatInsights/compliance-frontend/pull/624
- https://github.com/RedHatInsights/frontend-components/pull/556

Signed-off-by: Andrew Kofink <akofink@redhat.com>