### PR TITLE
Match serializers to openapi spec

### DIFF
--- a/app/controllers/v1/rule_results_controller.rb
+++ b/app/controllers/v1/rule_results_controller.rb
@@ -4,10 +4,14 @@ module V1
   # API for RuleResults
   class RuleResultsController < ApplicationController
     def index
-      render json: RuleResultSerializer.new(scope_search, metadata)
+      render_json scope_search
     end
 
     private
+
+    def serializer
+      RuleResultSerializer
+    end
 
     def resource
       RuleResult

--- a/app/controllers/v1/rules_controller.rb
+++ b/app/controllers/v1/rules_controller.rb
@@ -4,7 +4,7 @@ module V1
   # REST API for Rules
   class RulesController < ApplicationController
     def index
-      render json: RuleSerializer.new(scope_search, metadata)
+      render_json scope_search
     end
 
     def show
@@ -16,7 +16,7 @@ module V1
 
       raise ActiveRecord::RecordNotFound if rule.blank?
 
-      render json: RuleSerializer.new(rule)
+      render_json rule
     end
 
     private
@@ -25,12 +25,16 @@ module V1
       Rule
     end
 
+    def serializer
+      RuleSerializer
+    end
+
     def search_by_id
-      ::Pundit.policy_scope(User.current, ::Rule).friendly.find(params[:id])
+      pundit_scope.friendly.find(params[:id])
     end
 
     def search_by_ref_id
-      rule = Rule.latest.where(
+      rule = pundit_scope.latest.where(
         'rules.slug LIKE ?',
         "%#{ActiveRecord::Base.sanitize_sql_like(params[:id])}%"
       )

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -43,10 +43,7 @@ module Types
     end
 
     def last_scanned(args = {})
-      latest_test_result = ::TestResult.latest.find_by(
-        profile_id: args[:profile_id], host_id: object.id
-      )
-      latest_test_result&.end_time&.iso8601 || 'Never'
+      object.last_scanned(args)
     end
 
     private

--- a/app/models/concerns/system_like.rb
+++ b/app/models/concerns/system_like.rb
@@ -20,6 +20,12 @@ module SystemLike
     result
   end
 
+  def last_scanned(profile_id: nil)
+    rel = test_results.latest.order(:end_time)
+    rel = rel.where(profile_id: profile_id) if profile_id
+    rel.last&.end_time&.iso8601 || 'Never'
+  end
+
   def last_scan_results(profile = nil)
     return profile.results(self) if profile.present?
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -3,7 +3,7 @@
 # Host representation in insights compliance backend. Most of the times
 # these hosts will also show up in the insights-platform host inventory.
 class Host < ApplicationRecord
-  scoped_search on: %i[id name account_id os_major_version os_minor_version]
+  scoped_search on: %i[name os_major_version os_minor_version]
   scoped_search on: :compliant, ext_method: 'filter_by_compliance',
                 only_explicit: true
   scoped_search on: :compliance_score, ext_method: 'filter_by_compliance_score',

--- a/app/serializers/host_serializer.rb
+++ b/app/serializers/host_serializer.rb
@@ -4,5 +4,12 @@
 class HostSerializer
   include FastJsonapi::ObjectSerializer
   set_type :host
-  attributes :name, :profiles, :compliant
+  attributes :name, :os_major_version, :os_minor_version, :last_scanned,
+             :rules_passed, :rules_failed
+  attribute :compliant do |host|
+    host.compliant.values.all?
+  end
+
+  has_many :test_results
+  has_many :profiles
 end

--- a/app/serializers/rule_serializer.rb
+++ b/app/serializers/rule_serializer.rb
@@ -3,6 +3,9 @@
 # JSON API serialization for an OpenSCAP Rule
 class RuleSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :created_at, :updated_at, :ref_id, :title, :rationale,
-             :description, :severity, :slug
+  attributes :ref_id, :title, :rationale, :description, :severity, :slug
+  belongs_to :benchmark
+  has_many :profiles
+  has_many :rule_references
+  has_one :rule_identifier
 end

--- a/spec/api/v1/schemas.rb
+++ b/spec/api/v1/schemas.rb
@@ -30,6 +30,7 @@ module Api
         error: ERROR,
         metadata: METADATA,
         host: HOST,
+        host_relationships: HOST_RELATIONSHIPS,
         links: LINKS,
         benchmark: BENCHMARK,
         benchmark_relationships: BENCHMARK_RELATIONSHIPS,
@@ -38,7 +39,9 @@ module Api
         profile: PROFILE,
         profile_relationships: PROFILE_RELATIONSHIPS,
         rule_result: RULE_RESULT,
-        rule: RULE
+        rule_result_relationships: RULE_RESULT_RELATIONSHIPS,
+        rule: RULE,
+        rule_relationships: RULE_RELATIONSHIPS
       }.freeze
     end
   end

