### PR TITLE
Allow rules to be tailored on profiles#create API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,7 @@ class ApplicationController < ActionController::API
   include Pagination
   include Search
   include Rendering
-
-  ParamType = ActionController::Parameters
+  include Parameters
 
   def openapi
     send_file Rails.root.join('swagger/v1/openapi.v3.yaml')
@@ -19,12 +18,6 @@ class ApplicationController < ActionController::API
 
   def pundit_scope
     Pundit.policy_scope(current_user, resource)
-  end
-
-  def resource_params
-    params.permit(data: ParamType.map(attributes: ParamType.map))
-    params.require(:data).require(:attributes)
-          .permit(serializer.attributes_to_serialize.keys)
   end
 
   rescue_from Pundit::NotAuthorizedError do

--- a/app/controllers/concerns/parameters.rb
+++ b/app/controllers/concerns/parameters.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Reusable parameter checking for all controllers
+module Parameters
+  extend ActiveSupport::Concern
+
+  ParamType = ActionController::Parameters
+
+  RELATIONSHIP_TYPE = ParamType.map(
+    id: ParamType.string,
+    type: ParamType.string
+  )
+
+  included do
+    def resource_params
+      params.permit(data: ParamType.map(
+        attributes: ParamType.map,
+        relationships: ParamType.map
+      ))
+      params.require(:data).permit(attributes: {}, relationships: {})
+    end
+
+    def resource_attributes
+      resource_params[:attributes]&.permit(
+        serializer.attributes_to_serialize.keys
+      )
+    end
+
+    def resource_relationships
+      resource_params[:relationships]&.permit(relationship_types)
+    end
+
+    private
+
+    def relationship_types
+      serializer.relationships_to_serialize.keys
+                .each_with_object({}) do |relationship, h|
+        h[relationship] = ParamType.map(
+          data: ParamType.array(RELATIONSHIP_TYPE) | RELATIONSHIP_TYPE
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/v1/benchmarks_controller.rb
+++ b/app/controllers/v1/benchmarks_controller.rb
@@ -4,23 +4,21 @@ module V1
   # API for Benchmarks
   class BenchmarksController < ApplicationController
     def index
-      render json: benchmarks
+      render_json benchmarks
     end
 
     def show
-      render json: benchmark
+      render_json benchmark
     end
 
     private
 
     def benchmarks
-      @benchmarks ||= BenchmarkSerializer.new(authorize(scope_search), metadata)
+      @benchmarks ||= authorize(scope_search)
     end
 
     def benchmark
-      @benchmark ||= BenchmarkSerializer.new(
-        authorize(resource.find(params[:id]))
-      )
+      @benchmark ||= authorize(resource.find(params[:id]))
     end
 
     def scope
@@ -29,6 +27,10 @@ module V1
 
     def resource
       Xccdf::Benchmark
+    end
+
+    def serializer
+      BenchmarkSerializer
     end
   end
 end

--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -27,6 +27,7 @@ module V1
       profile = Profile.new(profile_create_attributes).fill_from_parent
 
       if profile.save
+        profile.update_rules(ids: new_rule_ids)
         render_json profile, status: :created
       else
         render_error profile
@@ -54,25 +55,32 @@ module V1
 
     def parent_profile
       @parent_profile ||= pundit_scope.find(
-        resource_params.require(:parent_profile_id)
+        resource_attributes.require(:parent_profile_id)
       )
     end
 
     def business_objective
       @business_objective ||= Pundit.policy_scope(
         current_user, BusinessObjective
-      ).from_title(resource_params[:business_objective])
+      ).from_title(resource_attributes[:business_objective])
     end
 
     def profile_create_attributes
-      resource_params.to_h.slice(*ALLOWED_CREATE_ATTRIBUTES)
-                     .merge(account_id: current_user.account_id).tap do |attrs|
+      resource_attributes.to_h.slice(*ALLOWED_CREATE_ATTRIBUTES)
+                         .merge(account_id: current_user.account_id)
+                         .tap do |attrs|
         parent_profile
 
         if business_objective
           attrs.except! :business_objective
           attrs[:business_objective_id] = business_objective.id
         end
+      end
+    end
+
+    def new_rule_ids
+      resource_relationships.to_h.dig(:rules, :data)&.map do |rule|
+        rule[:id]
       end
     end
 

