### PR TITLE
Implement profiles#create endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ gem 'prometheus_exporter', '>= 0.5'
 # Parsing OpenSCAP reports library
 gem 'openscap_parser', '~> 1.0.0'
 
+# REST API parameter type checking
+gem 'stronger_parameters'
+
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stronger_parameters (2.12.1)
+      actionpack (>= 3.2, < 6.1)
     systemu (2.6.5)
     thor (1.0.1)
     thread_safe (0.3.6)
@@ -385,6 +387,7 @@ DEPENDENCIES
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
+  stronger_parameters
   tzinfo-data
   uuid
   webmock

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,20 @@ class ApplicationController < ActionController::API
   include Search
   include Rendering
 
+  ParamType = ActionController::Parameters
+
   def openapi
     send_file Rails.root.join('swagger/v1/openapi.v3.yaml')
+  end
+
+  def pundit_scope
+    Pundit.policy_scope(current_user, resource)
+  end
+
+  def resource_params
+    params.permit(data: ParamType.map(attributes: ParamType.map))
+    params.require(:data).require(:attributes)
+          .permit(serializer.attributes_to_serialize.keys)
   end
 
   rescue_from Pundit::NotAuthorizedError do
@@ -22,13 +34,19 @@ class ApplicationController < ActionController::API
 
   rescue_from ActiveRecord::RecordNotFound do |error|
     logger.info "#{error.message} (#{error.class})"
-    render json: { errors: 'Resource not found' },
+    render json: { errors: "#{error.model} not found with ID #{error.id}" },
            status: :not_found
   end
 
   rescue_from ActionController::ParameterMissing do |error|
     logger.info "#{error.message} (#{error.class})"
     render json: { errors: "Parameter missing: #{error.message}" },
+           status: :unprocessable_entity
+  end
+
+  rescue_from StrongerParameters::InvalidParameter do |error|
+    logger.info "#{error.message} (#{error.class})"
+    render json: { errors: error.message },
            status: :unprocessable_entity
   end
 end

--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -3,6 +3,11 @@
 module V1
   # API for Profiles
   class ProfilesController < ApplicationController
+    ALLOWED_CREATE_ATTRIBUTES = %i[
+      name description compliance_threshold business_objective
+      parent_profile_id
+    ].freeze
+
     def index
       params[:search] ||= 'external=false and canonical=false'
       render_json scope_search.sort_by(&:score)
@@ -16,6 +21,16 @@ module V1
     def destroy
       authorize profile
       render_json profile.destroy, status: :accepted
+    end
+
+    def create
+      profile = Profile.new(profile_create_attributes).fill_from_parent
+
+      if profile.save
+        render_json profile, status: :created
+      else
+        render_error profile
+      end
     end
 
     def tailoring_file
@@ -34,7 +49,31 @@ module V1
     end
 
     def profile
-      @profile ||= Pundit.policy_scope(current_user, resource).find(params[:id])
+      @profile ||= pundit_scope.find(params[:id])
+    end
+
+    def parent_profile
+      @parent_profile ||= pundit_scope.find(
+        resource_params.require(:parent_profile_id)
+      )
+    end
+
+    def business_objective
+      @business_objective ||= Pundit.policy_scope(
+        current_user, BusinessObjective
+      ).from_title(resource_params[:business_objective])
+    end
+
+    def profile_create_attributes
+      resource_params.to_h.slice(*ALLOWED_CREATE_ATTRIBUTES)
+                     .merge(account_id: current_user.account_id).tap do |attrs|
+        parent_profile
+
+        if business_objective
+          attrs.except! :business_objective
+          attrs[:business_objective_id] = business_objective.id
+        end
+      end
     end
 
     def resource

--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -20,7 +20,7 @@ module Mutations
       def resolve(args = {})
         profile = ::Profile.new(new_profile_options(args))
         profile.save!
-        profile.add_rule_ref_ids(args[:selected_rule_ref_ids])
+        profile.add_rules(ref_ids: args[:selected_rule_ref_ids])
         { profile: profile }
       end
 

