### PR TITLE
RHICOMPL-760 Use display_name instead of fqdn from inventory

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -47,7 +47,7 @@ module Mutations
       )
 
       host.update!(
-        name: i_host['fqdn']
+        name: i_host['display_name']
       )
 
       host

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -9,7 +9,7 @@ module Xccdf
     def save_host
       @host = ::Host.find_or_initialize_by(id: inventory_host['id'],
                                            account_id: @account.id)
-      @host.update!(name: inventory_host['fqdn'],
+      @host.update!(name: inventory_host['display_name'],
                     os_major_version: inventory_host['os_major_version'],
                     os_minor_version: inventory_host['os_minor_version'])
     end

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -57,7 +57,7 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     HostInventoryAPI.expects(:new).returns(@api)
     @api.expects(:inventory_host).returns(
       'id' => NEW_ID,
-      'fqdn' => 'newhostname'
+      'display_name' => 'newhostname'
     )
 
     Schema.execute(

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -57,7 +57,7 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
     HostInventoryAPI.expects(:new).returns(@api)
     @api.expects(:inventory_host).returns(
       'id' => NEW_ID,
-      'fqdn' => 'newhostname'
+      'display_name' => 'newhostname'
     )
 
     Schema.execute(

--- a/test/services/concerns/xccdf/hosts_test.rb
+++ b/test/services/concerns/xccdf/hosts_test.rb
@@ -14,7 +14,7 @@ module Xccdf
         @test_result_file = test_result_file
         @host = host
         @account = account
-        @inventory_host = OpenStruct.new(id: @host.id, fqdn: @host.name,
+        @inventory_host = OpenStruct.new(id: @host.id, display_name: @host.name,
                                          os_major_version: 8,
                                          os_minor_version: 2)
         set_openscap_parser_data

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -7,7 +7,7 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   setup do
     @account = accounts(:one)
     @inventory_host = { 'id': hosts(:one).id,
-                        'fqdn': hosts(:one).name,
+                        'display_name': hosts(:one).name,
                         'account': @account.account_number }
     @host = hosts(:one)
     @url = 'http://localhost'

--- a/test/services/reports_tar_reader_test.rb
+++ b/test/services/reports_tar_reader_test.rb
@@ -14,7 +14,7 @@ class ReportsTarReaderTest < ActiveSupport::TestCase
           'id' => ::UUID.generate,
           'b64_identity' => 'b64_fake_identity',
           'metadata' => {
-            'fqdn' => 'lenovolobato.lobatolan.home'
+            'display_name' => 'lenovolobato.lobatolan.home'
           }
         )
       end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -22,7 +22,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
                           'b64_identity' => 'b64_fake_identity',
                           'id' => @host_id,
                           'metadata' => {
-                            'fqdn' => 'lenovolobato.lobatolan.home'
+                            'display_name' => 'lenovolobato.lobatolan.home'
                           })
     @report_parser.set_openscap_parser_data
     # A hack to skip API calls in the test env for the time being
@@ -32,7 +32,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       'results' => [
         { 'id' => @host_id,
           'account' => accounts(:test).account_number,
-          'fqdn' => @report_parser.test_result_file.test_result.host }
+          'display_name' => @report_parser.test_result_file.test_result.host }
       ]
     }
     connection.stubs(:get).with(
@@ -113,7 +113,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
                             'id' => @host_id,
                             'b64_identity' => 'b64_fake_identity',
                             'metadata' => {
-                              'fqdn' => 'lenovolobato.lobatolan.home'
+                              'display_name' => 'lenovolobato.lobatolan.home'
                             })
       assert_equal 10, @report_parser.op_benchmark.profiles.count
     end
@@ -202,7 +202,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
           'fakereport',
           'account' => accounts(:test).account_number,
           'b64_identity' => 'b64_fake_identity',
-          'metadata' => { 'fqdn': '123' }
+          'metadata' => { 'display_name': '123' }
         )
       end
     end
@@ -321,7 +321,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
           'id' => @host_id,
           'b64_identity' => 'b64_fake_identity',
           'metadata' => {
-            'fqdn' => 'lenovolobato.lobatolan.home'
+            'display_name' => 'lenovolobato.lobatolan.home'
           }
         )
       end


### PR DESCRIPTION
Our Host model requires a non-empty name. The display_name from
inventory is either the fqdn or the id if fqdn is null, so it's never null.

Signed-off-by: Andrew Kofink <akofink@redhat.com>