### PR TITLE
RHICOMPL-668 - Import os_major/minor on report parsing

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -14,11 +14,10 @@ module Mutations
 
     def inventory_host(id)
       ::HostInventoryAPI.new(
-        id,
         current_user.account,
         ::Settings.host_inventory_url,
         nil # infer identity from account
-      ).inventory_host
+      ).inventory_host(id)
     end
   end
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -363,8 +363,8 @@ type System implements Node {
     profileId: String
   ): String
   name: String!
-  osMajor: Int
-  osMinor: Int
+  osMajorVersion: Int
+  osMinorVersion: Int
   profiles: [Profile!]
   rulesFailed(
     """

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -363,6 +363,8 @@ type System implements Node {
     profileId: String
   ): String
   name: String!
+  osMajor: Int
+  osMinor: Int
   profiles: [Profile!]
   rulesFailed(
     """

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -9,6 +9,8 @@ module Types
 
     field :id, ID, null: false
     field :name, String, null: false
+    field :os_major, Int, null: true
+    field :os_minor, Int, null: true
     field :profiles, [::Types::Profile], null: true
     field :rules_passed, Int, null: false do
       argument :profile_id, String, 'Filter results by profile ID',

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -9,8 +9,8 @@ module Types
 
     field :id, ID, null: false
     field :name, String, null: false
-    field :os_major, Int, null: true
-    field :os_minor, Int, null: true
+    field :os_major_version, Int, null: true
+    field :os_minor_version, Int, null: true
     field :profiles, [::Types::Profile], null: true
     field :rules_passed, Int, null: false do
       argument :profile_id, String, 'Filter results by profile ID',

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -3,9 +3,7 @@
 # Host representation in insights compliance backend. Most of the times
 # these hosts will also show up in the insights-platform host inventory.
 class Host < ApplicationRecord
-  scoped_search on: %i[id name account_id os_major os_minor]
-  scoped_search on: :os_major, aliases: [:os_major_release]
-  scoped_search on: :os_minor, aliases: [:os_minor_release]
+  scoped_search on: %i[id name account_id os_major_version os_minor_version]
   scoped_search on: :compliant, ext_method: 'filter_by_compliance',
                 only_explicit: true
   scoped_search on: :compliance_score, ext_method: 'filter_by_compliance_score',

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -4,6 +4,8 @@
 # these hosts will also show up in the insights-platform host inventory.
 class Host < ApplicationRecord
   scoped_search on: %i[id name account_id os_major os_minor]
+  scoped_search on: :os_major, aliases: [:os_major_release]
+  scoped_search on: :os_minor, aliases: [:os_minor_release]
   scoped_search on: :compliant, ext_method: 'filter_by_compliance',
                 only_explicit: true
   scoped_search on: :compliance_score, ext_method: 'filter_by_compliance_score',

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -3,7 +3,7 @@
 # Host representation in insights compliance backend. Most of the times
 # these hosts will also show up in the insights-platform host inventory.
 class Host < ApplicationRecord
-  scoped_search on: %i[id name account_id]
+  scoped_search on: %i[id name account_id os_major os_minor]
   scoped_search on: :compliant, ext_method: 'filter_by_compliance',
                 only_explicit: true
   scoped_search on: :compliance_score, ext_method: 'filter_by_compliance_score',

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -46,11 +46,10 @@ module Xccdf
 
     def inventory_host
       @inventory_host ||= ::HostInventoryAPI.new(
-        @host_inventory_id,
         @account,
         ::Settings.host_inventory_url,
         @b64_identity
-      ).inventory_host
+      ).inventory_host(@host_inventory_id)
     end
   end
 end

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -42,9 +42,7 @@ class HostInventoryAPI
     )
     response.body['results'].inject([]) do |acc, host|
       os_major, os_minor = host['system_profile']['os_release'].split('.')
-      os_releases << { id: host['id'],
-                       os_major: os_major,
-                       os_minor: os_minor }
+      acc << { id: host['id'], os_major: os_major, os_minor: os_minor }
     end
   end
 

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -29,8 +29,8 @@ class HostInventoryAPI
     raise ::InventoryHostNotFound if @inventory_host.blank?
 
     if (os_release = system_profile([host_id]).first)