--- a/app/models/business_objective.rb
+++ b/app/models/business_objective.rb
@@ -8,6 +8,14 @@ class BusinessObjective < ApplicationRecord
   validates :title, presence: true
 
   scope :in_account, lambda { |account_or_account_id|
-    joins(:accounts).where(accounts: { id: account_or_account_id })
+    joins(:accounts).where(accounts: { id: account_or_account_id }).distinct
   }
+
+  scope :without_profiles, lambda {
+    includes(:profiles).where(profiles: { id: nil })
+  }
+
+  def self.from_title(title)
+    find_or_create_by(title: title) if title
+  end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -6,8 +6,10 @@ class ProfileSerializer
   set_type :profile
   belongs_to :account
   belongs_to :benchmark
-  belongs_to :business_objective
   belongs_to :parent_profile, record_type: :profile
+  has_many :rules
+  has_many :hosts
+  has_many :test_results
   attributes :name, :ref_id, :description, :score, :parent_profile_id,
              :external, :compliance_threshold, :os_major_version
   attribute :parent_profile_ref_id do |profile|

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,3 +3,5 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register "application/vnd.api+json", :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     scope "#{prefix}/#{ENV['APP_NAME']}" do
       namespace :v1 do
         resources :benchmarks, only: [:index, :show]
-        resources :profiles, only: [:index, :show, :destroy] do
+        resources :profiles, only: [:index, :show, :destroy, :create] do
           member do
             get 'tailoring_file'
           end
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         resources :rules, only: [:index, :show]
       end
       resources :benchmarks, controller: 'v1/benchmarks', only: [:index, :show]
-      resources :profiles, controller: 'v1/profiles', only: [:index, :show, :destroy] do
+      resources :profiles, controller: 'v1/profiles', only: [:index, :show, :destroy, :create] do
         member do
           get 'tailoring_file'
         end

--- a/spec/api/v1/schemas.rb
+++ b/spec/api/v1/schemas.rb
@@ -24,12 +24,14 @@ module Api
       SCHEMAS = {
         uuid: UUID,
         relationship: RELATIONSHIP,
+        relationship_collection: RELATIONSHIP_COLLECTION,
         error: ERROR,
         metadata: METADATA,
         host: HOST,
         links: LINKS,
         benchmark: BENCHMARK,
         profile: PROFILE,
+        profile_relationships: PROFILE_RELATIONSHIPS,
         rule_result: RULE_RESULT,
         rule: RULE
       }.freeze

--- a/spec/api/v1/schemas/profiles.rb
+++ b/spec/api/v1/schemas/profiles.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
+require './spec/api/v1/schemas/util'
+
 module Api
   module V1
     module Schemas
       module Profiles
+        extend Api::V1::Schemas::Util
+
         PROFILE = {
           type: 'object',
-          required: %w[name ref_id],
+          required: %w[parent_profile_id],
           properties: {
             parent_profile_id: {
               type: 'string',
               format: 'uuid',
               nullable: true,
-              example: '0105a0f0-7379-4897-a891-f95cfb9ddf9c'
+              example: '0105a0f0-7379-4897-a891-f95cfb9ddf9c',
+              required: true
             },
             parent_profile_ref_id: {
               type: 'string',
@@ -64,6 +69,18 @@ module Api
               type: 'string',
               example: '7'
             }
+          }
+        }.freeze
+
+        PROFILE_RELATIONSHIPS = {
+          type: 'object',
+          properties: {
+            account: ref_schema('relationship'),
+            benchmark: ref_schema('relationship'),
+            parent_profile: ref_schema('relationship'),
+            rules: ref_schema('relationship_collection'),
+            hosts: ref_schema('relationship_collection'),
+            test_results: ref_schema('relationship_collection')
           }
         }.freeze
       end

--- a/spec/api/v1/schemas/types.rb
+++ b/spec/api/v1/schemas/types.rb
@@ -16,6 +16,18 @@ module Api
             type: :string
           }
         }.freeze
+
+        RELATIONSHIP_COLLECTION = {
+          data: {
+            type: :array,
+            items: {
+              properties: {
+                id: ref_schema('uuid'),
+                type: :string
+              }
+            }
+          }
+        }.freeze
       end
     end
   end

--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -65,6 +65,43 @@ describe 'Profiles API' do
         run_test!
       end
     end
