### PR TITLE
Improve parsing performance

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,4 +3,21 @@
 # Abstract record class to be applied to all models
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.arel_find(collection, batch_size = 1000)
+    base_arel = arel_table[column_names.first].eq('')
+    collection.in_groups_of(batch_size, false).map do |batch|
+      where(batch.inject(base_arel) do |rel, record|
+        rel.or(yield(record))
+      end)
+    end.inject([], &:+)
+  end
+
+  def ==(other)
+    return super if self.class.column_names.include? 'id'
+
+    self.class.column_names.map do |col|
+      send(col) == other.send(col)
+    end.all?
+  end
 end

--- a/app/models/rule_reference.rb
+++ b/app/models/rule_reference.rb
@@ -18,9 +18,10 @@ class RuleReference < ApplicationRecord
                      message: 'and label combination already taken'
                    }
 
-  def self.find_from_oscap(oscap_references)
-    oscap_references.inject(where('1=0')) do |rel, reference|
-      rel.or(where(href: reference.href, label: reference.label))
+  def self.find_unique(references)
+    arel_find(references) do |reference|
+      arel_table[:href].eq(reference.href)
+                       .and(arel_table[:label].eq(reference.label))
     end
   end
 

--- a/app/models/rule_references_rule.rb
+++ b/app/models/rule_references_rule.rb
@@ -7,4 +7,14 @@ class RuleReferencesRule < ApplicationRecord
 
   validates :rule, presence: true
   validates :rule_reference, presence: true, uniqueness: { scope: :rule }
+
+  def self.find_unique(rule_references_rules)
+    arel_find(rule_references_rules) do |rule_references_rule|
+      arel_table[:rule_id].eq(rule_references_rule.rule_id).and(
+        arel_table[:rule_reference_id].eq(
+          rule_references_rule.rule_reference_id
+        )
+      )
+    end
+  end
 end

--- a/app/services/concerns/xccdf/rule_references.rb
+++ b/app/services/concerns/xccdf/rule_references.rb
@@ -7,17 +7,32 @@ module Xccdf
 
     included do
       def save_rule_references
-        @rule_references ||= @op_rule_references.map do |op_reference|
-          ::RuleReference.from_openscap_parser(op_reference)
-        end
+        @rule_references = new_rule_references + existing_rule_references
 
-        ::RuleReference.import!(new_rule_references, ignore: true)
+        ::RuleReference.import!(new_rule_references)
       end
 
       private
 
       def new_rule_references
-        @new_rule_references ||= @rule_references.select(&:new_record?)
+        @new_rule_references ||= new_op_rule_references.map do |op_reference|
+          RuleReference.new(href: op_reference.href, label: op_reference.label)
+        end
+      end
+
+      def existing_rule_references
+        @existing_rule_references ||= ::RuleReference
+                                      .find_unique(@op_rule_references)
+      end
+
+      def existing_href_labels
+        existing_rule_references.pluck(:href, :label)
+      end
+
+      def new_op_rule_references
+        @op_rule_references.reject do |op_reference|
+          existing_href_labels.include? [op_reference.href, op_reference.label]
+        end
       end
     end
   end

--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -4,7 +4,7 @@ module Xccdf
   # Methods related to saving TestResult from openscap_parser
   module TestResult
     def save_test_result
-      @test_result = ::TestResult.create(
+      @test_result = ::TestResult.create!(
         host: @host,
         profile: @host_profile,
         score: @op_test_result.score,

--- a/test/models/rule_reference_test.rb
+++ b/test/models/rule_reference_test.rb
@@ -29,6 +29,6 @@ class RuleReferenceTest < ActiveSupport::TestCase
   test 'finds an existing RuleReference from_oscap' do
     rule_reference = RuleReference.create!(OP_RULE_REFERENCE.to_h)
     assert_equal rule_reference.id,
-                 RuleReference.find_from_oscap([OP_RULE_REFERENCE]).first.id
+                 RuleReference.find_unique([OP_RULE_REFERENCE]).first.id
   end
 end

--- a/test/services/concerns/xccdf/rule_references_rules_test.rb
+++ b/test/services/concerns/xccdf/rule_references_rules_test.rb
@@ -19,7 +19,9 @@ class RuleReferencesRulesTest < ActiveSupport::TestCase
       save_rule_references_rules
     end
 
-    @rule_references_rules = nil # un-cache it from ||=
+    @new_rule_references_rules,
+      @existing_rule_references_rules,
+      @op_rule_references_rules = nil # un-cache it from ||=
     @op_rules = [
       OpenStruct.new(id: rules(:one).ref_id,
                      rule_references: [rule_references(:one)]),
@@ -30,6 +32,9 @@ class RuleReferencesRulesTest < ActiveSupport::TestCase
     assert_difference('RuleReferencesRule.count', 1) do
       save_rule_references_rules
     end
+
+    @new_rule_references_rules,
+      @existing_rule_references_rules = nil # un-cache it from ||=
 
     assert_difference('RuleReferencesRule.count', 0) do
       save_rule_references_rules

--- a/test/services/concerns/xccdf/rule_references_test.rb
+++ b/test/services/concerns/xccdf/rule_references_test.rb
@@ -17,7 +17,7 @@ class RuleReferencesTest < ActiveSupport::TestCase
       save_rule_references
     end
 
-    @rule_references, @new_rule_references = nil # un-cache it from ||=
+    @existing_rule_references, @new_rule_references = nil # un-cache it from ||=
     @op_rule_references = [OpenStruct.new(label: 'foo', href: ''),
                            OpenStruct.new(label: 'bar', href: '')]
     stubs(:new_rules).returns(


### PR DESCRIPTION
This change essentially boils down to removing N `selects` for N / 1000 (due to batch size). In order to accurately parse a report, we must determine if the records already exist in the DB. Before, we were using `find_or_initialize_by` for each RuleReference and RuleReferencesRule (37K records just for this table in the RHEL 7 0.1.46 SSG). Now we are executing a where query to determine existing records and only importing new records.

Importing RHEL 7 SSG, version 0.1.46, initial and subsequent imports. Initial import takes about half the time:

```
rake ssg:import DATASTREAM_FILE='./scap-security-guide-0.1.46/ssg-rhel7-ds.xml'

# Before

Importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml at 2020-07-30 04:14:25 UTC
Finished importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml in 86.885234702 seconds.

Importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml at 2020-07-30 04:16:10 UTC
Finished importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml in 7.394536394 seconds.

# After

Importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml at 2020-07-30 04:10:54 UTC
Finished importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml in 44.367159831 seconds.

Importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml at 2020-07-30 04:12:20 UTC
Finished importing ./scap-security-guide-0.1.46/ssg-rhel7-ds.xml in 7.29955355 seconds.
```

There is more room for improvement during parsing. The same thing done here with RuleReferences and RuleReferencesRules, our biggest tables, can be done for Rules as well. 

Signed-off-by: Andrew Kofink <akofink@redhat.com>