--- a/spec/api/v1/schemas/hosts.rb
+++ b/spec/api/v1/schemas/hosts.rb
@@ -1,21 +1,55 @@
 # frozen_string_literal: true
 
+require './spec/api/v1/schemas/util'
+
 module Api
   module V1
     module Schemas
       module Hosts
+        extend Api::V1::Schemas::Util
+
         HOST = {
           type: 'object',
-          required: %w[name account_id],
+          required: %w[name],
           properties: {
             name: {
               type: 'string',
               example: 'cloud.redhat.com'
             },
-            account_id: {
+            compliant: {
+              type: 'boolean',
+              example: true
+            },
+            os_major_version: {
               type: 'string',
-              example: '649cf080-ccce-4c02-ba60-21d046983c7f'
+              example: '7',
+              nullable: true
+            },
+            os_minor_version: {
+              type: 'string',
+              example: '3',
+              nullable: true
+            },
+            last_scanned: {
+              type: 'string',
+              example: '2020-06-04T19:31:55Z'
+            },
+            rules_passed: {
+              type: 'integer',
+              example: 34
+            },
+            rules_failed: {
+              type: 'integer',
+              example: 12
             }
+          }
+        }.freeze
+
+        HOST_RELATIONSHIPS = {
+          type: :object,
+          properties: {
+            profiles: ref_schema('relationship_collection'),
+            test_results: ref_schema('relationship_collection')
           }
         }.freeze
       end

--- a/spec/api/v1/schemas/rule_results.rb
+++ b/spec/api/v1/schemas/rule_results.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require './spec/api/v1/schemas/util'
+
 module Api
   module V1
     module Schemas
       module RuleResults
+        extend Api::V1::Schemas::Util
+
         RULE_RESULT = {
           type: 'object',
           required: %w[result],
@@ -12,6 +16,14 @@ module Api
               type: 'string',
               example: 'passed'
             }
+          }
+        }.freeze
+
+        RULE_RESULT_RELATIONSHIPS = {
+          type: :object,
+          properties: {
+            hosts: ref_schema('relationship_collection'),
+            rules: ref_schema('relationship_collection')
           }
         }.freeze
       end

--- a/spec/api/v1/schemas/rules.rb
+++ b/spec/api/v1/schemas/rules.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require './spec/api/v1/schemas/util'
+
 module Api
   module V1
     module Schemas
       module Rules
+        extend Api::V1::Schemas::Util
+
         RULE = {
           type: 'object',
           required: %w[title ref_id],
@@ -42,6 +46,16 @@ module Api
               ' of malicious activity on a system.\nAuditing these events'\
               ' could serve as evidence of potential system compromise.'
             }
+          }
+        }.freeze
+
+        RULE_RELATIONSHIPS = {
+          type: :object,
+          properties: {
+            benchmark: ref_schema('relationship'),
+            rule_identifier: ref_schema('relationship'),
+            profiles: ref_schema('relationship_collection'),
+            rule_references: ref_schema('relationship_collection')
           }
         }.freeze
       end

--- a/spec/integration/benchmarks_spec.rb
+++ b/spec/integration/benchmarks_spec.rb
@@ -30,7 +30,8 @@ describe 'Benchmarks API' do
                      properties: {
                        type: { type: :string },
                        id: ref_schema('uuid'),
-                       attributes: ref_schema('benchmark')
+                       attributes: ref_schema('benchmark'),
+                       relationships: ref_schema('benchmark_relationships')
                      }
                    }
                  }

