### PR TITLE
Create new hosts from inventory on profile update

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -8,52 +8,6 @@ module Mutations
     end
   end
 
-  # Helpers for inventory service related mutations
-  module InventoryServiceHelper
-    include UserHelper
-
-    def inventory_host(id)
-      ::HostInventoryAPI.new(
-        current_user.account,
-        ::Settings.host_inventory_url,
-        nil # infer identity from account
-      ).inventory_host(id)
-    end
-  end
-
-  # Helpers for host related mutations
-  module HostHelper
-    include UserHelper
-    include InventoryServiceHelper
-
-    def find_hosts(system_ids)
-      existing_systems = ::Pundit.policy_scope(current_user, ::Host)
-                                 .where(id: system_ids)
-      save_hosts(system_ids - existing_systems.pluck(:id))
-      existing_systems.reload
-    end
-
-    def save_hosts(ids)
-      ids.map do |id|
-        save_host(id)
-      end
-    end
-
-    def save_host(id)
-      i_host = inventory_host(id)
-      host = ::Host.find_or_initialize_by(
-        id: i_host['id'],
-        account_id: current_user.account.id
-      )
-
-      host.update!(
-        name: i_host['display_name']
-      )
-
-      host
-    end
-  end
-
   # Helpers for profile related mutations
   module ProfileHelper
     include UserHelper

--- a/app/graphql/mutations/profile/associate_systems.rb
+++ b/app/graphql/mutations/profile/associate_systems.rb
@@ -12,18 +12,13 @@ module Mutations
 
       def resolve(args = {})
         profile = find_profile(args[:id])
-        hosts = find_hosts(args[:system_ids])
-        profile_hosts = hosts.map do |host|
-          ProfileHost.new(profile_id: profile.id, host_id: host.id)
-        end
-        ProfileHost.import!(profile_hosts)
+        profile.update_hosts(args[:system_ids])
+
         { profile: profile }
       end
 
-      include HostHelper
       include UserHelper
       include ProfileHelper
-      include InventoryServiceHelper
     end
   end
 end

--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -11,14 +11,13 @@ module Mutations
       field :system, ::Types::System, null: true
 
       def resolve(args = {})
-        host = find_hosts([args[:id]]).first
+        host = Host.find_or_create_from_inventory(args[:id])
         external_profiles = host.profiles.where(external: true)
         internal_profiles = find_profiles(args[:profile_ids])
         host.update(profiles: internal_profiles + external_profiles)
         { system: host }
       end
 
-      include HostHelper
       include ProfileHelper
     end
   end

--- a/app/models/concerns/profile_hosts.rb
+++ b/app/models/concerns/profile_hosts.rb
@@ -8,13 +8,16 @@ module ProfileHosts
     has_many :profile_hosts, dependent: :destroy
     has_many :hosts, through: :profile_hosts, source: :host
 
-    def update_hosts(new_host_ids)
-      return unless new_host_ids
+    def update_hosts(ids)
+      return unless ids
 
-      profile_hosts.where.not(host_id: new_host_ids).destroy_all
-      ProfileHost.import((new_host_ids - host_ids).map do |host_id|
-        { host_id: host_id, profile_id: id }
-      end)
+      profile_hosts.destroy_all
+
+      new_profile_hosts = Host.find_or_create_hosts_by_inventory_ids(ids)
+                              .map do |host|
+        { host_id: host.id, profile_id: id }
+      end
+      ProfileHost.import!(new_profile_hosts)
     end
   end
 end

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -9,6 +9,8 @@ module V1
       User.current = users(:test)
       users(:test).update! account: accounts(:test)
       profiles(:one).update! account: accounts(:test)
+
+      mock_platform_api
     end
 
     def params(data)

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -3,6 +3,11 @@
 require 'test_helper'
 
 class AssociateProfilesMutationTest < ActiveSupport::TestCase
+  setup do
+    users(:test).update account: accounts(:test)
+    User.current = users(:test)
+  end
+
   test 'provide all required arguments' do
     query = <<-GRAPHQL
        mutation associateProfiles($input: associateProfilesInput!) {

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -3,6 +3,11 @@
 require 'test_helper'
 
 class AssociateSystemsMutationTest < ActiveSupport::TestCase
+  setup do
+    users(:test).update account: accounts(:test)
+    User.current = users(:test)
+  end
+
   test 'provide all required arguments' do
     query = <<-GRAPHQL
        mutation associateSystems($input: associateSystemsInput!) {

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -6,6 +6,13 @@ class HostTest < ActiveSupport::TestCase
   should validate_presence_of :name
   should validate_presence_of :account
 
+  setup do
+    users(:test).account = accounts(:test)
+    User.current = users(:test)
+
+    mock_platform_api
+  end
+
   test 'compliant returns a hash with all compliance statuses' do
     host = hosts(:one)
     host.profiles << [profiles(:one), profiles(:two)]
@@ -73,6 +80,24 @@ class HostTest < ActiveSupport::TestCase
       assert_includes Host.search_for('has_test_results = false'), hosts(:two)
       assert_not_includes(Host.search_for('has_test_results = false'),
                           hosts(:one))
+    end
+  end
+
+  context '.find_or_create_hosts_by_inventory_ids' do
+    setup do
+      Host.destroy_all
+    end
+
+    should 'return an array of hosts' do
+      host_ids = %w[ID1 ID2 ID3]
+      assert Host.find_or_create_hosts_by_inventory_ids(host_ids)[0].class, Host
+    end
+
+    should 'creates new hosts if needed' do
+      host_ids = %w[ID1 ID2 ID3]
+      assert_difference('Host.count', host_ids.size) do
+        Host.find_or_create_hosts_by_inventory_ids(host_ids)
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,3 +70,18 @@ unless Rails.env.production?
     end
   end
 end
+
+def mock_platform_api
+  require 'securerandom'
+
+  @url = 'http://localhost'
+  @b64_identity = '1234abcd'
+  @api = HostInventoryAPI.new(@account, @url, @b64_identity)
+  @connection = mock('faraday_connection')
+  @system_profile_response = OpenStruct.new(body: {
+    results: [{
+      id: "MOCK_INVENTORY_HOST_ID_#{SecureRandom.uuid}",
+      system_profile: { os_release: '8.2' } }]
+  }.to_json)
+  Platform.stubs(:connection).returns(@connection)
+end


### PR DESCRIPTION
When assigning a host that is not yet in the compliance database, updating the profile via the API will fail.
This adds a step to `update_hosts` to ensure that hosts are in the database and can be assigned.