-      @inventory_host[:os_major] = os_release[:os_major]
-      @inventory_host[:os_minor] = os_release[:os_minor]
+      @inventory_host[:os_major_version] = os_release[:os_major_version]
+      @inventory_host[:os_minor_version] = os_release[:os_minor_version]
     end
     @inventory_host
   end
@@ -42,7 +42,9 @@ class HostInventoryAPI
     )
     JSON.parse(response.body)['results'].inject([]) do |acc, host|
       os_major, os_minor = host['system_profile']['os_release'].split('.')
-      acc << { id: host['id'], os_major: os_major, os_minor: os_minor }
+      acc << { id: host['id'],
+               os_major_version: os_major,
+               os_minor_version: os_minor }
     end
   end
 

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -29,8 +29,8 @@ class HostInventoryAPI
     raise ::InventoryHostNotFound if @inventory_host.blank?
 
     if (os_release = system_profile([host_id]).first)
-      @inventory_host.os_major = os_release[:os_major]
-      @inventory_host.os_minor = os_release[:os_minor]
+      @inventory_host[:os_major] = os_release[:os_major]
+      @inventory_host[:os_minor] = os_release[:os_minor]
     end
     @inventory_host
   end
@@ -44,11 +44,6 @@ class HostInventoryAPI
       os_major, os_minor = host['system_profile']['os_release'].split('.')
       acc << { id: host['id'], os_major: os_major, os_minor: os_minor }
     end
-  end
-
-  def import_os_releases(ids)
-    os_releases = system_profile(ids)
-    Host.import os_releases
   end
 
   private

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -15,47 +15,47 @@ class HostInventoryAPI
     @b64_identity = b64_identity || @account.b64_identity
   end
 
-  def host_already_in_inventory(id)
+  def host_already_in_inventory(host_id)
     response = Platform.connection.get(
-      "#{@url}/#{id}", {}, X_RH_IDENTITY: @b64_identity
+      "#{@url}/#{host_id}", {}, X_RH_IDENTITY: @b64_identity
     )
-    find_results(JSON.parse(response.body))
+    find_results(JSON.parse(response.body), host_id)
   end
 
-  def inventory_host
+  def inventory_host(host_id)
     return @inventory_host if @inventory_host.present?
 
-    @inventory_host = host_already_in_inventory(@id)
+    @inventory_host = host_already_in_inventory(host_id)
     raise ::InventoryHostNotFound if @inventory_host.blank?
 
-    if (os_release = host_os_releases([@id]).first)
-      @inventory_host.os_major = os_release.os_major
-      @inventory_host.os_minor = os_release.os_minor
+    if (os_release = system_profile([host_id]).first)
+      @inventory_host.os_major = os_release[:os_major]
+      @inventory_host.os_minor = os_release[:os_minor]
     end
     @inventory_host
   end
 
-  def host_os_releases(ids)
+  def system_profile(ids)
     response = Platform.connection.get(
       "#{@url}/#{ids.join(',')}/system_profile", { per_page: 50, page: 1 },
       X_RH_IDENTITY: @b64_identity
     )
-    response.body['results'].inject([]) do |acc, host|
+    JSON.parse(response.body)['results'].inject([]) do |acc, host|
       os_major, os_minor = host['system_profile']['os_release'].split('.')
       acc << { id: host['id'], os_major: os_major, os_minor: os_minor }
     end
   end
 
   def import_os_releases(ids)
-    os_releases = host_os_releases(ids)
+    os_releases = system_profile(ids)
     Host.import os_releases
   end
 
   private
 
-  def find_results(body)
+  def find_results(body, host_id)
     body['results'].find do |host|
-      host['account'] == @account.account_number && host['id'] == @id
+      host['account'] == @account.account_number && host['id'] == host_id
     end
   end
 end

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -27,11 +27,10 @@ class HostInventoryAPI
 
     @inventory_host = host_already_in_inventory(@id)
     raise ::InventoryHostNotFound if @inventory_host.blank?
-    os_release = host_os_releases([@id]).first
-    raise ::InventoryInvalidOsRelease unless os_release[:os_major] && os_release[:os_minor]
-
-    @inventory_host.os_major = os_major
-    @inventory_host.os_minor = os_minor
+    if (os_release = host_os_releases([@id]).first)
+      @inventory_host.os_major = os_major
+      @inventory_host.os_minor = os_minor
+    end
     @inventory_host
   end
 

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -27,9 +27,10 @@ class HostInventoryAPI
 
     @inventory_host = host_already_in_inventory(@id)
     raise ::InventoryHostNotFound if @inventory_host.blank?