--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -20,7 +20,7 @@ module Mutations
       def resolve(args = {})
         profile = ::Profile.new(new_profile_options(args))
         profile.save!
-        profile.add_rules(ref_ids: args[:selected_rule_ref_ids])
+        profile.update_rules(ref_ids: args[:selected_rule_ref_ids])
         { profile: profile }
       end
 

--- a/app/serializers/benchmark_serializer.rb
+++ b/app/serializers/benchmark_serializer.rb
@@ -4,4 +4,8 @@
 class BenchmarkSerializer
   include FastJsonapi::ObjectSerializer
   attributes :ref_id, :title, :version, :description
+  has_many :rules
+  has_many :profiles do |benchmark|
+    Pundit.policy_scope(User.current, Profile).where(benchmark: benchmark)
+  end
 end

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -7,7 +7,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
+  wrap_parameters format: []
 end
 
 # To enable root element in JSON for ActiveRecord objects.

--- a/spec/api/v1/schemas.rb
+++ b/spec/api/v1/schemas.rb
@@ -30,6 +30,7 @@ module Api
         host: HOST,
         links: LINKS,
         benchmark: BENCHMARK,
+        benchmark_relationships: BENCHMARK_RELATIONSHIPS,
         profile: PROFILE,
         profile_relationships: PROFILE_RELATIONSHIPS,
         rule_result: RULE_RESULT,

--- a/spec/api/v1/schemas/benchmarks.rb
+++ b/spec/api/v1/schemas/benchmarks.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require './spec/api/v1/schemas/util'
+
 module Api
   module V1
     module Schemas
       module Benchmarks
+        extend Api::V1::Schemas::Util
+
         BENCHMARK = {
           type: 'object',
           required: %w[ref_id title version],
@@ -24,6 +28,14 @@ module Api
             description: {
               type: 'string'
             }
+          }
+        }.freeze
+
+        BENCHMARK_RELATIONSHIPS = {
+          type: :object,
+          properties: {
+            rules: ref_schema('relationship_collection'),
+            profiles: ref_schema('relationship_collection')
           }
         }.freeze
       end

