### PR TITLE
[RHICOMPL-467] Allow host/profile association via API V1

### DIFF
--- a/app/controllers/concerns/parameters.rb
+++ b/app/controllers/concerns/parameters.rb
@@ -30,6 +30,12 @@ module Parameters
       resource_params[:relationships]&.permit(relationship_types)
     end
 
+    def new_relationship_ids(relationship)
+      resource_relationships.to_h.dig(relationship, :data)&.map do |resource|
+        resource[:id]
+      end
+    end
+
     private
 
     def relationship_types

--- a/app/models/concerns/profile_hosts.rb
+++ b/app/models/concerns/profile_hosts.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Methods that are related to a profile's hosts
+module ProfileHosts
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :profile_hosts, dependent: :destroy
+    has_many :hosts, through: :profile_hosts, source: :host
+
+    def update_hosts(new_host_ids)
+      return unless new_host_ids
+
+      profile_hosts.where.not(host_id: new_host_ids).destroy_all
+      ProfileHost.import((new_host_ids - host_ids).map do |host_id|
+        { host_id: host_id, profile_id: id }
+      end)
+    end
+  end
+end

--- a/app/models/concerns/profile_rules.rb
+++ b/app/models/concerns/profile_rules.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Methods that are related to a profile's rules
+module ProfileRules
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :profile_rules, dependent: :delete_all
+    has_many :rules, through: :profile_rules, source: :rule
+
+    def update_rules(ids: nil, ref_ids: nil)
+      ProfileRule.where(
+        rule_id: rule_ids_to_destroy(ids, ref_ids), profile_id: id
+      ).destroy_all
+
+      ProfileRule.import!(rule_ids_to_add(ids, ref_ids).map do |rule_id|
+        ProfileRule.new(profile_id: id, rule_id: rule_id)
+      end)
+    end
+
+    private
+
+    def rule_ids_to_add(ids, ref_ids)
+      new_rules(ids, ref_ids).where.not(id: rule_ids).pluck(:id)
+    end
+
+    def rule_ids_to_destroy(ids, ref_ids)
+      rule_ids - new_rules(ids, ref_ids).pluck(:id)
+    end
+
+    def new_rules(ids, ref_ids)
+      bm_rules = benchmark.rules.select(:id)
+
+      rel = if ids
+              bm_rules.where(id: ids)
+            elsif ref_ids
+              bm_rules.where(ref_id: ref_ids)
+            end
+
+      rel&.any? ? rel : bm_rules.where(id: parent_profile_rule_ids)
+    end
+
+    def parent_profile_rule_ids
+      parent_profile&.rules&.select(:id) || []
+    end
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -6,11 +6,9 @@ class Profile < ApplicationRecord
   include ProfileScoring
   include ProfilePolicyAssociation
   include ProfileSearching
+  include ProfileHosts
+  include ProfileRules
 
-  has_many :profile_rules, dependent: :delete_all
-  has_many :rules, through: :profile_rules, source: :rule
-  has_many :profile_hosts, dependent: :destroy
-  has_many :hosts, through: :profile_hosts, source: :host
   has_many :test_results, dependent: :destroy
   belongs_to :account, optional: true
   belongs_to :business_objective, optional: true
@@ -87,40 +85,4 @@ class Profile < ApplicationRecord
     benchmark ? benchmark.inferred_os_major_version : 'N/A'
   end
   alias os_major_version major_os_version
-
-  def update_rules(ids: nil, ref_ids: nil)
-    ProfileRule.where(
-      rule_id: rule_ids_to_destroy(ids, ref_ids), profile_id: id
-    ).destroy_all
-
-    ProfileRule.import!(rule_ids_to_add(ids, ref_ids).map do |rule_id|
-      ProfileRule.new(profile_id: id, rule_id: rule_id)
-    end)
-  end
-
-  private
-
-  def rule_ids_to_add(ids, ref_ids)
-    new_rules(ids, ref_ids).where.not(id: rule_ids).pluck(:id)
-  end
-
-  def rule_ids_to_destroy(ids, ref_ids)
-    rule_ids - new_rules(ids, ref_ids).pluck(:id)
-  end
-
-  def new_rules(ids, ref_ids)
-    bm_rules = benchmark.rules.select(:id)
-
-    rel = if ids
-            bm_rules.where(id: ids)
-          elsif ref_ids
-            bm_rules.where(ref_id: ref_ids)
-          end
-
-    rel&.any? ? rel : bm_rules.where(id: parent_profile_rule_ids)
-  end
-
-  def parent_profile_rule_ids
-    parent_profile&.rules&.select(:id) || []
-  end
 end

