### PR TITLE
Fix failing profiles_controller#index tests

### DIFF
--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -51,6 +51,7 @@ module V1
       end
 
       test 'canonical profiles can be requested' do
+        profiles(:two).update! parent_profile_id: profiles(:one).id
         search_query = 'canonical=true'
         get v1_profiles_url, params: { search: search_query }
         assert_response :success
@@ -82,6 +83,7 @@ module V1
       end
 
       test 'all profile types can be requested at the same time' do
+        profiles(:two).update! parent_profile_id: profiles(:one).id
         internal = Profile.create!(
           account: accounts(:test), name: 'foo', ref_id: 'foo',
           benchmark: benchmarks(:one),


### PR DESCRIPTION
Looks like we merged https://github.com/RedHatInsights/compliance-backend/pull/497 without properly rebasing and re-testing. Anyway, this should fix it.

Signed-off-by: Andrew Kofink <akofink@redhat.com>