--- a/spec/integration/rule_results_spec.rb
+++ b/spec/integration/rule_results_spec.rb
@@ -3,9 +3,15 @@
 require 'swagger_helper'
 
 describe 'RuleResults API' do
+  fixtures :accounts, :rules, :hosts, :rule_results
+
+  before do
+    hosts(:one).update(account: accounts(:test))
+    rule_results(:one).update(host: hosts(:one), rule: rules(:one))
+  end
+
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/rule_results" do
     get 'List all rule_results' do
-      fixtures :rules, :hosts, :rule_results
       tags 'rule_result'
       description 'Lists all rule_results requested'
       operationId 'ListRuleResults'
@@ -15,60 +21,30 @@ describe 'RuleResults API' do
       pagination_params
       search_params
 
+      include_param
+
       response '200', 'lists all rule_results requested' do
-        let(:'X-RH-IDENTITY') do
-          Account.create(
-            account_number: x_rh_identity[:identity][:account_number]
-          )
-          user = User.from_x_rh_identity(x_rh_identity[:identity])
-          user.save
-          hosts(:one).update(account: user.account)
-          rule_results(:one).update(host: hosts(:one), rule: rules(:one))
-          encoded_header
-        end
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:test)) }
+        let(:include) { '' } # work around buggy rswag
         schema type: :object,
                properties: {
-                 meta: { '$ref' => '#/components/schemas/metadata' },
-                 links: { '$ref' => '#/components/schemas/links' },
+                 meta: ref_schema('metadata'),
+                 links: ref_schema('links'),
                  data: {
                    type: :array,
                    items: {
                      properties: {
                        type: { type: :string },
                        id: { type: :string, format: :uuid },
-                       attributes: {
-                         '$ref' => '#/components/schemas/rule_result'
-                       }
+                       attributes: ref_schema('rule_result'),
+                       relationships: ref_schema('rule_result_relationships')
                      }
                    }
                  }
                }
-        examples 'application/vnd.api+json' => {
-          meta: { filter: 'result=notselected' },
-          data: [
-            {
-              type: 'Rule Result',
-              id: 'd9654ad0-7cb5-4f61-b57c-0d22e3341dcc',
-              attributes: {
-                result: 'notselected'
-              },
-              relationships: {
-                host: {
-                  data: {
-                    id: '6b97bc3a-3614-411f-9a9d-4a8a5b041687',
-                    type: 'host'
-                  }
-                },
-                rule: {
-                  data: {
-                    id: '9bi7bc3a-2314-4929-9a9d-4a8a5b041687',
-                    type: 'rule'
-                  }
-                }
-              }
-            }
-          ]
-        }
+
+        after { |e| autogenerate_examples(e) }
+
         run_test!
       end
     end

--- a/spec/integration/rules_spec.rb
+++ b/spec/integration/rules_spec.rb
@@ -3,9 +3,14 @@
 require 'swagger_helper'
 
 describe 'Rules API' do
+  fixtures :accounts, :profiles, :rules
+
+  before do
+    profiles(:one).update!(rules: rules[0...-1], account: accounts(:test))
+  end
+
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/rules" do
     get 'List all rules' do
-      fixtures :rules
       tags 'rule'
       description 'Lists all rules requested'
       operationId 'ListRules'
@@ -15,53 +20,30 @@ describe 'Rules API' do
       pagination_params
       search_params
 
+      include_param
+
       response '200', 'lists all rules requested' do
-        let(:'X-RH-IDENTITY') { encoded_header }
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:test)) }
+        let(:include) { '' } # work around buggy rswag
         schema type: :object,
                properties: {
-                 meta: { '$ref' => '#/components/schemas/metadata' },
-                 links: { '$ref' => '#/components/schemas/links' },
+                 meta: ref_schema('metadata'),
+                 links: ref_schema('links'),
                  data: {
                    type: :array,
                    items: {
                      properties: {
                        type: { type: :string },
                        id: { type: :string, format: :uuid },
-                       attributes: { '$ref' => '#/components/schemas/rule' }
+                       attributes: ref_schema('rule'),
+                       relationships: ref_schema('rule_relationships')
                      }
                    }
                  }
                }