+
+    post 'Create a profile' do
+      fixtures :accounts, :profiles, :benchmarks
+      tags 'profile'
+      description 'Create a profile with the provided attributes'
+      operationId 'CreateProfile'
+
+      content_types
+      auth_header
+
+      parameter name: :data, in: :body, required: true, schema: {
+        type: :object,
+        data: {
+          type: :object,
+          properties: {
+            attributes: ref_schema('profile')
+          }
+        }
+      }
+
+      response '201', 'creates a profile' do
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:one)) }
+        let(:include) { '' } # work around buggy rswag
+        let(:data) do
+          { data: { attributes: {
+            parent_profile_id: profiles(:two).id,
+            name: 'A custom name',
+            compliance_threshold: 93.5,
+            business_objective: 'LATAM Expansion'
+          } } }
+        end
+
+        after { |e| autogenerate_examples(e) }
+
+        run_test!
+      end
+    end
   end
 
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/profiles/{id}" do
@@ -110,11 +147,7 @@ describe 'Profiles API' do
                      type: { type: :string },
                      id: ref_schema('uuid'),
                      attributes: ref_schema('profile'),
-                     relationships: {
-                       account: ref_schema('relationship'),
-                       benchmark: ref_schema('relationship'),
-                       parent_profile: ref_schema('relationship')
-                     }
+                     relationships: ref_schema('profile_relationships')
                    }
                  }
                }
@@ -146,11 +179,7 @@ describe 'Profiles API' do
                      id: ref_schema('uuid'),
                      attributes: ref_schema('profile')
                    },
