### PR TITLE
[RHICOMPL-574] Update host OS info from inventory

### DIFF
--- a/app/controllers/concerns/inventory_service_helper.rb
+++ b/app/controllers/concerns/inventory_service_helper.rb
@@ -24,9 +24,7 @@ module InventoryServiceHelper
         account_id: current_user.account.id
       )
 
-      host.update!(
-        name: i_host['display_name']
-      )
+      host.update_from_inventory_host!(i_host)
 
       host
     end

--- a/app/jobs/inventory_host_updated_job.rb
+++ b/app/jobs/inventory_host_updated_job.rb
@@ -31,6 +31,6 @@ class InventoryHostUpdatedJob
     )
     Host.find_by!(
       id: message['host']['id']
-    ).update!(name: message['host']['display_name'])
+    ).update_from_inventory_host!(message['host'])
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -54,4 +54,10 @@ class Host < ApplicationRecord
       }
     end
   end
+
+  def update_from_inventory_host!(i_host)
+    update!(name: i_host['display_name'],
+            os_major_version: i_host['os_major_version'],
+            os_minor_version: i_host['os_minor_version'])
+  end
 end

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -9,9 +9,7 @@ module Xccdf
     def save_host
       @host = ::Host.find_or_initialize_by(id: inventory_host['id'],
                                            account_id: @account.id)
-      @host.update!(name: inventory_host['display_name'],
-                    os_major_version: inventory_host['os_major_version'],
-                    os_minor_version: inventory_host['os_minor_version'])
+      @host.update_from_inventory_host!(inventory_host)
     end
 
     def host_profile

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -16,6 +16,15 @@ class HostTest < ActiveSupport::TestCase
     assert_equal expected_result, host.compliant
   end
 
+  test 'update_from_inventory_host' do
+    hosts(:one).update_from_inventory_host!('display_name' => 'foo',
+                                            'os_major_version' => 7,
+                                            'os_minor_version' => 5)
+    assert_equal hosts(:one).name, 'foo'
+    assert_equal hosts(:one).os_major_version, 7
+    assert_equal hosts(:one).os_minor_version, 5
+  end
+
   context 'external methods for search' do
     setup do
       @host = hosts(:one)


### PR DESCRIPTION
Now, every time we update our host record from the inventory (3 places
total), we update the host's name and OS information. Updates happen
during report parsing, InventoryHostUpdatedJob, and when we initially
create the host from an existing inventory record.

Signed-off-by: Andrew Kofink <akofink@redhat.com>