### PR TITLE
[RHICOMPL-467] Consolidate REST and graphql inventory logic

### DIFF
--- a/app/controllers/concerns/inventory_service_helper.rb
+++ b/app/controllers/concerns/inventory_service_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Module to support controller integrations with the host inventory service
+module InventoryServiceHelper
+  extend ActiveSupport::Concern
+
+  included do
+    def add_inventory_hosts(ids)
+      existing_hosts = ::Pundit.policy_scope(current_user, ::Host)
+                               .where(id: ids)
+      save_hosts(ids - existing_hosts.pluck(:id)) + existing_hosts
+    end
+
+    def save_hosts(ids)
+      ids.map do |id|
+        save_host(id)
+      end
+    end
+
+    def save_host(id)
+      i_host = inventory_host(id)
+      host = ::Host.find_or_initialize_by(
+        id: i_host['id'],
+        account_id: current_user.account.id
+      )
+
+      host.update!(
+        name: i_host['display_name']
+      )
+
+      host
+    end
+
+    def inventory_host(id)
+      ::HostInventoryAPI.new(
+        current_user.account,
+        ::Settings.host_inventory_url,
+        nil # infer identity from account
+      ).inventory_host(id)
+    end
+  end
+end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -8,50 +8,10 @@ module Mutations
     end
   end
 
-  # Helpers for inventory service related mutations
-  module InventoryServiceHelper
-    include UserHelper
-
-    def inventory_host(id)
-      ::HostInventoryAPI.new(
-        current_user.account,
-        ::Settings.host_inventory_url,
-        nil # infer identity from account
-      ).inventory_host(id)
-    end
-  end
-
   # Helpers for host related mutations
   module HostHelper
     include UserHelper
-    include InventoryServiceHelper
-
-    def find_hosts(system_ids)
-      existing_systems = ::Pundit.policy_scope(current_user, ::Host)
-                                 .where(id: system_ids)
-      save_hosts(system_ids - existing_systems.pluck(:id))
-      existing_systems.reload
-    end
-
-    def save_hosts(ids)
-      ids.map do |id|
-        save_host(id)
-      end
-    end
-
-    def save_host(id)
-      i_host = inventory_host(id)
-      host = ::Host.find_or_initialize_by(
-        id: i_host['id'],
-        account_id: current_user.account.id
-      )
-
-      host.update!(
-        name: i_host['display_name']
-      )
-
-      host
-    end
+    include ::InventoryServiceHelper
   end
 
   # Helpers for profile related mutations

--- a/app/graphql/mutations/profile/associate_systems.rb
+++ b/app/graphql/mutations/profile/associate_systems.rb
@@ -12,18 +12,13 @@ module Mutations
 
       def resolve(args = {})
         profile = find_profile(args[:id])
-        hosts = find_hosts(args[:system_ids])
-        profile_hosts = hosts.map do |host|
-          ProfileHost.new(profile_id: profile.id, host_id: host.id)
-        end
-        ProfileHost.import!(profile_hosts)
+        add_inventory_hosts(args[:system_ids])
+        profile.update_hosts(args[:system_ids])
         { profile: profile }
       end
 
       include HostHelper
-      include UserHelper
       include ProfileHelper
-      include InventoryServiceHelper
     end
   end
 end

--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -11,7 +11,7 @@ module Mutations
       field :system, ::Types::System, null: true
 
       def resolve(args = {})
-        host = find_hosts([args[:id]]).first
+        host = add_inventory_hosts([args[:id]]).first
         external_profiles = host.profiles.where(external: true)
         internal_profiles = find_profiles(args[:profile_ids])
         host.update(profiles: internal_profiles + external_profiles)

--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -71,6 +71,11 @@ describe 'Profiles API' do
 
     post 'Create a profile' do
       fixtures :accounts, :profiles, :rules, :hosts, :benchmarks
+
+      before do
+        accounts(:one).hosts = hosts
+      end
+
       tags 'profile'
       description 'Create a profile with the provided attributes'
       operationId 'CreateProfile'
@@ -269,6 +274,9 @@ describe 'Profiles API' do
 
     patch 'Update a profile' do
       fixtures :accounts, :rules, :hosts, :benchmarks, :profiles
+      before do
+        accounts(:one).hosts = hosts
+      end
       tags 'profile'
       description 'Updates a profile'
       operationId 'UpdateProfile'


### PR DESCRIPTION
When a profile and host are associated but the host only exists in the
inventory, we must create the host from the inventory in our own
database. We must handle this in both REST and graphql. This change
consolidates the two code paths to use the same InventoryServiceHelper.

Signed-off-by: Andrew Kofink <akofink@redhat.com>