### PR TITLE
Handle RBAC errors appropriately by returning 403

### DIFF
--- a/app/services/rbac_api.rb
+++ b/app/services/rbac_api.rb
@@ -9,12 +9,16 @@ class RbacApi
   end
 
   def check_user
-    body = JSON.parse(access_check_response.body)
-    body['data'].find do |access_check|
-      return true if access_check['permission'] == 'compliance:*:*'
+    begin
+      body = JSON.parse(access_check_response.body)
+      body['data'].find do |access_check|
+        return true if access_check['permission'] == 'compliance:*:*'
+      end
+    rescue Faraday::ClientError => e
+      Rails.logger.info("#{e.message} #{e.response}")
     end
-  rescue Faraday::ClientError => e
-    Rails.logger.info("#{e.message} #{e.response}")
+
+    false
   end
 
   private

--- a/test/services/rbac_api_test.rb
+++ b/test/services/rbac_api_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RbacApiTest < ActiveSupport::TestCase
+  context 'check_user' do
+    setup do
+      @rbac_api = RbacApi.new('')
+      @no_data_response = OpenStruct.new(body: { 'data' => [] }.to_json)
+      @no_compliance_access_response = OpenStruct.new(
+        body: { 'data' => [{ 'permission' => 'remediations:*:*' }] }.to_json
+      )
+      @compliance_access_response = OpenStruct.new(
+        body: { 'data' => [{ 'permission' => 'compliance:*:*' }] }.to_json
+      )
+    end
+
+    should 'return false during rbac/faraday error' do
+      @rbac_api.expects(:access_check_response)
+               .raises(Faraday::ClientError.new(''))
+
+      assert_not @rbac_api.check_user
+    end
+
+    should 'return false when rbac shows no access' do
+      @rbac_api.expects(:access_check_response)
+               .returns(@no_data_response)
+
+      assert_not @rbac_api.check_user
+    end
+
+    should 'return false when rbac shows no access to compliance' do
+      @rbac_api.expects(:access_check_response)
+               .returns(@no_compliance_access_response)
+
+      assert_not @rbac_api.check_user
+    end
+
+    should 'return true when rbac shows access to compliance' do
+      @rbac_api.expects(:access_check_response)
+               .returns(@compliance_access_response)
+
+      assert @rbac_api.check_user
+    end
+  end
+end


### PR DESCRIPTION
Well, this is embarrassing. Fixed, and now with tests!

`Rails.logger.info(...)` returns `true`

Tip: hide whitespace changes for easier reviewing.

https://github.com/RedHatInsights/compliance-backend/pull/503 fixes existing tests on the master branch

Signed-off-by: Andrew Kofink <akofink@redhat.com>