### PR TITLE
Fix finding new rule references rules in parsing

### DIFF
--- a/app/services/concerns/xccdf/rule_references_rules.rb
+++ b/app/services/concerns/xccdf/rule_references_rules.rb
@@ -32,10 +32,6 @@ module Xccdf
         )
       end
 
-      def existing_ids
-        existing_rule_references_rules.pluck(:rule_id, :rule_reference_id)
-      end
-
       def new_rule_references_rules
         @new_rule_references_rules ||= new_op_rule_references_rules
                                        .map do |op_rule_references_rule|
@@ -46,13 +42,15 @@ module Xccdf
         end
       end
 
-      def new_op_rule_references_rules
-        op_rule_references_rules.reject do |op_rule_references_rule|
-          existing_ids.include? [
-            op_rule_references_rule.rule_id,
-            op_rule_references_rule.rule_reference_id
-          ]
+      def existing_op_rule_references_rules
+        existing_rule_references_rules.map do |rule_references_rule|
+          RuleReferencesRuleStruct.new(rule_references_rule.rule_id,
+                                       rule_references_rule.rule_reference_id)
         end
+      end
+
+      def new_op_rule_references_rules
+        op_rule_references_rules - existing_op_rule_references_rules
       end
 
       def rule_references_for(op_rule: nil)


### PR DESCRIPTION
Before, new_rule_references_rules was always the entire set. This PR uses the RuleReferencesRulesStruct and subtraction rather than a loop with `reject` and `include?` which took forever to run (not sure why we didn't catch this on the first PR).

Towards https://projects.engineering.redhat.com/browse/RHICOMPL-698