### PR TITLE
RHICOMPL-750 - Remove external profiles after system culling

### DIFF
--- a/app/models/profile_host.rb
+++ b/app/models/profile_host.rb
@@ -10,6 +10,7 @@ class ProfileHost < ApplicationRecord
   validates :host, presence: true, uniqueness: { scope: :profile }
 
   after_destroy :destroy_orphaned_host
+  after_destroy :destroy_orphaned_external_profile
 
   def destroy_orphaned_host
     return unless host.profiles.empty?
@@ -19,5 +20,11 @@ class ProfileHost < ApplicationRecord
     else
       DeleteHost.new.perform(id: host.id)
     end
+  end
+
+  def destroy_orphaned_external_profile
+    return unless profile.external && profile.hosts.empty?
+
+    profile.destroy
   end
 end

--- a/test/models/profile_host_test.rb
+++ b/test/models/profile_host_test.rb
@@ -23,17 +23,31 @@ class ProfileHostTest < ActiveSupport::TestCase
     assert_equal 0, DeleteHost.jobs.size
   end
 
-  test 'destory associated external policies if they have no more hosts' do
+  test 'destroy associated external policies if they have no more hosts' do
     internal_profile = Profile.create(name: 'foo', benchmark: benchmarks(:one),
-                                      ref_id: 'foo')
+                                      ref_id: 'foo', account: accounts(:one))
     external_profile = Profile.create(name: 'baz', benchmark: benchmarks(:one),
-                                      ref_id: 'baz', external: true)
+                                      ref_id: 'baz', external: true,
+                                      account: accounts(:one))
     host = Host.create(profiles: [internal_profile, external_profile],
                        name: 'bar', account: accounts(:one))
-    assert_difference('Profile.count', -1) do
-      host.destroy
-    end
+    assert_difference('Profile.count', -1) { host.destroy }
     assert_equal internal_profile, Profile.find(internal_profile.id)
     assert_empty Profile.where(id: external_profile.id)
+  end
+
+  test 'does not destroy external policies if they still have hosts' do
+    internal_profile = Profile.create(name: 'foo', benchmark: benchmarks(:one),
+                                      ref_id: 'foo', account: accounts(:one))
+    external_profile = Profile.create(name: 'baz', benchmark: benchmarks(:one),
+                                      ref_id: 'baz', external: true,
+                                      account: accounts(:one))
+    host = Host.create(profiles: [internal_profile, external_profile],
+                       name: 'bar', account: accounts(:one))
+    another_host = Host.create(profiles: [external_profile],
+                               name: 'bar2', account: accounts(:one))
+    assert_difference('Profile.count', 0) { host.destroy }
+    assert_equal internal_profile, Profile.find(internal_profile.id)
+    assert_includes Profile.find(external_profile.id).hosts, another_host
   end
 end

--- a/test/models/profile_host_test.rb
+++ b/test/models/profile_host_test.rb
@@ -22,4 +22,18 @@ class ProfileHostTest < ActiveSupport::TestCase
     assert_empty Host.where(id: host.id)
     assert_equal 0, DeleteHost.jobs.size
   end
+
+  test 'destory associated external policies if they have no more hosts' do
+    internal_profile = Profile.create(name: 'foo', benchmark: benchmarks(:one),
+                                      ref_id: 'foo')
+    external_profile = Profile.create(name: 'baz', benchmark: benchmarks(:one),
+                                      ref_id: 'baz', external: true)
+    host = Host.create(profiles: [internal_profile, external_profile],
+                       name: 'bar', account: accounts(:one))
+    assert_difference('Profile.count', -1) do
+      host.destroy
+    end
+    assert_equal internal_profile, Profile.find(internal_profile.id)
+    assert_empty Profile.where(id: external_profile.id)
+  end
 end


### PR DESCRIPTION
When the following happens:

 - A host is registered and assigned to an external policy
 - The host is later on removed via System culling

The host is removed, but the external policy remains. This is
not only problematic because of the unused cruft in the
database, but also if the user tries to create a new Policy now
with the same ref ID, they won't be able to do it (422 error),
and they won't be able to remove the old Policy except through
the API (which is not in prod yet)