+
     if (os_release = host_os_releases([@id]).first)
-      @inventory_host.os_major = os_major
-      @inventory_host.os_minor = os_minor
+      @inventory_host.os_major = os_release.os_major
+      @inventory_host.os_minor = os_release.os_minor
     end
     @inventory_host
   end
@@ -39,14 +40,12 @@ class HostInventoryAPI
       "#{@url}/#{ids.join(',')}/system_profile", { per_page: 50, page: 1 },
       X_RH_IDENTITY: @b64_identity
     )
-    os_releases = []
-    response.body['results'].each do |host|
+    response.body['results'].inject([]) do |acc, host|
       os_major, os_minor = host['system_profile']['os_release'].split('.')
       os_releases << { id: host['id'],
                        os_major: os_major,
                        os_minor: os_minor }
     end
-    os_releases
   end
 
   def import_os_releases(ids)

--- a/db/migrate/20200610083045_add_os_major_and_os_minor_to_hosts.rb
+++ b/db/migrate/20200610083045_add_os_major_and_os_minor_to_hosts.rb
@@ -2,5 +2,7 @@ class AddOsMajorAndOsMinorToHosts < ActiveRecord::Migration[5.2]
   def change
     add_column :hosts, :os_major, :integer
     add_column :hosts, :os_minor, :integer
+    add_index :hosts, :os_major
+    add_index :hosts, :os_minor
   end
 end

--- a/db/migrate/20200610083045_add_os_major_and_os_minor_to_hosts.rb
+++ b/db/migrate/20200610083045_add_os_major_and_os_minor_to_hosts.rb
@@ -1,8 +1,8 @@
 class AddOsMajorAndOsMinorToHosts < ActiveRecord::Migration[5.2]
   def change
-    add_column :hosts, :os_major, :integer
-    add_column :hosts, :os_minor, :integer
-    add_index :hosts, :os_major
-    add_index :hosts, :os_minor
+    add_column :hosts, :os_major_version, :integer
+    add_column :hosts, :os_minor_version, :integer
+    add_index :hosts, :os_major_version
+    add_index :hosts, :os_minor_version
   end
 end

--- a/db/migrate/20200610083045_add_os_major_and_os_minor_to_hosts.rb
+++ b/db/migrate/20200610083045_add_os_major_and_os_minor_to_hosts.rb
@@ -1,0 +1,6 @@
+class AddOsMajorAndOsMinorToHosts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :hosts, :os_major, :integer
+    add_column :hosts, :os_minor, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,10 +57,12 @@ ActiveRecord::Schema.define(version: 2020_06_10_083045) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "account_id"
-    t.integer "os_major"
-    t.integer "os_minor"
+    t.integer "os_major_version"
+    t.integer "os_minor_version"
     t.index ["account_id"], name: "index_hosts_on_account_id"
     t.index ["name"], name: "index_hosts_on_name"
+    t.index ["os_major_version"], name: "index_hosts_on_os_major_version"
+    t.index ["os_minor_version"], name: "index_hosts_on_os_minor_version"
   end
 
   create_table "profile_hosts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_205535) do
+ActiveRecord::Schema.define(version: 2020_06_10_083045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 2020_04_28_205535) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "account_id"
+    t.integer "os_major"
+    t.integer "os_minor"
     t.index ["account_id"], name: "index_hosts_on_account_id"
     t.index ["name"], name: "index_hosts_on_name"
   end

--- a/lib/tasks/import_host_os_releases.rake
+++ b/lib/tasks/import_host_os_releases.rake
@@ -11,11 +11,12 @@ task import_host_os_releases: :environment do
   begin
     start_time = Time.now.utc
     puts "Starting import_host_os_releases job at #{start_time}"
+    inventory_api = HostInventoryAPI.new(
+      Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
+    )
     ::Host.find_in_batches(batch_size: 50) do |hosts|
       begin
-        HostInventoryAPI.new(
-          Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
-        ).import_os_releases(host_ids)
+        inventory_api.import_os_releases(host_ids)
       rescue Faraday::ClientError => e
         Rails.logger.info("#{e.message} #{e.response}")
       end