--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -70,7 +70,7 @@ describe 'Profiles API' do
     end
 
     post 'Create a profile' do
-      fixtures :accounts, :profiles, :rules, :benchmarks
+      fixtures :accounts, :profiles, :rules, :hosts, :benchmarks
       tags 'profile'
       description 'Create a profile with the provided attributes'
       operationId 'CreateProfile'
@@ -109,6 +109,12 @@ describe 'Profiles API' do
                   { id: 'cc9afa66-3536-4d2e-bc8e-10111d13ec50', type: 'rule' },
                   { id: '06a19f0e-5c7a-4d54-bc66-e932a96bf954', type: 'rule' }
                 ]
+              },
+              hosts: {
+                data: [
+                  { id: '6c3837ed-edac-4522-83a1-147af958f0f2', type: 'host' },
+                  { id: 'f896d5e7-e44e-41cb-8e8e-96aab6d895d6', type: 'host' }
+                ]
               }
             }
           }
@@ -131,6 +137,11 @@ describe 'Profiles API' do
                 rules: {
                   data: profiles(:two).benchmark.rules.map do |rule|
                     { id: rule.id, type: 'rule' }
+                  end
+                },
+                hosts: {
+                  data: hosts.map do |host|
+                    { id: host.id, type: 'host' }
                   end
                 }
               }
@@ -257,7 +268,7 @@ describe 'Profiles API' do
     end
 
     patch 'Update a profile' do
-      fixtures :accounts, :benchmarks, :profiles
+      fixtures :accounts, :rules, :hosts, :benchmarks, :profiles
       tags 'profile'
       description 'Updates a profile'
       operationId 'UpdateProfile'
@@ -299,6 +310,12 @@ describe 'Profiles API' do
                   { id: 'cc9afa66-3536-4d2e-bc8e-10111d13ec50', type: 'rule' },
                   { id: '06a19f0e-5c7a-4d54-bc66-e932a96bf954', type: 'rule' }
                 ]
+              },
+              hosts: {
+                data: [
+                  { id: '6c3837ed-edac-4522-83a1-147af958f0f2', type: 'host' },
+                  { id: 'f896d5e7-e44e-41cb-8e8e-96aab6d895d6', type: 'host' }
+                ]
               }
             }
           }
@@ -339,6 +356,11 @@ describe 'Profiles API' do
                 rules: {
                   data: profiles(:two).benchmark.rules.map do |rule|
                     { id: rule.id, type: 'rule' }
+                  end
+                },
+                hosts: {
+                  data: hosts.map do |host|
+                    { id: host.id, type: 'host' }
                   end
                 }
               }

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -774,7 +774,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "2375e6a8-859a-4649-8779-43df2bc04e82",
+                  "id": "e2ef5fb5-9981-4528-81bb-947b0426cd07",
                   "type": "profile",
                   "attributes": {
                     "name": "A custom name",
@@ -788,7 +788,7 @@
                     "parent_profile_ref_id": "xccdf_org.ssgproject.profile2",
                     "canonical": false,
                     "tailored": true,
-                    "total_host_count": 0,
+                    "total_host_count": 2,
                     "compliant_host_count": 0,
                     "business_objective": "LATAM Expansion"
                   },
@@ -824,7 +824,16 @@
                       ]
                     },
                     "hosts": {
-                      "data": []
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "host"
+                        },
+                        {
+                          "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                          "type": "host"
+                        }
+                      ]
                     },
                     "test_results": {
                       "data": []
@@ -908,6 +917,18 @@
                             "type": "rule"
                           }
                         ]
+                      },
+                      "hosts": {
+                        "data": [
+                          {
+                            "id": "6c3837ed-edac-4522-83a1-147af958f0f2",
+                            "type": "host"
+                          },
+                          {
+                            "id": "f896d5e7-e44e-41cb-8e8e-96aab6d895d6",
+                            "type": "host"
+                          }
+                        ]
                       }
                     }
                   }