-        examples 'application/vnd.api+json' => {
-          meta: { filter: 'title=Record Access Events to Audit Log directory' },
-          data: [
-            {
-              type: 'Rule',
-              id: 'd9654ad0-7cb5-4f61-b57c-0d22e3341dcc',
-              attributes: {
-                title: 'Record Access Events to Audit Log directory',
-                ref_id: 'xccdf_org.ssgproject.content_rule_directory_access_'\
-                'var_log_audit',
-                severity: 'Low',
-                description: 'The audit system should collect access events to'\
-                ' read audit log directory.\nThe following audit rule will '\
-                'assure that access to audit log directory are\ncollected.\n-a'\
-                ' always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000'\
-                '-F auid!=unset -F key=access-audit-trail\nIf the auditd '\
-                'daemon is configured to use the augenrules\nprogram to read '\
-                'audit rules during daemon startup (the default), add '\
-                'the\nrule to a file with suffix .rules in the directory\n'\
-                '/etc/audit/rules.d.\nIf the auditd daemon is configured to '\
-                'use the auditctl\nutility to read audit rules during daemon '\
-                'startup, add the rule to\n/etc/audit/audit.rules file.',
-                rationale: 'Attempts to read the logs should be recorded,'\
-                ' suspicious access to audit log files could be an indicator'\
-                ' of malicious activity on a system.\nAuditing these events'\
-                ' could serve as evidence of potential system compromise.'
-              }
-            }
-          ]
-        }
+
+        after { |e| autogenerate_examples(e) }
+
         run_test!
       end
     end
@@ -69,80 +51,46 @@ describe 'Rules API' do
 
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/rules/{id}" do
     get 'Retrieve a rule' do
-      fixtures :hosts, :benchmarks, :rules, :profiles
       tags 'rule'
       description 'Retrieves data for a rule'
       operationId 'ShowRule'
 
       content_types
       auth_header
-      pagination_params
-      search_params
 
       parameter name: :id, in: :path, type: :string
+      include_param
 
       response '404', 'rule not found' do
-        let(:id) { 'invalid' }
-        let(:'X-RH-IDENTITY') { encoded_header }
-        examples 'application/vnd.api+json' => {
-          errors: 'Resource not found'
-        }
+        let(:id) { rules.last.id }
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:test)) }
+        let(:include) { '' } # work around buggy rswag
+
+        after { |e| autogenerate_examples(e) }
+
         run_test!
       end
 
       response '200', 'retrieves a rule' do
-        let(:'X-RH-IDENTITY') { encoded_header }
-        let(:id) do
-          Account.create(
-            account_number: x_rh_identity[:identity][:account_number]
-          )
-          user = User.from_x_rh_identity(x_rh_identity[:identity])
-          user.save
-          profiles(:one).update!(account: user.account, hosts: [hosts(:one)])
-          rules(:one).rule_results.destroy_all
-          rules(:one).update!(profiles: [profiles(:one)])
-          rules(:one).id
-        end
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:test)) }
+        let(:id) { rules(:one).id }
+        let(:include) { '' } # work around buggy rswag
         schema type: :object,
                properties: {
-                 meta: { '$ref' => '#/components/schemas/metadata' },
-                 links: { '$ref' => '#/components/schemas/links' },
+                 meta: ref_schema('metadata'),
+                 links: ref_schema('links'),
                  data: {
                    type: :object,
                    properties: {
                      type: { type: :string },
-                     id: { type: :string, format: :uuid },
-                     attributes: { '$ref' => '#/components/schemas/rule' }
+                     id: ref_schema('uuid'),
+                     attributes: ref_schema('rule'),
+                     relationships: ref_schema('rule_relationships')
                    }
                  }
                }
