### PR TITLE
Ensure all consumers log all messages received

### DIFF
--- a/app/consumers/application_consumer.rb
+++ b/app/consumers/application_consumer.rb
@@ -2,4 +2,14 @@
 
 # Parent class for all Racecar consumers, contains general logic
 class ApplicationConsumer < Racecar::Consumer
+  def process(message)
+    @msg_value = JSON.parse(message.value)
+    logger.info "Received message, enqueueing: #{@msg_value}"
+  end
+
+  protected
+
+  def logger
+    Rails.logger
+  end
 end

--- a/app/consumers/compliance_reports_consumer.rb
+++ b/app/consumers/compliance_reports_consumer.rb
@@ -9,7 +9,8 @@ class ComplianceReportsConsumer < ApplicationConsumer
   subscribes_to Settings.platform_kafka_topic
 
   def process(message)
-    @msg_value = JSON.parse(message.value)
+    super(message)
+
     raise EntitlementError unless identity.valid?
 
     download_file
@@ -86,9 +87,5 @@ class ComplianceReportsConsumer < ApplicationConsumer
       'service': 'compliance',
       'validation': result
     }.to_json
-  end
-
-  def logger
-    Rails.logger
   end
 end

--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -6,20 +6,13 @@ class InventoryEventsConsumer < ApplicationConsumer
   subscribes_to Settings.platform_kafka_inventory_topic
 
   def process(message)
-    msg_value = JSON.parse(message.value)
-    logger.info "Received message, enqueueing: #{message.value}"
+    super(message)
 
-    case msg_value['type']
+    case @msg_value['type']
     when 'delete'
-      DeleteHost.perform_async(msg_value)
+      DeleteHost.perform_async(@msg_value)
     when 'updated'
-      InventoryHostUpdatedJob.perform_async(msg_value)
+      InventoryHostUpdatedJob.perform_async(@msg_value)
     end
-  end
-
-  private
-
-  def logger
-    Rails.logger
   end
 end


### PR DESCRIPTION
While debugging our consumers recently, I realized that not all messages are logged; sometimes validations are performed first, which makes it difficult to debug what went wrong. Shared logic like logging should be part of the ApplicationConsumer.

This is fine to merge as is, but I may add to it as I continue to debug the consumers.

Signed-off-by: Andrew Kofink <akofink@redhat.com>