--- a/lib/tasks/import_host_os_releases.rake
+++ b/lib/tasks/import_host_os_releases.rake
@@ -21,23 +21,18 @@ task import_host_os_releases: :environment do
         begin
           os_releases = inventory_api.system_profile(hosts.pluck(:id))
           print "Found OS releases for account #{account.account_number}: "
-          puts "#{os_releases}"
-          print "Importing..."
+          puts os_releases
+          print 'Importing...'
           Host.import os_releases
-          puts "IMPORTED"
+          puts 'IMPORTED'
         rescue Faraday::ClientError => e
           Rails.logger.info("#{e.message} #{e.response}")
         end
       end
     end
-    end_time = Time.now.utc
-    duration = end_time - start_time
-    puts "Finishing import_host_os_releases job at #{end_time} "\
-         "and last #{duration} seconds"
+    puts "Finishing import_host_os_releases job at #{Time.now.utc} "\
+         "and last #{end_time - start_time} seconds"
   rescue StandardError => e
-    ExceptionNotifier.notify_exception(
-      e,
-      data: OpenshiftEnvironment.summary
-    )
+    ExceptionNotifier.notify_exception(e, data: OpenshiftEnvironment.summary)
   end
 end

--- a/lib/tasks/import_host_os_releases.rake
+++ b/lib/tasks/import_host_os_releases.rake
@@ -16,7 +16,7 @@ task import_host_os_releases: :environment do
     )
     ::Host.find_in_batches(batch_size: 50) do |hosts|
       begin
-        inventory_api.import_os_releases(host_ids)
+        inventory_api.import_os_releases(hosts.pluck(:id))
       rescue Faraday::ClientError => e
         Rails.logger.info("#{e.message} #{e.response}")
       end

--- a/lib/tasks/import_host_os_releases.rake
+++ b/lib/tasks/import_host_os_releases.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+desc <<-END_DESC
+  Imports the os_release field from the system_profile stored in the Inventory.
+
+  Examples:
+    # JOBS_ACCOUNT_NUMBER=000001 rake import_host_os_releases
+END_DESC
+
+task import_host_os_releases: :environment do
+  begin
+    start_time = Time.now.utc
+    puts "Starting import_host_os_releases job at #{start_time}"
+    ::Host.find_in_batches(batch_size: 50) do |hosts|
+      begin
+        HostInventoryAPI.new(
+          Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
+        ).import_os_releases(host_ids)
+      rescue Faraday::ClientError => e
+        Rails.logger.info("#{e.message} #{e.response}")
+      end
+    end
+    end_time = Time.now.utc
+    duration = end_time - start_time
+    puts "Finishing import_host_os_releases job at #{end_time} "\
+         "and last #{duration} seconds"
+  rescue StandardError => e
+    ExceptionNotifier.notify_exception(
+      e,
+      data: OpenshiftEnvironment.summary
+    )
+  end
+end

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -9,8 +9,8 @@ task sync_with_inventory: [:environment] do
     account.hosts.each do |host|
       begin
         host = ::HostInventoryAPI.new(
-          host.id, account, ::Settings.host_inventory_url, account.b64_identity
-        ).inventory_host
+          account, ::Settings.host_inventory_url, account.b64_identity
+        ).inventory_host(host.id)
       rescue ::InventoryHostNotFound
         print "Account #{account.account_number}: "\
           "System #{host.id} - #{host.name} not found in the inventory. "\

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -14,6 +14,9 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     @b64_identity = '1234abcd'
     @api = HostInventoryAPI.new(@account, @url, @b64_identity)
     @connection = mock('faraday_connection')
+    @system_profile_response = OpenStruct.new(body: {
+      results: [{ id: @host.id, system_profile: { os_release: '8.2' } }]
+    }.to_json)
     Platform.stubs(:connection).returns(@connection)
   end
 
@@ -31,15 +34,12 @@ class HostInventoryApiTest < ActiveSupport::TestCase
 
   test 'inventory_host for host already in inventory' do
     @api.expects(:host_already_in_inventory).returns(@host)