-        examples 'application/vnd.api+json' => {
-          data: {
-            type: 'Rule',
-            id: 'd9654ad0-7cb5-4f61-b57c-0d22e3341dcc',
-            attributes: {
-              title: 'Record Access Events to Audit Log directory',
-              ref_id: 'xccdf_org.ssgproject.content_rule_directory_access_'\
-              'var_log_audit',
-              severity: 'Low',
-              description: 'The audit system should collect access events to '\
-              'read audit log directory.\nThe following audit rule will assure'\
-              ' that access to audit log directory are\ncollected.\n-a '\
-              'always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000'\
-              '-F auid!=unset -F key=access-audit-trail\nIf the auditd daemon'\
-              'is configured to use the augenrules\nprogram to read audit'\
-              ' rules during daemon startup (the default), add the\nrule to'\
-              ' a file with suffix .rules in the directory\n'\
-              '/etc/audit/rules.d.\nIf the auditd daemon is configured to use'\
-              ' the auditctl\nutility to read audit rules during daemon '\
-              'startup, add the rule to\n/etc/audit/audit.rules file.',
-              rationale: 'Attempts to read the logs should be recorded,'\
-              ' suspicious access to audit log files could be an indicator'\
-              ' of malicious activity on a system.\nAuditing these events'\
-              ' could serve as evidence of potential system compromise.'
-            }
-          }
-        }
+
+        after { |e| autogenerate_examples(e) }
 
         run_test!
       end

--- a/spec/integration/systems_spec.rb
+++ b/spec/integration/systems_spec.rb
@@ -3,9 +3,9 @@
 require 'swagger_helper'
 
 describe 'Systems API' do
+  fixtures :accounts, :hosts
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/systems" do
     get 'List all hosts' do
-      fixtures :hosts
       tags 'host'
       description 'Lists all hosts requested'
       operationId 'ListHosts'
@@ -15,35 +15,30 @@ describe 'Systems API' do
       pagination_params
       search_params
 
+      include_param
+
       response '200', 'lists all hosts requested' do
-        let(:'X-RH-IDENTITY') { encoded_header }
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:one)) }
+        let(:include) { '' } # work around buggy rswag
         schema type: :object,
                properties: {
-                 meta: { '$ref' => '#/components/schemas/metadata' },
-                 links: { '$ref' => '#/components/schemas/links' },
+                 meta: ref_schema('metadata'),
+                 links: ref_schema('links'),
                  data: {
                    type: :array,
                    items: {
                      properties: {
                        type: { type: :string },
-                       id: { type: :string, format: :uuid },
-                       attributes: { '$ref' => '#/components/schemas/host' }
+                       id: ref_schema('uuid'),
+                       attributes: ref_schema('host'),
+                       relationships: ref_schema('host_relationships')
                      }
                    }
                  }
                }
-        examples 'application/vnd.api+json' => {
-          data: [
-            {
-              type: 'Host',
-              id: 'd9654ad0-7cb5-4f61-b57c-0d22e3341dcc',
-              attributes: {
-                name: 'Standard System Security Profile for Fedora',
-                ref_id: 'xccdf_org.ssgproject.content_host_standard'
-              }
-            }
-          ]
-        }
+
+        after { |e| autogenerate_examples(e) }
+
         run_test!
       end
     end

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -147,6 +147,9 @@
                           },
                           "attributes": {
                             "$ref": "#/components/schemas/benchmark"
+                          },
+                          "relationships": {
+                            "$ref": "#/components/schemas/benchmark_relationships"
                           }
                         }
                       }
@@ -774,7 +777,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "e2ef5fb5-9981-4528-81bb-947b0426cd07",
+                  "id": "3d65ab5b-718e-4817-9c30-de201b2356f3",
                   "type": "profile",
                   "attributes": {
                     "name": "A custom name",
@@ -1010,7 +1013,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "ad762496-2af7-44c8-a38c-f38c4d1ea0a6",
+                        "id": "a8495924-f365-4e81-bf8b-82e2d7cf5cf9",
                         "type": "account"
                       }
                     },
