### PR TITLE
Mute sidekiq Redis.exists logs

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+Redis.exists_returns_integer = false # remove on sidekiq upgrade
+
 sidekiq_config = lambda do |config|
   config.redis = {
     url: "redis://#{Settings.redis_url}",


### PR DESCRIPTION
In the sidekiq logs, constantly, is printed:

```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/opt/app-root/src/bundle/ruby/2.6.0/gems/sidekiq-5.2.7/lib/sidekiq/launcher.rb:105:in `block (2 levels) in ❤')
```

Sidekiq doesn't offer an updated version that fixes this deprecation yet.