### PR TITLE
Benchmarks have been parsed if canonical profiles match

### DIFF
--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -16,7 +16,7 @@ module Xccdf
       end
 
       def benchmark_profiles_saved?
-        benchmark.profiles.count == @op_benchmark.profiles.count
+        benchmark.profiles.canonical.count == @op_benchmark.profiles.count
       end
 
       def benchmark_rules_saved?

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -28,7 +28,8 @@ module Xccdf
       ::Xccdf::Benchmark.any_instance.expects(:rules)
                         .returns(['rule-mock1']).at_least_once
       ::Xccdf::Benchmark.any_instance.expects(:profiles)
-                        .returns(['profile-mock1']).at_least_once
+                        .returns(stub(canonical: ['profile-mock1']))
+                        .at_least_once
       assert_difference('Xccdf::Benchmark.count', 1) do
         mock.save_benchmark
       end
@@ -40,7 +41,8 @@ module Xccdf
       ::Xccdf::Benchmark.any_instance.expects(:rules)
                         .returns(['rule-mock1']).at_least_once
       ::Xccdf::Benchmark.any_instance.expects(:profiles)
-                        .returns(['profile-mock1']).at_least_once
+                        .returns(stub(canonical: ['profile-mock1']))
+                        .at_least_once
       mock.save_benchmark
       assert mock.benchmark_contents_equal_to_op?
 


### PR DESCRIPTION
`benchmark.profiles` includes non-canonical profiles. When parsing, only canonical profiles are created for a benchmark, so we can skip parsing the benchmark if the canonical profiles match the existing report.

Signed-off-by: Andrew Kofink <akofink@redhat.com>