### PR TITLE
[RHICOMPL-844] Set sidekiq concurrency to 1 in devel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,6 +272,6 @@ services:
       - POSTGRESQL_TEST_DATABASE=compliance_test
       - POSTGRESQL_USER=insights
       - POSTGRESQL_PASSWORD=insights
-      - SIDEKIQ_CONCURRENCY=5
+      - SIDEKIQ_CONCURRENCY=1
   redis:
     image: redis:latest


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHICOMPL-844

Debugging with 5 concurrent job workers is tough, and there is no real load locally, so it makes sense to only allow 1 job at a time.

Signed-off-by: Andrew Kofink <akofink@redhat.com>