-                   relationships: {
-                     account: ref_schema('relationship'),
-                     benchmark: ref_schema('relationship'),
-                     parent_profile: ref_schema('relationship')
-                   },
+                   relationships: ref_schema('profile_relationships'),
                    included: {
                      type: :array,
                      items: {
@@ -211,11 +240,7 @@ describe 'Profiles API' do
                      type: { type: :string },
                      id: ref_schema('uuid'),
                      attributes: ref_schema('profile'),
-                     relationships: {
-                       account: ref_schema('relationship'),
-                       benchmark: ref_schema('relationship'),
-                       parent_profile: ref_schema('relationship')
-                     }
+                     relationships: ref_schema('profile_relationships')
                    }
                  }
                }

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -296,16 +296,113 @@
             "description": "lists all profiles requested filtered by OS",
             "examples": {
               "application/vnd.api+json": {
-                "data": [],
+                "data": [
+                  {
+                    "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                    "type": "profile",
+                    "attributes": {
+                      "name": "profile1",
+                      "ref_id": "xccdf_org.ssgproject.profile1",
+                      "description": null,
+                      "score": 98.0,
+                      "parent_profile_id": null,
+                      "external": false,
+                      "compliance_threshold": 100.0,
+                      "os_major_version": "7",
+                      "parent_profile_ref_id": null,
+                      "canonical": true,
+                      "tailored": false,
+                      "total_host_count": 0,
+                      "compliant_host_count": 0,
+                      "business_objective": null
+                    },
+                    "relationships": {
+                      "account": {
+                        "data": null
+                      },
+                      "benchmark": {
+                        "data": {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "benchmark"
+                        }
+                      },
+                      "parent_profile": {
+                        "data": null
+                      },
+                      "rules": {
+                        "data": []
+                      },
+                      "hosts": {
+                        "data": []
+                      },
+                      "test_results": {
+                        "data": [
+                          {
+                            "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                            "type": "test_result"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                    "type": "profile",
+                    "attributes": {
+                      "name": "profile2",
+                      "ref_id": "xccdf_org.ssgproject.profile2",
+                      "description": null,
+                      "score": 98.0,
+                      "parent_profile_id": null,
+                      "external": false,
+                      "compliance_threshold": 100.0,
+                      "os_major_version": "7",
+                      "parent_profile_ref_id": null,
+                      "canonical": true,
+                      "tailored": false,
+                      "total_host_count": 0,
+                      "compliant_host_count": 0,
+                      "business_objective": null
+                    },
+                    "relationships": {
+                      "account": {
+                        "data": null
+                      },
+                      "benchmark": {
+                        "data": {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "benchmark"
+                        }
+                      },
+                      "parent_profile": {
+                        "data": null
+                      },
+                      "rules": {
+                        "data": []
+                      },
+                      "hosts": {
+                        "data": []
+                      },
+                      "test_results": {
+                        "data": [
+                          {
+                            "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                            "type": "test_result"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
                 "meta": {
-                  "total": 0,
+                  "total": 2,
                   "search": "os_major_version = 7",
                   "limit": 10,
                   "offset": 1
                 },
                 "links": {
                   "first": "/api/compliance/profiles?limit=10&search=os_major_version = 7&offset=1",
-                  "last": "/api/compliance/profiles?limit=10&search=os_major_version = 7&offset=0"
+                  "last": "/api/compliance/profiles?limit=10&search=os_major_version = 7&offset=1"
                 }
               }
             },
@@ -335,6 +432,99 @@
                           }
                         }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a profile",
+        "tags": [
+          "profile"
+        ],
+        "description": "Create a profile with the provided attributes",
+        "operationId": "CreateProfile",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "creates a profile",
+            "examples": {
+              "application/vnd.api+json": {
+                "data": {
+                  "id": "feb7537d-b530-48db-8b51-0abd226829fa",
+                  "type": "profile",
+                  "attributes": {
+                    "name": "A custom name",
+                    "ref_id": "xccdf_org.ssgproject.profile2",
+                    "description": null,
+                    "score": 0,
+                    "parent_profile_id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                    "external": false,
+                    "compliance_threshold": 93.5,
+                    "os_major_version": "7",
+                    "parent_profile_ref_id": "xccdf_org.ssgproject.profile2",
+                    "canonical": false,
+                    "tailored": false,
+                    "total_host_count": 0,
+                    "compliant_host_count": 0,
+                    "business_objective": "LATAM Expansion"
+                  },
+                  "relationships": {
+                    "account": {
+                      "data": {
+                        "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                        "type": "account"
+                      }
+                    },
+                    "benchmark": {
+                      "data": {
+                        "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                        "type": "benchmark"
+                      }
+                    },
+                    "parent_profile": {
+                      "data": {
+                        "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                        "type": "profile"
+                      }
+                    },
+                    "rules": {
+                      "data": []
+                    },
+                    "hosts": {
+                      "data": []
+                    },
+                    "test_results": {
+                      "data": []
+                    }
+                  }
+                }
+              }
+            },
+            "content": {}
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "type": "object",
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "$ref": "#/components/schemas/profile"
                     }
                   }
                 }
@@ -384,7 +574,7 @@
             "description": "profile not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Resource not found"
+                "errors": "Profile not found with ID invalid"
               }
             },
             "content": {}
@@ -415,7 +605,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "56f767cf-6e55-475b-a8ec-016dd7e48863",
+                        "id": "02f8f65e-8d32-4cef-b0b6-c982cabd855e",
                         "type": "account"
                       }
                     },
@@ -425,11 +615,27 @@
                         "type": "benchmark"
                       }
                     },
-                    "business_objective": {
-                      "data": null
-                    },
                     "parent_profile": {
                       "data": null
+                    },
+                    "rules": {
+                      "data": []
+                    },
+                    "hosts": {
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "host"
+                        }
+                      ]
+                    },
+                    "test_results": {
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "test_result"
+                        }
+                      ]
                     }
                   }
                 },
@@ -471,27 +677,11 @@
                           "$ref": "#/components/schemas/profile"
                         },
                         "relationships": {
-                          "account": {
-                            "$ref": "#/components/schemas/relationship"
-                          },
-                          "benchmark": {
-                            "$ref": "#/components/schemas/relationship"
-                          },
-                          "parent_profile": {
-                            "$ref": "#/components/schemas/relationship"
-                          }
+                          "$ref": "#/components/schemas/profile_relationships"
                         }
                       },
                       "relationships": {
-                        "account": {
-                          "$ref": "#/components/schemas/relationship"
-                        },
-                        "benchmark": {
-                          "$ref": "#/components/schemas/relationship"
-                        },
-                        "parent_profile": {
-                          "$ref": "#/components/schemas/relationship"
-                        }
+                        "$ref": "#/components/schemas/profile_relationships"
                       },
                       "included": {
                         "type": "array",
@@ -557,7 +747,7 @@
             "description": "profile not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Resource not found"
+                "errors": "Profile not found with ID invalid"
               }
             },
             "content": {}
