### PR TITLE
Ignore scap-security-guide content in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ config/environments/*.local.yml
 brakeman_output.markdown
 
 Gemfile.local
+
+scap-security-guide*


### PR DESCRIPTION
The ssg:sync_rhel rake tasks lays down SSG files for RHEL 6, 7, and 8.
We won't ever want to commit them to the repo unless as part of the
tests.