--- a/spec/api/v1/schemas/types.rb
+++ b/spec/api/v1/schemas/types.rb
@@ -15,6 +15,7 @@ module Api
           properties: {
             data: {
               type: :object,
+              nullable: true,
               properties: {
                 id: ref_schema('uuid'),
                 type: { type: :string }

--- a/spec/integration/benchmarks_spec.rb
+++ b/spec/integration/benchmarks_spec.rb
@@ -15,45 +15,29 @@ describe 'Benchmarks API' do
       pagination_params
       search_params
 
+      include_param
+
       response '200', 'lists all benchmarks requested' do
         let(:'X-RH-IDENTITY') { encoded_header }
+        let(:include) { '' } # work around buggy rswag
         schema type: :object,
                properties: {
-                 meta: { '$ref' => '#/components/schemas/metadata' },
-                 links: { '$ref' => '#/components/schemas/links' },
+                 meta: ref_schema('metadata'),
+                 links: ref_schema('links'),
                  data: {
                    type: :array,
                    items: {
                      properties: {
                        type: { type: :string },
-                       id: { type: :string, format: :uuid },
-                       attributes: {
-                         '$ref' => '#/components/schemas/benchmark'
-                       }
+                       id: ref_schema('uuid'),
+                       attributes: ref_schema('benchmark')
                      }
                    }
                  }
                }
-        examples 'application/vnd.api+json' => {
-          meta: { filter:
-                  'ref_id=xccdf_org.ssgproject.content_benchmark_RHEL-7' },
-          data: [
-            {
-              type: 'benchmark',
-              id: '1b743185-361a-4b9a-bf48-a8efd7114093',
-              attributes: {
-                description: 'This guide presents ... which provides required '\
-                             'settings for US Department of Defense systems, '\
-                             'is one example of a baseline created from '\
-                             'this guidance.',
-                ref_id: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
-                title: 'Guide to the Secure Configuration of Red Hat '\
-                       'Enterprise Linux 7',
-                version: '0.1.46'
-              }
-            }
-          ]
-        }
+
+        after { |e| autogenerate_examples(e) }
+
         run_test!
       end
     end
@@ -61,59 +45,47 @@ describe 'Benchmarks API' do
 
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/benchmarks/{id}" do
     get 'Retrieve a benchmark' do
-      fixtures :benchmarks
+      fixtures :benchmarks, :profiles, :rules
       tags 'benchmark'
       description 'Retrieves data for a benchmark'
       operationId 'ShowBenchmark'
 
       content_types
       auth_header
-      pagination_params
-      search_params
 
       parameter name: :id, in: :path, type: :string
+      include_param
 
       response '404', 'benchmark not found' do
         let(:id) { 'invalid' }
         let(:'X-RH-IDENTITY') { encoded_header }
-        examples 'application/vnd.api+json' => {
-          errors: 'Resource not found'
-        }
+        let(:include) { '' } # work around buggy rswag
+
+        after { |e| autogenerate_examples(e) }
+
         run_test!
       end
 
       response '200', 'retrieves a benchmark' do
         let(:'X-RH-IDENTITY') { encoded_header }
         let(:id) { benchmarks(:one).id }
+        let(:include) { '' } # work around buggy rswag
         schema type: :object,
                properties: {
-                 meta: { '$ref' => '#/components/schemas/metadata' },
-                 links: { '$ref' => '#/components/schemas/links' },
+                 meta: ref_schema('metadata'),
+                 links: ref_schema('links'),
                  data: {
                    type: :object,
                    properties: {
                      type: { type: :string },
-                     id: { type: :string, format: :uuid },
-                     attributes: { '$ref' => '#/components/schemas/benchmark' }
+                     id: ref_schema('uuid'),
+                     attributes: ref_schema('benchmark'),
+                     relationships: ref_schema('benchmark_relationships')
                    }
                  }
                }
-        examples 'application/vnd.api+json' => {
-          data: {
-            type: 'benchmark',
-            id: 'd9654ad0-7cb5-4f61-b57c-0d22e3341dcc',
-            attributes: {
-              description: 'This guide presents ... which provides required '\
-                           'settings for US Department of Defense systems, '\
-                           'is one example of a baseline created from '\
-                           'this guidance.',
-              ref_id: 'xccdf_org.ssgproject.content_benchmark_RHEL-7',
-              title: 'Guide to the Secure Configuration of Red Hat '\
-                     'Enterprise Linux 7',
-              version: '0.1.46'
-            }
-          }
-        }
+
+        after { |e| autogenerate_examples(e) }
 
         run_test!
       end

--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -16,6 +16,8 @@ describe 'Profiles API' do
       pagination_params
       search_params
 
+      include_param
+
       response '200', 'lists all profiles requested' do
         before do
           profiles(:one).update!(account: accounts(:one))
@@ -33,7 +35,8 @@ describe 'Profiles API' do
                      properties: {
                        type: { type: :string },
                        id: ref_schema('uuid'),
-                       attributes: ref_schema('profile')
+                       attributes: ref_schema('profile'),
+                       relationships: ref_schema('profile_relationships')
                      }
                    }
                  }
@@ -67,7 +70,7 @@ describe 'Profiles API' do
     end
 
     post 'Create a profile' do
-      fixtures :accounts, :profiles, :benchmarks
+      fixtures :accounts, :profiles, :rules, :benchmarks
       tags 'profile'
       description 'Create a profile with the provided attributes'
       operationId 'CreateProfile'
@@ -97,6 +100,14 @@ describe 'Profiles API' do
               'of these checks should pass.',
               compliance_threshold: 95.0,
               business_objective: 'APAC Expansion'
+            },
+            relationships: {
+              rules: {
+                data: [
+                  { id: 'cc9afa66-3536-4d2e-bc8e-10111d13ec50', type: 'rule' },
+                  { id: '06a19f0e-5c7a-4d54-bc66-e932a96bf954', type: 'rule' }
+                ]
+              }
             }
           }
         }
@@ -113,6 +124,13 @@ describe 'Profiles API' do
                 name: 'A custom name',
                 compliance_threshold: 93.5,
                 business_objective: 'LATAM Expansion'
+              },
+              relationships: {
+                rules: {
+                  data: profiles(:two).benchmark.rules.map do |rule|
+                    { id: rule.id, type: 'rule' }
+                  end
+                }
               }
             }
           }
@@ -212,18 +230,20 @@ describe 'Profiles API' do
                    properties: {
                      type: { type: :string },
                      id: ref_schema('uuid'),
-                     attributes: ref_schema('profile')
+                     attributes: ref_schema('profile'),
+                     relationships: ref_schema('profile_relationships')
                    },
