### PR TITLE
Add more logging to Sidekiq jobs

### DIFF
--- a/app/jobs/delete_host.rb
+++ b/app/jobs/delete_host.rb
@@ -7,8 +7,10 @@ class DeleteHost
 
   def perform(message)
     Host.transaction do
+      Sidekiq.logger.info("Deleting rule results for host #{message['id']}")
       RuleResult.where(host_id: message['id']).delete_all
       rescue_not_found do
+        Sidekiq.logger.info("Destroying host #{message['id']}")
         Host.find_by!(id: message['id']).destroy
       end
     end

--- a/app/jobs/destroy_profiles_job.rb
+++ b/app/jobs/destroy_profiles_job.rb
@@ -5,6 +5,8 @@ class DestroyProfilesJob
   include Sidekiq::Worker
 
   def perform(ids)
+    Sidekiq.logger.info("Destroying profiles with IDs: #{ids}...")
     Profile.where(id: ids).destroy_all
+    Sidekiq.logger.info('Finished')
   end
 end

--- a/app/jobs/inventory_host_updated_job.rb
+++ b/app/jobs/inventory_host_updated_job.rb
@@ -9,9 +9,7 @@ class InventoryHostUpdatedJob
     return wrong_format_warning(message) unless valid_message_format(message)
 
     rescue_not_found do
-      Host.find_by!(
-        id: message['host']['id']
-      ).update!(name: message['host']['display_name'])
+      update_host(message)
     end
   end
 
@@ -24,5 +22,15 @@ class InventoryHostUpdatedJob
       'Received a message to update a hostname but message '\
       "doesn't have the expected format - #{message}"
     )
+  end
+
+  def update_host(message)
+    Sidekiq.logger.info(
+      "Updating host #{message['host']['id']} name "\
+      " to #{message['host']['display_name']}"
+    )
+    Host.find_by!(
+      id: message['host']['id']
+    ).update!(name: message['host']['display_name'])
   end
 end

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -11,6 +11,10 @@ class ParseReportJob
 
     @file = file
     @msg_value = message
+    Sidekiq.logger.info(
+      "Parsing report for account #{@msg_value['account']}, "\
+      "system #{@msg_value['id']}"
+    )
     save_all
   end
 

--- a/test/jobs/delete_host_test.rb
+++ b/test/jobs/delete_host_test.rb
@@ -23,7 +23,7 @@ class DeleteHostTest < ActiveSupport::TestCase
   test 'logs if message contains an ID not found ' do
     DeleteHost.perform_async(@message.merge('id': 'notfound'))
     assert_equal 1, DeleteHost.jobs.size
-    Sidekiq.logger.expects(:info)
+    Sidekiq.logger.expects(:info).at_least_once
     assert_difference('Host.count', 0) do
       DeleteHost.drain
     end

--- a/test/jobs/inventory_host_updated_job_test.rb
+++ b/test/jobs/inventory_host_updated_job_test.rb
@@ -34,7 +34,7 @@ class InventoryHostUpdatedJobTest < ActiveSupport::TestCase
       'host': { 'id': 'notfound', 'display_name': 'abc' }
     )
     assert_equal 1, InventoryHostUpdatedJob.jobs.size
-    Sidekiq.logger.expects(:info)
+    Sidekiq.logger.expects(:info).at_least_once
     InventoryHostUpdatedJob.drain
   end
 end


### PR DESCRIPTION
Currently, it's very hard for QE to test which systems are getting deleted and which aren't in order to test https://github.com/RedHatInsights/compliance-backend/commit/0b9466cc011945326c849a60a5d5e2de65748e6d. 

This adds extra logging to all jobs, which will probably be useful in the future to figure out what is happening, particularly in production where there is no Payload Tracker. 