### PR TITLE
Add hosts#show and add includes to hosts API

### DIFF
--- a/app/controllers/v1/systems_controller.rb
+++ b/app/controllers/v1/systems_controller.rb
@@ -4,17 +4,27 @@ module V1
   # API for Systems (only Hosts for the moment)
   class SystemsController < ApplicationController
     def index
-      render json: HostSerializer.new(scope_search, metadata)
+      render_json scope_search
+    end
+
+    def show
+      render_json host
     end
 
     def destroy
-      host = Host.find(params[:id])
       authorize host
-      host.destroy
-      render HostSerializer.new(host)
+      render_json host.destroy
     end
 
     private
+
+    def host
+      @host ||= pundit_scope.find(params[:id])
+    end
+
+    def serializer
+      HostSerializer
+    end
 
     def resource
       Host

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
           end
         end
         resources :rule_results, only: [:index]
-        resources :systems, only: [:index, :destroy]
+        resources :systems, only: [:index, :show, :destroy]
         resources :rules, only: [:index, :show]
       end
       resources :benchmarks, controller: 'v1/benchmarks', only: [:index, :show]
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
         end
       end
       resources :rule_results, controller: 'v1/rule_results', only: [:index]
-      resources :systems, controller: 'v1/systems', only: [:index, :destroy]
+      resources :systems, controller: 'v1/systems', only: [:index, :show, :destroy]
       resources :rules, controller: 'v1/rules', only: [:index, :show]
       mount Rswag::Api::Engine => '/',
         as: "#{prefix}/#{ENV['APP_NAME']}/rswag_api"

--- a/spec/integration/systems_spec.rb
+++ b/spec/integration/systems_spec.rb
@@ -4,6 +4,11 @@ require 'swagger_helper'
 
 describe 'Systems API' do
   fixtures :accounts, :hosts
+
+  before do
+    hosts(:one).update!(account: accounts(:one))
+  end
+
   path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/systems" do
     get 'List all hosts' do
       tags 'host'
@@ -37,6 +42,51 @@ describe 'Systems API' do
                  }
                }
 
+        after { |e| autogenerate_examples(e) }
+
+        run_test!
+      end
+    end
+  end
+
+  path "#{ENV['PATH_PREFIX']}/#{ENV['APP_NAME']}/systems/{id}" do
+    get 'Retrieve a system' do
+      tags 'host'
+      description 'Lists all hosts requested'
+      operationId 'ListHosts'
+
+      content_types
+      auth_header
+
+      parameter name: :id, in: :path, type: :string
+      include_param
+
+      response '404', 'system not found' do
+        let(:id) { 'invalid' }
+        let(:'X-RH-IDENTITY') { encoded_header }
+        let(:include) { '' } # work around buggy rswag
+        after { |e| autogenerate_examples(e) }
+        run_test!
+      end
+
+      response '200', 'retrieves a system' do
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:one)) }
+        let(:id) { hosts(:one).id }
+        let(:include) { '' } # work around buggy rswag
+        schema type: :object,
+               properties: {
+                 meta: ref_schema('metadata'),
+                 links: ref_schema('links'),
+                 data: {
+                   type: :object,
+                   properties: {
+                     type: { type: :string },
+                     id: ref_schema('uuid'),
+                     attributes: ref_schema('host'),
+                     relationships: ref_schema('host_relationships')
+                   }
+                 }
+               }
         after { |e| autogenerate_examples(e) }
 
         run_test!

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -777,7 +777,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "3d65ab5b-718e-4817-9c30-de201b2356f3",
+                  "id": "90392693-82fb-4e78-bf06-00f988d5b545",
                   "type": "profile",
                   "attributes": {
                     "name": "A custom name",
@@ -1013,7 +1013,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "a8495924-f365-4e81-bf8b-82e2d7cf5cf9",
+                        "id": "14ea2548-e89b-4749-b948-947a7632ab68",
                         "type": "account"
                       }
                     },