@@ -598,11 +788,17 @@
                         "type": "benchmark"
                       }
                     },
-                    "business_objective": {
-                      "data": null
-                    },
                     "parent_profile": {
                       "data": null
+                    },
+                    "rules": {
+                      "data": []
+                    },
+                    "hosts": {
+                      "data": []
+                    },
+                    "test_results": {
+                      "data": []
                     }
                   }
                 }
@@ -632,15 +828,7 @@
                           "$ref": "#/components/schemas/profile"
                         },
                         "relationships": {
-                          "account": {
-                            "$ref": "#/components/schemas/relationship"
-                          },
-                          "benchmark": {
-                            "$ref": "#/components/schemas/relationship"
-                          },
-                          "parent_profile": {
-                            "$ref": "#/components/schemas/relationship"
-                          }
+                          "$ref": "#/components/schemas/profile_relationships"
                         }
                       }
                     }
@@ -1129,6 +1317,19 @@
           "type": "string"
         }
       },
+      "relationship_collection": {
+        "data": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/uuid"
+              },
+              "type": "string"
+            }
+          }
+        }
+      },
       "error": {
         "type": "object",
         "required": [
@@ -1221,15 +1422,15 @@
       "profile": {
         "type": "object",
         "required": [
-          "name",
-          "ref_id"
+          "parent_profile_id"
         ],
         "properties": {
           "parent_profile_id": {
             "type": "string",
             "format": "uuid",
             "nullable": true,
-            "example": "0105a0f0-7379-4897-a891-f95cfb9ddf9c"
+            "example": "0105a0f0-7379-4897-a891-f95cfb9ddf9c",
+            "required": true
           },
           "parent_profile_ref_id": {
             "type": "string",
@@ -1277,6 +1478,29 @@
           "os_major_version": {
             "type": "string",
             "example": "7"
+          }
+        }
+      },
+      "profile_relationships": {
+        "type": "object",
+        "properties": {
+          "account": {
+            "$ref": "#/components/schemas/relationship"
+          },
+          "benchmark": {
+            "$ref": "#/components/schemas/relationship"
+          },
+          "parent_profile": {
+            "$ref": "#/components/schemas/relationship"
+          },
+          "rules": {
+            "$ref": "#/components/schemas/relationship_collection"
+          },
+          "hosts": {
+            "$ref": "#/components/schemas/relationship_collection"
+          },
+          "test_results": {
+            "$ref": "#/components/schemas/relationship_collection"
           }
         }
       },

--- a/test/models/business_objective_test.rb
+++ b/test/models/business_objective_test.rb
@@ -3,6 +3,17 @@
 require 'test_helper'
 
 class BusinessObjectiveTest < ActiveSupport::TestCase
+  fixtures :profiles, :business_objectives
   should have_many :profiles
   should validate_presence_of :title
+
+  context 'without_accounts' do
+    should 'return orphaned business objectives' do
+      profiles(:one).update! business_objective: business_objectives(:one)
+      assert_includes BusinessObjective.without_profiles,
+                      business_objectives(:two)
+      assert_not_includes BusinessObjective.without_profiles,
+                          business_objectives(:one)
+    end
+  end
 end


### PR DESCRIPTION
Any params not specified are inherited from the parent profile

Minimal params:
```js
{
	"data": {
		"attributes": {
			"parent_profile_id": "1007b72e-7f0f-486f-911a-5c392c724faa"
		}
	}
}
```

All allowable params:
```js
{
	"data": {
		"attributes": {
			"parent_profile_id": "1007b72e-7f0f-486f-911a-5c392c724faa",
			"name": "My profile",
			"description": "The best profile ever",
			"compliance_threshold": 95.0,
			"business_objective": "LATAM Expansion"
		}
	}
}
```

rswag :( I'm trying to figure out how to pass JSON like parameters, but I haven't yet figured it out (see profiles_spec.rb).

Signed-off-by: Andrew Kofink <akofink@redhat.com>