@@ -989,7 +1010,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "eaa86e92-fe95-4174-9260-279edc170afa",
+                        "id": "ad762496-2af7-44c8-a38c-f38c4d1ea0a6",
                         "type": "account"
                       }
                     },
@@ -1170,7 +1191,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "4fc1bac4-6425-4706-a51e-34ece921568f",
+                  "id": "316aff02-6475-4c3c-b539-1e5bedff5db7",
                   "type": "profile",
                   "attributes": {
                     "name": "An updated custom name",
@@ -1184,7 +1205,7 @@
                     "parent_profile_ref_id": "xccdf_org.ssgproject.profile2",
                     "canonical": false,
                     "tailored": true,
-                    "total_host_count": 0,
+                    "total_host_count": 2,
                     "compliant_host_count": 0,
                     "business_objective": "APAC Expansion"
                   },
@@ -1220,7 +1241,16 @@
                       ]
                     },
                     "hosts": {
-                      "data": []
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "host"
+                        },
+                        {
+                          "id": "37f7eeff-831b-5c41-984a-254965f58c0f",
+                          "type": "host"
+                        }
+                      ]
                     },
                     "test_results": {
                       "data": []
@@ -1310,6 +1340,18 @@
                           {
                             "id": "06a19f0e-5c7a-4d54-bc66-e932a96bf954",
                             "type": "rule"
+                          }
+                        ]
+                      },
+                      "hosts": {
+                        "data": [
+                          {
+                            "id": "6c3837ed-edac-4522-83a1-147af958f0f2",
+                            "type": "host"
+                          },
+                          {
+                            "id": "f896d5e7-e44e-41cb-8e8e-96aab6d895d6",
+                            "type": "host"
                           }
                         ]
                       }

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -265,6 +265,40 @@ class ProfileTest < ActiveSupport::TestCase
     end
   end
 
+  context 'update_hosts' do
+    should 'add new hosts to an empty host set' do
+      profiles(:one).update!(hosts: [])
+      assert_empty(profiles(:one).hosts)
+      assert_difference('profiles(:one).hosts.count', hosts.count) do
+        profiles(:one).update_hosts(hosts.pluck(:id))
+      end
+    end
+
+    should 'add new hosts to an existing host set' do
+      profiles(:one).update!(hosts: hosts[0...-1])
+      assert_not_empty(profiles(:one).hosts)
+      assert_difference('profiles(:one).hosts.count', 1) do
+        profiles(:one).update_hosts(hosts.pluck(:id))
+      end
+    end
+
+    should 'remove old hosts from an existing host set' do
+      profiles(:one).update!(hosts: hosts)
+      assert_equal hosts.count, profiles(:one).hosts.count
+      assert_difference('profiles(:one).reload.hosts.count', -hosts.count) do
+        profiles(:one).update_hosts([])
+      end
+    end
+
+    should 'add new and remove old hosts from an existing host set' do
+      profiles(:one).update!(host_ids: hosts.pluck(:id)[0...-1])
+      assert_not_empty(profiles(:one).hosts)
+      assert_difference('profiles(:one).hosts.count', 0) do
+        profiles(:one).update_hosts(hosts.pluck(:id)[1..-1])
+      end
+    end
+  end
+
   context 'update_rules' do
     should 'add new rules to an empty rule set' do
       profiles(:one).update!(rules: [])


### PR DESCRIPTION
Works the same as the rules relationship:


```js
PATCH api/v1/profiles/{uuid}
{
	"data": {
		"attributes": {
			"name": "My updated tailored profile",
			"compliance_threshold": 90
		},
		"relationships": {
			"rules": {
				"data": [
					{
						"id": "cc9afa66-3536-4d2e-bc8e-10111d13ec50",
						"type": "rule"
					},
					{
						"id": "06a19f0e-5c7a-4d54-bc66-e932a96bf954",
						"type": "rule"
					},
					{
						"id": "fcd8ee29-5af4-47bf-9e29-2de12f20fe9a",
						"type": "rule"
					}
				]
			},
			"hosts": {
				"data": [
					{
						"id": "cc9afa66-3536-4d2e-bc8e-10111d13ec50",
						"type": "host"
					}
				]
			}
		}
	}
}
```

Also works with POST/create.

Based on changes in https://github.com/RedHatInsights/compliance-backend/pull/510 - I will rebase this PR once 510 is merged.