@@ -1191,7 +1194,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "316aff02-6475-4c3c-b539-1e5bedff5db7",
+                  "id": "d9e2c76a-cf26-4f76-8fd0-42781ecbf48f",
                   "type": "profile",
                   "attributes": {
                     "name": "An updated custom name",
@@ -1549,6 +1552,16 @@
               "type": "string",
               "default": ""
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
           }
         ],
         "responses": {
@@ -1556,32 +1569,39 @@
             "description": "lists all rule_results requested",
             "examples": {
               "application/vnd.api+json": {
-                "meta": {
-                  "filter": "result=notselected"
-                },
                 "data": [
                   {
-                    "type": "Rule Result",
-                    "id": "d9654ad0-7cb5-4f61-b57c-0d22e3341dcc",
+                    "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                    "type": "rule_result",
                     "attributes": {
-                      "result": "notselected"
+                      "result": "pass"
                     },
                     "relationships": {
                       "host": {
                         "data": {
-                          "id": "6b97bc3a-3614-411f-9a9d-4a8a5b041687",
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
                           "type": "host"
                         }
                       },
                       "rule": {
                         "data": {
-                          "id": "9bi7bc3a-2314-4929-9a9d-4a8a5b041687",
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
                           "type": "rule"
                         }
                       }
                     }
                   }
-                ]
+                ],
+                "meta": {
+                  "total": 1,
+                  "search": null,
+                  "limit": 10,
+                  "offset": 1
+                },
+                "links": {
+                  "first": "/api/compliance/rule_results?limit=10&offset=1",
+                  "last": "/api/compliance/rule_results?limit=10&offset=1"
+                }
               }
             },
             "content": {
@@ -1608,6 +1628,9 @@
                           },
                           "attributes": {
                             "$ref": "#/components/schemas/rule_result"
+                          },
+                          "relationships": {
+                            "$ref": "#/components/schemas/rule_result_relationships"
                           }
                         }
                       }
@@ -1671,6 +1694,16 @@
               "type": "string",
               "default": ""
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
           }
         ],
         "responses": {
@@ -1678,22 +1711,52 @@
             "description": "lists all rules requested",
             "examples": {
               "application/vnd.api+json": {
-                "meta": {
-                  "filter": "title=Record Access Events to Audit Log directory"
-                },
                 "data": [
                   {
-                    "type": "Rule",
-                    "id": "d9654ad0-7cb5-4f61-b57c-0d22e3341dcc",
+                    "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                    "type": "rule",
                     "attributes": {
-                      "title": "Record Access Events to Audit Log directory",
-                      "ref_id": "xccdf_org.ssgproject.content_rule_directory_access_var_log_audit",
-                      "severity": "Low",
-                      "description": "The audit system should collect access events to read audit log directory.\\nThe following audit rule will assure that access to audit log directory are\\ncollected.\\n-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000-F auid!=unset -F key=access-audit-trail\\nIf the auditd daemon is configured to use the augenrules\\nprogram to read audit rules during daemon startup (the default), add the\\nrule to a file with suffix .rules in the directory\\n/etc/audit/rules.d.\\nIf the auditd daemon is configured to use the auditctl\\nutility to read audit rules during daemon startup, add the rule to\\n/etc/audit/audit.rules file.",
-                      "rationale": "Attempts to read the logs should be recorded, suspicious access to audit log files could be an indicator of malicious activity on a system.\\nAuditing these events could serve as evidence of potential system compromise."
+                      "ref_id": "MyStringOne",
+                      "title": "MyString",
+                      "rationale": "MyText",
+                      "description": "MyText",
+                      "severity": "high",
+                      "slug": "MyStringOne"
+                    },
+                    "relationships": {
+                      "benchmark": {
+                        "data": {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "benchmark"
+                        }
+                      },
+                      "profiles": {
+                        "data": [
+                          {
+                            "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                            "type": "profile"
+                          }
+                        ]
+                      },
+                      "rule_references": {
+                        "data": []
+                      },
+                      "rule_identifier": {
+                        "data": null
+                      }
                     }
                   }
-                ]
+                ],
+                "meta": {
+                  "total": 1,
+                  "search": null,
+                  "limit": 10,
+                  "offset": 1
+                },
+                "links": {
+                  "first": "/api/compliance/rules?limit=10&offset=1",
+                  "last": "/api/compliance/rules?limit=10&offset=1"
+                }
               }
             },
             "content": {
@@ -1720,6 +1783,9 @@
                           },
                           "attributes": {
                             "$ref": "#/components/schemas/rule"
+                          },
+                          "relationships": {
+                            "$ref": "#/components/schemas/rule_relationships"
                           }
                         }
                       }
