### PR TITLE
RHICOMPL-668 - Import os_major/minor on report parsing

### DIFF
--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -9,7 +9,9 @@ module Xccdf
     def save_host
       @host = ::Host.find_or_initialize_by(id: inventory_host['id'],
                                            account_id: @account.id)
-      @host.update!(name: inventory_host['fqdn'])
+      @host.update!(name: inventory_host['fqdn'],
+                    os_major_version: inventory_host['os_major_version'],
+                    os_minor_version: inventory_host['os_minor_version'])
     end
 
     def host_profile

--- a/test/services/concerns/xccdf/hosts_test.rb
+++ b/test/services/concerns/xccdf/hosts_test.rb
@@ -14,7 +14,9 @@ module Xccdf
         @test_result_file = test_result_file
         @host = host
         @account = account
-        @inventory_host = OpenStruct.new(id: @host.id, fqdn: @host.name)
+        @inventory_host = OpenStruct.new(id: @host.id, fqdn: @host.name,
+                                         os_major_version: 8,
+                                         os_minor_version: 2)
         set_openscap_parser_data
       end
     end
@@ -43,6 +45,13 @@ module Xccdf
       assert_difference('ProfileRule.count', 0) do
         @parser.associate_rules_from_rule_results
       end
+    end
+
+    test 'saves the OS attributes upon report parsing' do
+      @parser.save_host
+      parser_host = @parser.instance_variable_get('@host')
+      assert_equal 8, parser_host.reload.os_major_version
+      assert_equal 2, parser_host.reload.os_minor_version
     end
   end
 end


### PR DESCRIPTION
Before this change, we got the os_release fields from the inventory, but we didn't update the compliance database. This just makes sure we update the os_major_version and os_minor_version with the values we get from the inventory.