### PR TITLE
[RHICOMPL-827] Add 'compliance' kafka group prefix

### DIFF
--- a/config/racecar.rb
+++ b/config/racecar.rb
@@ -1,3 +1,4 @@
 Racecar.configure do |config|
   config.log_level = 'info'
+  config.group_id_prefix = 'compliance'
 end


### PR DESCRIPTION
Consumer group IDs of all services should be unique and the service easily identifiable. Now, our consumer group IDs will have the format `compliance.inventory-events-consumer`

https://projects.engineering.redhat.com/browse/RHICOMPL-827

Signed-off-by: Andrew Kofink <akofink@redhat.com>