@@ -1194,7 +1194,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "d9e2c76a-cf26-4f76-8fd0-42781ecbf48f",
+                  "id": "170537e4-7111-4675-973e-3a9a9fb73057",
                   "type": "profile",
                   "attributes": {
                     "name": "An updated custom name",
@@ -2054,6 +2054,119 @@
                           "relationships": {
                             "$ref": "#/components/schemas/host_relationships"
                           }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/compliance/systems/{id}": {
+      "get": {
+        "summary": "Retrieve a system",
+        "tags": [
+          "host"
+        ],
+        "description": "Lists all hosts requested",
+        "operationId": "ListHosts",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "system not found",
+            "examples": {
+              "application/vnd.api+json": {
+                "errors": "Host not found with ID invalid"
+              }
+            },
+            "content": {}
+          },
+          "200": {
+            "description": "retrieves a system",
+            "examples": {
+              "application/vnd.api+json": {
+                "data": {
+                  "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                  "type": "host",
+                  "attributes": {
+                    "name": "MyStringone",
+                    "os_major_version": null,
+                    "os_minor_version": null,
+                    "last_scanned": "2020-03-25T14:51:17Z",
+                    "rules_passed": 0,
+                    "rules_failed": 0,
+                    "compliant": true
+                  },
+                  "relationships": {
+                    "test_results": {
+                      "data": [
+                        {
+                          "id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
+                          "type": "test_result"
+                        }
+                      ]
+                    },
+                    "profiles": {
+                      "data": []
+                    }
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "$ref": "#/components/schemas/uuid"
+                        },
+                        "attributes": {
+                          "$ref": "#/components/schemas/host"
+                        },
+                        "relationships": {
+                          "$ref": "#/components/schemas/host_relationships"
                         }
                       }
                     }

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -8,40 +8,63 @@ module V1
       SystemsController.any_instance.expects(:authenticate_user)
     end
 
-    test 'index lists all systems' do
-      SystemsController.any_instance.expects(:policy_scope).with(Host)
-                       .returns(Host.all).at_least_once
-      get v1_systems_url
+    context 'index' do
+      should 'lists all systems' do
+        SystemsController.any_instance.expects(:policy_scope).with(Host)
+                         .returns(Host.all).at_least_once
+        get v1_systems_url
 
-      assert_response :success
-    end
-
-    test 'index accepts search' do
-      SystemsController.any_instance.expects(:policy_scope).with(Host)
-                       .returns(Host.all).at_least_once
-      get v1_systems_url, params: { search: 'name=bar' }
-
-      assert_response :success
-    end
-
-    test 'destroy hosts with authorized user' do
-      User.current = users(:test)
-      users(:test).update(account: accounts(:test))
-      hosts(:one).update(account: accounts(:test))
-      assert_difference('Host.count', -1) do
-        delete "#{v1_systems_url}/#{hosts(:one).id}"
+        assert_response :success
       end
-      assert_response :success
+
+      should 'accept search' do
+        SystemsController.any_instance.expects(:policy_scope).with(Host)
+                         .returns(Host.all).at_least_once
+        get v1_systems_url, params: { search: 'name=bar' }
+
+        assert_response :success
+      end
     end
 
-    test 'does not destroy hosts that do not belong to the user' do
-      User.current = users(:test)
-      users(:test).update(account: accounts(:test))
-      hosts(:one).update(account: nil)
-      assert_difference('Host.count', 0) do
-        delete "#{v1_systems_url}/#{hosts(:one).id}"
+    context 'destroy' do
+      should 'destroy hosts with authorized user' do
+        User.current = users(:test)
+        users(:test).update(account: accounts(:test))
+        hosts(:one).update(account: accounts(:test))
+        assert_difference('Host.count', -1) do
+          delete "#{v1_systems_url}/#{hosts(:one).id}"
+        end
+        assert_response :success
       end
-      assert_response :forbidden
+
+      should 'not destroy hosts that do not belong to the user' do
+        User.current = users(:test)
+        users(:test).update(account: accounts(:test))
+        hosts(:one).update(account: nil)
+        assert_difference('Host.count', 0) do
+          delete "#{v1_systems_url}/#{hosts(:one).id}"
+        end
+        assert_response :not_found
+      end
+    end
+
+    context 'show' do
+      setup do
+        users(:test).update!(account: accounts(:test))
+        User.current = users(:test)
+        hosts(:one).update!(account: accounts(:test))
+      end
+
+      should 'show a host in the related account' do
+        get system_path(hosts(:one))
+        assert_response :success
+        assert_equal hosts(:one).id, JSON.parse(response.body).dig('data', 'id')
+      end
+
+      should 'return 404 for hosts in other accounts' do
+        get system_path(hosts(:two))
+        assert_response :not_found
+      end
     end
   end
 end


### PR DESCRIPTION
This adds parity to the systems API with our other V1 APIs
- Add a systems#show endpoint
- Allow specifying includes in the hosts API

https://projects.engineering.redhat.com/browse/RHICOMPL-763

Signed-off-by: Andrew Kofink <akofink@redhat.com>