### PR TITLE
Allow profiles to differ only by in/external

### DIFF
--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -9,10 +9,6 @@ module ProfilePolicyAssociation
 
     def policy
       return self unless external
-
-      Profile.includes(:benchmark)
-             .find_by(account: account_id, external: false, ref_id: ref_id,
-                      benchmarks: { ref_id: benchmark.ref_id })
     end
 
     def policy_profiles

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,8 +15,9 @@ class Profile < ApplicationRecord
   belongs_to :benchmark, class_name: 'Xccdf::Benchmark'
   belongs_to :parent_profile, class_name: 'Profile', optional: true
 
-  validates :ref_id, uniqueness: { scope: %i[account_id benchmark_id] },
-                     presence: true
+  validates :ref_id, presence: true, uniqueness: {
+    scope: %i[account_id benchmark_id external]
+  }
   validates :name, presence: true
   validates :benchmark_id, presence: true
   validates :compliance_threshold, numericality: true

--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -16,7 +16,7 @@ module Xccdf
       end
 
       def benchmark_profiles_saved?
-        benchmark.profiles.count == @op_benchmark.profiles.count
+        benchmark.profiles.canonical.count == @op_benchmark.profiles.count
       end
 
       def benchmark_rules_saved?

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -38,7 +38,7 @@ module Xccdf
     def test_result_profile
       ::Profile.canonical
                .where(ref_id: @test_result_file.test_result.profile_id,
-                      benchmark: @benchmark).first ||
+                      benchmark: @benchmark).order(:external).first ||
         ::Profile.find_or_initialize_by(
           ref_id: @test_result_file.test_result.profile_id,
           name: @test_result_file.test_result.profile_id,

--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -4,7 +4,8 @@ module Xccdf
   # Methods related to saving TestResult from openscap_parser
   module TestResult
     def save_test_result
-      @test_result = ::TestResult.create!(
+      require 'pry'; binding.pry
+      @test_result = ::TestResult.find_or_create_by!(
         host: @host,
         profile: @host_profile,
         score: @op_test_result.score,

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -20,22 +20,22 @@ module Xccdf
       def save_all_benchmark_info
         return if benchmark_contents_equal_to_op?
 
-        save_benchmark
-        save_profiles
-        save_rules
-        save_rule_identifiers
-        save_profile_rules
-        save_rule_references
-        save_rule_references_rules
+        save_benchmark; Sidekiq.logger.info('save_benchmark')
+        save_profiles; Sidekiq.logger.info('save_profiles')
+        save_rules; Sidekiq.logger.info('save_rules')
+        save_rule_identifiers; Sidekiq.logger.info('save_rule_identifiers')
+        save_profile_rules; Sidekiq.logger.info('save_profile_rules')
+        save_rule_references; Sidekiq.logger.info('save_rule_references')
+        save_rule_references_rules; Sidekiq.logger.info('save_rule_references_rules')
       end
 
       def save_all_test_result_info
-        save_host
-        save_profile_host
-        save_test_result
-        save_rule_results
-        associate_rules_from_rule_results
-        invalidate_cache
+        save_host; Sidekiq.logger.info('save_host')
+        save_profile_host; Sidekiq.logger.info('save_profile_host')
+        save_test_result; Sidekiq.logger.info('save_test_result')
+        save_rule_results; Sidekiq.logger.info('save_rule_results')
+        associate_rules_from_rule_results; Sidekiq.logger.info('associate_rules_from_rule_results')
+        invalidate_cache; Sidekiq.logger.info('invalidate_cache')
       end
 
       def set_openscap_parser_data

--- a/db/migrate/20200804012906_add_uniqueness_by_external_to_profiles.rb
+++ b/db/migrate/20200804012906_add_uniqueness_by_external_to_profiles.rb
@@ -1,0 +1,11 @@
+class AddUniquenessByExternalToProfiles < ActiveRecord::Migration[5.2]
+  def up
+    remove_index(:profiles, %i[ref_id account_id benchmark_id])
+    add_index(:profiles, %i[ref_id account_id benchmark_id external], unique: true, name: 'uniqueness')
+  end
+
+  def down
+    remove_index(:profiles, %i[ref_id account_id benchmark_id external])
+    add_index(:profiles, %i[ref_id account_id benchmark_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_10_083045) do
+ActiveRecord::Schema.define(version: 2020_08_04_012906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 2020_06_10_083045) do
     t.index ["external"], name: "index_profiles_on_external"
     t.index ["name"], name: "index_profiles_on_name"
     t.index ["parent_profile_id"], name: "index_profiles_on_parent_profile_id"
-    t.index ["ref_id", "account_id", "benchmark_id"], name: "index_profiles_on_ref_id_and_account_id_and_benchmark_id", unique: true
+    t.index ["ref_id", "account_id", "benchmark_id", "external"], name: "uniqueness", unique: true
   end
 
   create_table "rule_identifiers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Before this change, profiles were unique by ref_id, account_id,
benchmark_id. Now added to the list is external.

Definitely a DRAFT. Need to pause on this to look at something else.

Signed-off-by: Andrew Kofink <akofink@redhat.com>