-    system_profile_response = OpenStruct.new(body: {
-      results: [{ id: @host.id, system_profile: { os_release: '8.2' } }]
-    }.to_json)
     @connection.expects(:get).with(
       "#{@url}#{ENV['PATH_PREFIX']}/inventory/v1/hosts/"\
       "#{@host.id}/system_profile",
       { per_page: 50, page: 1 },
       X_RH_IDENTITY: @b64_identity
-    ).returns(system_profile_response)
+    ).returns(@system_profile_response)
     assert_equal @host, @api.inventory_host(@host.id)
     assert_equal 8, @host.os_major
     assert_equal 2, @host.os_minor
@@ -66,5 +66,34 @@ class HostInventoryApiTest < ActiveSupport::TestCase
       @host.id,
       'find_results did not return the expected match by ID'
     )
+  end
+
+  test 'system_profile returns a hash with OS info if found' do
+    @connection.expects(:get).with(
+      "#{@url}#{ENV['PATH_PREFIX']}/inventory/v1/hosts/"\
+      "#{@host.id}/system_profile",
+      { per_page: 50, page: 1 },
+      X_RH_IDENTITY: @b64_identity
+    ).returns(@system_profile_response)
+    system_profile_results = @api.system_profile([@host.id])
+    assert_equal '8', system_profile_results.first[:os_major]
+    assert_equal '2', system_profile_results.first[:os_minor]
+    assert_equal @host.id, system_profile_results.first[:id]
+  end
+
+  test 'system_profile returns a hash without OS info if not found' do
+    wrong_system_profile_response = OpenStruct.new(body: {
+      results: [{ id: @host.id, system_profile: { os_release: '' } }]
+    }.to_json)
+    @connection.expects(:get).with(
+      "#{@url}#{ENV['PATH_PREFIX']}/inventory/v1/hosts/"\
+      "#{@host.id}/system_profile",
+      { per_page: 50, page: 1 },
+      X_RH_IDENTITY: @b64_identity
+    ).returns(wrong_system_profile_response)
+    system_profile_results = @api.system_profile([@host.id])
+    assert_equal nil, system_profile_results.first[:os_major]
+    assert_equal nil, system_profile_results.first[:os_minor]
+    assert_equal @host.id, system_profile_results.first[:id]
   end
 end

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -12,8 +12,7 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     @host = hosts(:one)
     @url = 'http://localhost'
     @b64_identity = '1234abcd'
-    @api = HostInventoryAPI.new(@host.id, @account,
-                                @url, @b64_identity)
+    @api = HostInventoryAPI.new(@account, @url, @b64_identity)
     @connection = mock('faraday_connection')
     Platform.stubs(:connection).returns(@connection)
   end
@@ -32,22 +31,33 @@ class HostInventoryApiTest < ActiveSupport::TestCase
 
   test 'inventory_host for host already in inventory' do
     @api.expects(:host_already_in_inventory).returns(@host)
-    assert_equal @host, @api.inventory_host
+    system_profile_response = OpenStruct.new(body: {
+      results: [{ id: @host.id, system_profile: { os_release: '8.2' }}]
+    }.to_json)
+    @connection.expects(:get).with(
+      "#{@url}#{ENV['PATH_PREFIX']}/inventory/v1/hosts/#{@host.id}/system_profile",
+      { per_page: 50, page: 1 },
+      X_RH_IDENTITY: @b64_identity
+    ).returns(system_profile_response)
+    assert_equal @host, @api.inventory_host(@host.id)
+    assert_equal 8, @host.os_major
+    assert_equal 2, @host.os_minor
   end
 
   test 'inventory_host for host not already in inventory' do
     assert_raises(::InventoryHostNotFound) do
       @api.expects(:host_already_in_inventory).returns(nil)
-      @api.inventory_host
+      @api.inventory_host(@host.id)
     end
   end
 
   test 'find_results matches on ID' do
     assert_equal(
       @api.send(
-        :find_results, 'results' => [
+        :find_results, { 'results' => [
           { 'account' => @account.account_number, 'id' => @host.id }
-        ]
+        ]},
+        @host.id
       )['id'],
       @host.id,
       'find_results did not return the expected match by ID'

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -41,8 +41,8 @@ class HostInventoryApiTest < ActiveSupport::TestCase
       X_RH_IDENTITY: @b64_identity
     ).returns(@system_profile_response)
     assert_equal @host, @api.inventory_host(@host.id)