-                   relationships: ref_schema('profile_relationships'),
-                   included: {
-                     type: :array,
-                     items: {
-                       type: :object,
-                       properties: {
-                         type: { type: :string },
-                         id: ref_schema('uuid'),
-                         attributes: ref_schema('benchmark')
-                       }
+                   relationships: ref_schema('profile_relationships')
+                 },
+                 included: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       type: { type: :string },
+                       id: ref_schema('uuid'),
+                       attributes: ref_schema('benchmark'),
+                       relationships: ref_schema('benchmark_relationships')
                      }
                    }
                  }

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -57,6 +57,16 @@
               "type": "string",
               "default": ""
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
           }
         ],
         "responses": {
@@ -64,21 +74,54 @@
             "description": "lists all benchmarks requested",
             "examples": {
               "application/vnd.api+json": {
-                "meta": {
-                  "filter": "ref_id=xccdf_org.ssgproject.content_benchmark_RHEL-7"
-                },
                 "data": [
                   {
+                    "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
                     "type": "benchmark",
-                    "id": "1b743185-361a-4b9a-bf48-a8efd7114093",
                     "attributes": {
-                      "description": "This guide presents ... which provides required settings for US Department of Defense systems, is one example of a baseline created from this guidance.",
                       "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
-                      "title": "Guide to the Secure Configuration of Red Hat Enterprise Linux 7",
-                      "version": "0.1.46"
+                      "title": "Benchmark One",
+                      "version": "0.1.45",
+                      "description": "The first benchmark"
+                    },
+                    "relationships": {
+                      "rules": {
+                        "data": [
+                          {
+                            "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                            "type": "rule"
+                          },
+                          {
+                            "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      "profiles": {
+                        "data": [
+                          {
+                            "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                            "type": "profile"
+                          },
+                          {
+                            "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                            "type": "profile"
+                          }
+                        ]
+                      }
                     }
                   }
-                ]
+                ],
+                "meta": {
+                  "total": 1,
+                  "search": null,
+                  "limit": 10,
+                  "offset": 1
+                },
+                "links": {
+                  "first": "/api/compliance/benchmarks?limit=10&offset=1",
+                  "last": "/api/compliance/benchmarks?limit=10&offset=1"
+                }
               }
             },
             "content": {
@@ -100,8 +143,7 @@
                             "type": "string"
                           },
                           "id": {
-                            "type": "string",
-                            "format": "uuid"
+                            "$ref": "#/components/schemas/uuid"
                           },
                           "attributes": {
                             "$ref": "#/components/schemas/benchmark"
@@ -134,48 +176,22 @@
             }
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "description": "The number of items to return",
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "description": "The number of items to skip before starting to collect the result set",
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            }
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
-            "schema": {
-              "type": "string",
-              "default": ""
-            }
-          },
-          {
             "name": "id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
           }
         ],
         "responses": {
@@ -183,7 +199,7 @@
             "description": "benchmark not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Resource not found"
+                "errors": "Xccdf::Benchmark not found with ID invalid"
               }
             },
             "content": {}
@@ -193,13 +209,39 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
+                  "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
                   "type": "benchmark",
-                  "id": "d9654ad0-7cb5-4f61-b57c-0d22e3341dcc",
                   "attributes": {
-                    "description": "This guide presents ... which provides required settings for US Department of Defense systems, is one example of a baseline created from this guidance.",
                     "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
-                    "title": "Guide to the Secure Configuration of Red Hat Enterprise Linux 7",
-                    "version": "0.1.46"
+                    "title": "Benchmark One",
+                    "version": "0.1.45",
+                    "description": "The first benchmark"
+                  },
+                  "relationships": {
+                    "rules": {
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "rule"
+                        },
+                        {
+                          "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                          "type": "rule"
+                        }
+                      ]
+                    },
+                    "profiles": {
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "profile"
+                        },
+                        {
+                          "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                          "type": "profile"
+                        }
+                      ]
+                    }
                   }
                 }
               }
@@ -222,11 +264,13 @@
                           "type": "string"
                         },
                         "id": {
-                          "type": "string",
-                          "format": "uuid"
+                          "$ref": "#/components/schemas/uuid"
                         },
                         "attributes": {
                           "$ref": "#/components/schemas/benchmark"
+                        },
+                        "relationships": {
+                          "$ref": "#/components/schemas/benchmark_relationships"
                         }
                       }
                     }
