### PR TITLE
RHICOMPL-748 - Support no os_release in inventory

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -41,7 +41,7 @@ class HostInventoryAPI
       X_RH_IDENTITY: @b64_identity
     )
     JSON.parse(response.body)['results'].inject([]) do |acc, host|
-      os_major, os_minor = host['system_profile']['os_release'].split('.')
+      os_major, os_minor = find_os_release(host['system_profile'])
       acc << { id: host['id'],
                os_major_version: os_major,
                os_minor_version: os_minor }
@@ -49,6 +49,12 @@ class HostInventoryAPI
   end
 
   private
+
+  def find_os_release(system_profile)
+    return [nil, nil] if system_profile['os_release'].blank?
+
+    system_profile['os_release'].split('.')
+  end
 
   def find_results(body, host_id)
     body['results'].find do |host|

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -83,7 +83,7 @@ class HostInventoryApiTest < ActiveSupport::TestCase
 
   test 'system_profile returns a hash without OS info if not found' do
     wrong_system_profile_response = OpenStruct.new(body: {
-      results: [{ id: @host.id, system_profile: { os_release: '' } }]
+      results: [{ id: @host.id, system_profile: {} }]
     }.to_json)
     @connection.expects(:get).with(
       "#{@url}#{ENV['PATH_PREFIX']}/inventory/v1/hosts/"\
@@ -92,8 +92,8 @@ class HostInventoryApiTest < ActiveSupport::TestCase
       X_RH_IDENTITY: @b64_identity
     ).returns(wrong_system_profile_response)
     system_profile_results = @api.system_profile([@host.id])
-    assert_equal nil, system_profile_results.first[:os_major_version]
-    assert_equal nil, system_profile_results.first[:os_minor_version]
+    assert_nil system_profile_results.first[:os_major_version]
+    assert_nil system_profile_results.first[:os_minor_version]
     assert_equal @host.id, system_profile_results.first[:id]
   end
 end


### PR DESCRIPTION
Currently, when someone assigns a new system that doesn't exist in compliance to a policy, if the system doesn't have a os_release (which happens often on testing environments), we get the following error:
`NoMethodError: undefined method `split' for nil:NilClass`

This PR prevents that error from happening. 