-    assert_equal 8, @host.os_major
-    assert_equal 2, @host.os_minor
+    assert_equal 8, @host.os_major_version
+    assert_equal 2, @host.os_minor_version
   end
 
   test 'inventory_host for host not already in inventory' do
@@ -76,8 +76,8 @@ class HostInventoryApiTest < ActiveSupport::TestCase
       X_RH_IDENTITY: @b64_identity
     ).returns(@system_profile_response)
     system_profile_results = @api.system_profile([@host.id])
-    assert_equal '8', system_profile_results.first[:os_major]
-    assert_equal '2', system_profile_results.first[:os_minor]
+    assert_equal '8', system_profile_results.first[:os_major_version]
+    assert_equal '2', system_profile_results.first[:os_minor_version]
     assert_equal @host.id, system_profile_results.first[:id]
   end
 
@@ -92,8 +92,8 @@ class HostInventoryApiTest < ActiveSupport::TestCase
       X_RH_IDENTITY: @b64_identity
     ).returns(wrong_system_profile_response)
     system_profile_results = @api.system_profile([@host.id])
-    assert_equal nil, system_profile_results.first[:os_major]
-    assert_equal nil, system_profile_results.first[:os_minor]
+    assert_equal nil, system_profile_results.first[:os_major_version]
+    assert_equal nil, system_profile_results.first[:os_minor_version]
     assert_equal @host.id, system_profile_results.first[:id]
   end
 end

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -32,10 +32,11 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   test 'inventory_host for host already in inventory' do
     @api.expects(:host_already_in_inventory).returns(@host)
     system_profile_response = OpenStruct.new(body: {
-      results: [{ id: @host.id, system_profile: { os_release: '8.2' }}]
+      results: [{ id: @host.id, system_profile: { os_release: '8.2' } }]
     }.to_json)
     @connection.expects(:get).with(
-      "#{@url}#{ENV['PATH_PREFIX']}/inventory/v1/hosts/#{@host.id}/system_profile",
+      "#{@url}#{ENV['PATH_PREFIX']}/inventory/v1/hosts/"\
+      "#{@host.id}/system_profile",
       { per_page: 50, page: 1 },
       X_RH_IDENTITY: @b64_identity
     ).returns(system_profile_response)
@@ -54,9 +55,12 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   test 'find_results matches on ID' do
     assert_equal(
       @api.send(
-        :find_results, { 'results' => [
-          { 'account' => @account.account_number, 'id' => @host.id }
-        ]},
+        :find_results, {
+          'results' =>
+          [
+            { 'account' => @account.account_number, 'id' => @host.id }
+          ]
+        },
         @host.id
       )['id'],
       @host.id,

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -35,13 +35,33 @@ class XccdfReportParserTest < ActiveSupport::TestCase
           'fqdn' => @report_parser.test_result_file.test_result.host }
       ]
     }
-    connection.stubs(:get).returns(OpenStruct.new(body: get_body.to_json))
+    connection.stubs(:get).with(
+      "#{::Settings.host_inventory_url}#{ENV['PATH_PREFIX']}" \
+      "/inventory/v1/hosts/#{@host_id}",
+      {}, X_RH_IDENTITY: 'b64_fake_identity'
+    ).returns(OpenStruct.new(body: get_body.to_json))
     post_body = {
       'data' => [{ 'host' => {
         'name' => @report_parser.test_result_file.test_result.host
       } }]
     }
     connection.stubs(:post).returns(OpenStruct.new(body: post_body.to_json))
+    system_profile_body = {
+      'results' => [
+        {
+          'id' => @host_id,
+          'system_profile' => {
+            'os_release': '8.3'
+          }
+        }
+      ]
+    }
+    connection.stubs(:get).with(
+      "#{::Settings.host_inventory_url}#{ENV['PATH_PREFIX']}" \
+      "/inventory/v1/hosts/#{[@host_id].join(',')}/system_profile",
+      { per_page: 50, page: 1 },
+      X_RH_IDENTITY: 'b64_fake_identity'
+    ).returns(OpenStruct.new(body: system_profile_body.to_json))
   end
 
   context 'benchmark' do


### PR DESCRIPTION
Just a draft for now. The idea is to have these fields available to us so that:

- Supportability can be quickly checked
- Filtering becomes trivial
- Showing the OS doesn't require us waiting a potentially long time for inventory to release changes
- Hosts without an OS can be quickly deemed unsupported