@@ -1749,48 +1815,22 @@
             }
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "description": "The number of items to return",
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "type": "integer",
-            "description": "The number of items to skip before starting to collect the result set",
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            }
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "required": false,
-            "type": "string",
-            "description": "Query string compliant with scoped_search query language: https://github.com/wvanbergen/scoped_search/wiki/Query-language",
-            "schema": {
-              "type": "string",
-              "default": ""
-            }
-          },
-          {
             "name": "id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
           }
         ],
         "responses": {
@@ -1798,7 +1838,7 @@
             "description": "rule not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Resource not found"
+                "errors": "Rule not found with ID 37f7eeff-831b-5c41-984a-254965f58c0f"
               }
             },
             "content": {}
@@ -1808,14 +1848,37 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "type": "Rule",
-                  "id": "d9654ad0-7cb5-4f61-b57c-0d22e3341dcc",
+                  "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                  "type": "rule",
                   "attributes": {
-                    "title": "Record Access Events to Audit Log directory",
-                    "ref_id": "xccdf_org.ssgproject.content_rule_directory_access_var_log_audit",
-                    "severity": "Low",
-                    "description": "The audit system should collect access events to read audit log directory.\\nThe following audit rule will assure that access to audit log directory are\\ncollected.\\n-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000-F auid!=unset -F key=access-audit-trail\\nIf the auditd daemonis configured to use the augenrules\\nprogram to read audit rules during daemon startup (the default), add the\\nrule to a file with suffix .rules in the directory\\n/etc/audit/rules.d.\\nIf the auditd daemon is configured to use the auditctl\\nutility to read audit rules during daemon startup, add the rule to\\n/etc/audit/audit.rules file.",
-                    "rationale": "Attempts to read the logs should be recorded, suspicious access to audit log files could be an indicator of malicious activity on a system.\\nAuditing these events could serve as evidence of potential system compromise."
+                    "ref_id": "MyStringOne",
+                    "title": "MyString",
+                    "rationale": "MyText",
+                    "description": "MyText",
+                    "severity": "high",
+                    "slug": "MyStringOne"
+                  },
+                  "relationships": {
+                    "benchmark": {
+                      "data": {
+                        "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                        "type": "benchmark"
+                      }
+                    },
+                    "profiles": {
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "profile"
+                        }
+                      ]
+                    },
+                    "rule_references": {
+                      "data": []
+                    },
+                    "rule_identifier": {
+                      "data": null
+                    }
                   }
                 }
               }
@@ -1838,11 +1901,13 @@
                           "type": "string"
                         },
                         "id": {
-                          "type": "string",
-                          "format": "uuid"
+                          "$ref": "#/components/schemas/uuid"
                         },
                         "attributes": {
                           "$ref": "#/components/schemas/rule"
+                        },
+                        "relationships": {
+                          "$ref": "#/components/schemas/rule_relationships"
                         }
                       }
                     }
@@ -1905,6 +1970,16 @@
               "type": "string",
               "default": ""
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
           }
         ],
         "responses": {
@@ -1914,14 +1989,42 @@
               "application/vnd.api+json": {
                 "data": [
                   {
-                    "type": "Host",
-                    "id": "d9654ad0-7cb5-4f61-b57c-0d22e3341dcc",
+                    "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                    "type": "host",
                     "attributes": {
-                      "name": "Standard System Security Profile for Fedora",
-                      "ref_id": "xccdf_org.ssgproject.content_host_standard"
+                      "name": "MyStringone",
+                      "os_major_version": null,
+                      "os_minor_version": null,
+                      "last_scanned": "2020-03-25T14:51:17Z",
+                      "rules_passed": 0,
+                      "rules_failed": 0,
+                      "compliant": true
+                    },
+                    "relationships": {
+                      "test_results": {
+                        "data": [
+                          {
+                            "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                            "type": "test_result"
+                          }
+                        ]
+                      },
+                      "profiles": {
+                        "data": []
+                      }
                     }
                   }
-                ]
+                ],
+                "meta": {
+                  "total": 1,
+                  "search": null,
+                  "limit": 10,
+                  "offset": 1
+                },
+                "links": {
+                  "first": "/api/compliance/systems?limit=10&offset=1",
+                  "last": "/api/compliance/systems?limit=10&offset=1"
+                }
               }
             },
             "content": {
@@ -1943,11 +2046,13 @@
                             "type": "string"
                           },
                           "id": {
-                            "type": "string",
-                            "format": "uuid"
+                            "$ref": "#/components/schemas/uuid"
                           },
                           "attributes": {
                             "$ref": "#/components/schemas/host"
+                          },
+                          "relationships": {
+                            "$ref": "#/components/schemas/host_relationships"
                           }
                         }
                       }
