### PR TITLE
s/alias/aliases/ for scoped_search deprecation

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -6,8 +6,8 @@ class Rule < ApplicationRecord
   extend FriendlyId
   friendly_id :ref_id, use: :slugged
   scoped_search on: %i[id ref_id severity]
-  scoped_search relation: :rule_references, on: :label, alias: :reference
-  scoped_search relation: :rule_identifier, on: :label, alias: :identifier
+  scoped_search relation: :rule_references, on: :label, aliases: %i[reference]
+  scoped_search relation: :rule_identifier, on: :label, aliases: %i[identifier]
   include OpenscapParserDerived
 
   has_many :profile_rules, dependent: :delete_all

--- a/app/models/xccdf/benchmark.rb
+++ b/app/models/xccdf/benchmark.rb
@@ -8,8 +8,9 @@ module Xccdf
   class Benchmark < ApplicationRecord
     scoped_search on: %i[id ref_id title version]
     scoped_search relation: :profiles, on: :id, rename: :profile_ids,
-                  alias: :profile_id
-    scoped_search relation: :rules, on: :id, rename: :rule_ids, alias: :rule_id
+                  aliases: %i[profile_id]
+    scoped_search relation: :rules, on: :id, rename: :rule_ids,
+                  aliases: %i[rule_id]
     scoped_search on: :os_major_version, ext_method: 'os_major_version_search',
                   only_explicit: true, operators: ['=', '!='],
                   validator: ScopedSearch::Validators::INTEGER


### PR DESCRIPTION
Just some fixes for deprecations to remove warning messages - nothing should have changed logically.

Signed-off-by: Andrew Kofink <akofink@redhat.com>