### PR TITLE
[RHICOMPL-838] Rescue remediations errors, bubble errors on import

### DIFF
--- a/app/services/remediations_api.rb
+++ b/app/services/remediations_api.rb
@@ -12,8 +12,8 @@ class RemediationsAPI
     ::Rule.with_profiles.find_in_batches(batch_size: 100) do |rules|
       update_rules(remediations_available(remediations_response(rules)))
     end
-  rescue Faraday::ClientError => e
-    Rails.logger.info("#{e.message} #{e.response}")
+  rescue Faraday::ClientError, Faraday::ConnectionFailed => e
+    Rails.logger.error(e.full_message)
   end
 
   private

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -23,7 +23,7 @@ ExceptionNotification.configure do |config|
 
   config.add_notifier :slack, {
     webhook_url: Settings.slack_webhook,
-    channel: '#insights-compliance',
+    channel: '#forum-cloudservices-compliance',
     additional_parameters: {
       mrkdwn: true
     }

--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -56,6 +56,8 @@ namespace :ssg do
         e,
         data: OpenshiftEnvironment.summary
       )
+      puts "Import failed for #{filename} in #{Time.zone.now - start} seconds."
+      raise e
     end
   end
 end

--- a/test/tasks/import_datastream_test.rb
+++ b/test/tasks/import_datastream_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class ImportDatastreamTest < ActiveSupport::TestCase
+  setup do
+    HostInventoryAPI.any_instance.stubs(:inventory_host).returns(
+      'display_name' => 'foo',
+      'os_major_version' => 7,
+      'os_minor_version' => 5
+    )
+  end
+
+  test 'ssg:import fails on error' do
+    filepath = 'test/fixtures/files/xccdf_report.xml'
+
+    ENV['DATASTREAM_FILE'] = filepath
+
+    DatastreamImporter.any_instance.expects(:import!).raises(StandardError)
+
+    assert_raises StandardError do
+      Rake::Task['ssg:import'].execute
+    end
+  end
+end


### PR DESCRIPTION
This change adds connection errors to the list of rescued errors when
importing remediations. It also ensures that any exceptions that are
raised cause the entire rake task to fail (ssg:import_latest_supported).
It also updates the slack channel for exception notifications to
forum-cloudservices-compliance.

https://projects.engineering.redhat.com/browse/RHICOMPL-838

Signed-off-by: Andrew Kofink <akofink@redhat.com>