@@ -2043,17 +2148,49 @@
       "host": {
         "type": "object",
         "required": [
-          "name",
-          "account_id"
+          "name"
         ],
         "properties": {
           "name": {
             "type": "string",
             "example": "cloud.redhat.com"
           },
-          "account_id": {
+          "compliant": {
+            "type": "boolean",
+            "example": true
+          },
+          "os_major_version": {
             "type": "string",
-            "example": "649cf080-ccce-4c02-ba60-21d046983c7f"
+            "example": "7",
+            "nullable": true
+          },
+          "os_minor_version": {
+            "type": "string",
+            "example": "3",
+            "nullable": true
+          },
+          "last_scanned": {
+            "type": "string",
+            "example": "2020-06-04T19:31:55Z"
+          },
+          "rules_passed": {
+            "type": "integer",
+            "example": 34
+          },
+          "rules_failed": {
+            "type": "integer",
+            "example": 12
+          }
+        }
+      },
+      "host_relationships": {
+        "type": "object",
+        "properties": {
+          "profiles": {
+            "$ref": "#/components/schemas/relationship_collection"
+          },
+          "test_results": {
+            "$ref": "#/components/schemas/relationship_collection"
           }
         }
       },
@@ -2223,6 +2360,17 @@
           }
         }
       },
+      "rule_result_relationships": {
+        "type": "object",
+        "properties": {
+          "hosts": {
+            "$ref": "#/components/schemas/relationship_collection"
+          },
+          "rules": {
+            "$ref": "#/components/schemas/relationship_collection"
+          }
+        }
+      },
       "rule": {
         "type": "object",
         "required": [
@@ -2249,6 +2397,23 @@
           "rationale": {
             "type": "string",
             "example": "Attempts to read the logs should be recorded, suspicious access to audit log files could be an indicator of malicious activity on a system.\\nAuditing these events could serve as evidence of potential system compromise."
+          }
+        }
+      },
+      "rule_relationships": {
+        "type": "object",
+        "properties": {
+          "benchmark": {
+            "$ref": "#/components/schemas/relationship"
+          },
+          "rule_identifier": {
+            "$ref": "#/components/schemas/relationship"
+          },
+          "profiles": {
+            "$ref": "#/components/schemas/relationship_collection"
+          },
+          "rule_references": {
+            "$ref": "#/components/schemas/relationship_collection"
           }
         }
       }

--- a/test/controllers/v1/rules_controller_test.rb
+++ b/test/controllers/v1/rules_controller_test.rb
@@ -41,9 +41,12 @@ module V1
       assert_response :success
     end
 
-    test 'finds rules not within the user scope but within latest' do
+    test 'finds latest canonical rules' do
+      assert(profiles(:one).canonical?)
+      profiles(:one).rules << rules(:two)
+      assert(rules(:two).canonical?)
       assert_includes(Rule.latest, rules(:two))
-      assert_not_includes(::Pundit.policy_scope(users(:test), ::Rule),
+      assert_not_includes(accounts(:test).profiles.map(&:rules).uniq,
                           rules(:two))
       get v1_rule_url(rules(:two).ref_id)
 


### PR DESCRIPTION
This revisits all controllers, serializers, specs, schemas, etc. for API V1. So far we have implemented profiles and benchmarks. This matches that work to the other V1 resources.

Signed-off-by: Andrew Kofink <akofink@redhat.com>