@@ -289,6 +333,16 @@
               "type": "string",
               "default": ""
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
           }
         ],
         "responses": {
@@ -429,6 +483,9 @@
                           },
                           "attributes": {
                             "$ref": "#/components/schemas/profile"
+                          },
+                          "relationships": {
+                            "$ref": "#/components/schemas/profile_relationships"
                           }
                         }
                       }
@@ -462,7 +519,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "3ff92a51-fa16-497a-b01b-c89d7fb19d24",
+                  "id": "8528687e-c44e-4c01-bded-c45a183792f0",
                   "type": "profile",
                   "attributes": {
                     "name": "A custom name",
@@ -475,7 +532,7 @@
                     "os_major_version": "7",
                     "parent_profile_ref_id": "xccdf_org.ssgproject.profile2",
                     "canonical": false,
-                    "tailored": false,
+                    "tailored": true,
                     "total_host_count": 0,
                     "compliant_host_count": 0,
                     "business_objective": "LATAM Expansion"
@@ -500,7 +557,16 @@
                       }
                     },
                     "rules": {
-                      "data": []
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "rule"
+                        },
+                        {
+                          "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                          "type": "rule"
+                        }
+                      ]
                     },
                     "hosts": {
                       "data": []
@@ -568,6 +634,20 @@
                       "description": "This profile contains rules to ensure standard security baseline\\nof a Red Hat Enterprise Linux 7 system. Regardless of your system's workload\\nall of these checks should pass.",
                       "compliance_threshold": 95.0,
                       "business_objective": "APAC Expansion"
+                    },
+                    "relationships": {
+                      "rules": {
+                        "data": [
+                          {
+                            "id": "cc9afa66-3536-4d2e-bc8e-10111d13ec50",
+                            "type": "rule"
+                          },
+                          {
+                            "id": "06a19f0e-5c7a-4d54-bc66-e932a96bf954",
+                            "type": "rule"
+                          }
+                        ]
+                      }
                     }
                   }
                 }
@@ -648,7 +728,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "e9b83492-f95d-4659-9273-3ab378e5868d",
+                        "id": "b301900b-fe92-4df5-a50b-e3ba87a75f82",
                         "type": "account"
                       }
                     },
@@ -691,6 +771,32 @@
                       "title": "Benchmark One",
                       "version": "0.1.45",
                       "description": "The first benchmark"
+                    },
+                    "relationships": {
+                      "rules": {
+                        "data": [
+                          {
+                            "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                            "type": "rule"
+                          },
+                          {
+                            "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      "profiles": {
+                        "data": [
+                          {
+                            "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                            "type": "profile"
+                          },
+                          {
+                            "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                            "type": "profile"
+                          }
+                        ]
+                      }
                     }
                   }
                 ]
@@ -725,21 +831,24 @@
                       },
                       "relationships": {
                         "$ref": "#/components/schemas/profile_relationships"
-                      },
-                      "included": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "id": {
-                              "$ref": "#/components/schemas/uuid"
-                            },
-                            "attributes": {
-                              "$ref": "#/components/schemas/benchmark"
-                            }
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "$ref": "#/components/schemas/uuid"
+                          },
+                          "attributes": {
+                            "$ref": "#/components/schemas/benchmark"
+                          },
+                          "relationships": {
+                            "$ref": "#/components/schemas/benchmark_relationships"
                           }
                         }
                       }
