### PR TITLE
Un-memoize instance variables in inventory-consumer

### DIFF
--- a/app/consumers/concerns/report_parsing.rb
+++ b/app/consumers/concerns/report_parsing.rb
@@ -82,7 +82,7 @@ module ReportParsing
     end
 
     def identity
-      @identity ||= IdentityHeader.new(b64_identity)
+      IdentityHeader.new(b64_identity)
     end
   end
 end


### PR DESCRIPTION
When I implemented this, I thought it'd be good to memoize some of these things, especially `report_contents` since it pulls from S3. It turns out that racecar consumers keep a single object around the entire time, so every time we get a message, we're dealing with the exact same object with all instance variables set from the last time.

Introduced in https://github.com/RedHatInsights/compliance-backend/pull/528
Related to https://projects.engineering.redhat.com/browse/RHICOMPL-765

Signed-off-by: Andrew Kofink <akofink@redhat.com>