@@ -1360,6 +1469,7 @@
         "properties": {
           "data": {
             "type": "object",
+            "nullable": true,
             "properties": {
               "id": {
                 "$ref": "#/components/schemas/uuid"
@@ -1475,6 +1585,17 @@
           },
           "description": {
             "type": "string"
+          }
+        }
+      },
+      "benchmark_relationships": {
+        "type": "object",
+        "properties": {
+          "rules": {
+            "$ref": "#/components/schemas/relationship_collection"
+          },
+          "profiles": {
+            "$ref": "#/components/schemas/relationship_collection"
           }
         }
       },

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -238,25 +238,15 @@ class ProfileTest < ActiveSupport::TestCase
     DESCRIPTION = 'The best profile ever'
 
     should 'copy attributes from the parent profile' do
-      profile = Profile.new(parent_profile_id: profiles(:one).id)
-                       .fill_from_parent
+      profile = Profile.new(
+        parent_profile_id: profiles(:one).id, account_id: accounts(:one).id
+      ).fill_from_parent
 
       assert_equal profiles(:one).ref_id, profile.ref_id
       assert_equal profiles(:one).name, profile.name
       assert_equal profiles(:one).description, profile.description
       assert_equal profiles(:one).benchmark_id, profile.benchmark_id
       assert_not profile.external
-    end
-
-    should 'copy rules from the parent profile on save' do
-      profile = Profile.new(parent_profile_id: profiles(:one).id)
-                       .fill_from_parent
-
-      assert_not_equal Set.new(profiles(:one).rules.pluck(:id)),
-                       Set.new(profile.rules.pluck(:id))
-      profile.save
-      assert_equal Set.new(profiles(:one).rules.pluck(:id)),
-                   Set.new(profile.reload.rules.pluck(:id))
     end
 
     should 'allow some customized attributes' do


### PR DESCRIPTION
POST body containing rules relationships:

```js
{
	"data": {
		"attributes": {
			"parent_profile_id": "1007b72e-7f0f-486f-911a-5c392c724faa",
			"name": "My tailored profile",
			"compliance_threshold": 95.0
		},
		"relationships": {
			"rules": {
				"data": [
					{
						"id": "cc9afa66-3536-4d2e-bc8e-10111d13ec50",
						"type": "rule"
					},
					{
						"id": "06a19f0e-5c7a-4d54-bc66-e932a96bf954",
						"type": "rule"
					},
					{
						"id": "fcd8ee29-5af4-47bf-9e29-2de12f20fe9a",
						"type": "rule"
					}
				]
			}
		}
	}
}

# Response:

HTTP/1.1 201 Created
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: X-Requested-With,content-type
Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, PATCH, DELETE
Access-Control-Allow-Origin: *
cache-control: max-age=0, private, must-revalidate
connection: close
content-type: application/vnd.api+json
date: Tue, 23 Jun 2020 15:42:29 GMT
etag: W/"62bba6ee45343fbc2bbe364beb645a35"
transfer-encoding: chunked
vary: Origin
x-request-id: 31f18b51-105c-48b6-8844-880f335f5162
x-runtime: 0.275060

{
    "data": {
        "attributes": {
            "business_objective": null,
            "canonical": false,
            "compliance_threshold": 95.0,
            "compliant_host_count": 0,
            "description": "Ensures PCI-DSS v3.2.1 related security configuration settings are applied.",
            "external": false,
            "name": "My tailored profile",
            "os_major_version": "8",
            "parent_profile_id": "1007b72e-7f0f-486f-911a-5c392c724faa",
            "parent_profile_ref_id": "xccdf_org.ssgproject.content_profile_pci-dss",
            "ref_id": "xccdf_org.ssgproject.content_profile_pci-dss",
            "score": 0,
            "tailored": true,
            "total_host_count": 0
        },
        "id": "679133ea-bbe0-47ed-ae36-4093d4402b03",
        "relationships": {
            "account": {
                "data": {
                    "id": "8c926d2a-17d6-4398-8895-2652971113c1",
                    "type": "account"
                }
            },
            "benchmark": {
                "data": {
                    "id": "c0e2ce89-fb9a-4e29-a51b-23f2398cde83",
                    "type": "benchmark"
                }
            },
            "hosts": {
                "data": []
            },
            "parent_profile": {
                "data": {
                    "id": "1007b72e-7f0f-486f-911a-5c392c724faa",
                    "type": "profile"
                }
            },
            "rules": {
                "data": [
                    {
                        "id": "06a19f0e-5c7a-4d54-bc66-e932a96bf954",
                        "type": "rule"
                    },
                    {
                        "id": "cc9afa66-3536-4d2e-bc8e-10111d13ec50",
                        "type": "rule"
                    },
                    {
                        "id": "fcd8ee29-5af4-47bf-9e29-2de12f20fe9a",
                        "type": "rule"
                    }
                ]
            },
            "test_results": {
                "data": []
            }
        },
        "type": "profile"
    }
}
```

Note that the shape of the request and response are the same, other than unspecified attributes or relationships in the request.

On create, if no valid rules are specified, the parent profile rules are added to the new profile. Valid rules are those that exist in the parent profile's benchmark only.

Signed-off-by: Andrew Kofink <akofink@redhat.com>