### PR TITLE
[RHICOMPL-574] sync_with_inventory actually saves host

### DIFF
--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -8,9 +8,11 @@ task sync_with_inventory: [:environment] do
     puts "Starting to review account #{account.account_number}"
     account.hosts.each do |host|
       begin
-        host = ::HostInventoryAPI.new(
-          account, ::Settings.host_inventory_url, account.b64_identity
-        ).inventory_host(host.id)
+        host.update_from_inventory_host!(
+          ::HostInventoryAPI.new(
+            account, ::Settings.host_inventory_url, account.b64_identity
+          ).inventory_host(host.id)
+        )
       rescue ::InventoryHostNotFound
         print "Account #{account.account_number}: "\
           "System #{host.id} - #{host.name} not found in the inventory. "\

--- a/test/tasks/sync_with_inventory_test.rb
+++ b/test/tasks/sync_with_inventory_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class SyncWithInventoryTest < ActiveSupport::TestCase
+  setup do
+    HostInventoryAPI.any_instance.stubs(:inventory_host).returns(
+      'display_name' => 'foo',
+      'os_major_version' => 7,
+      'os_minor_version' => 5
+    )
+  end
+
+  test 'sync_with_inventory' do
+    assert_not_equal hosts(:one).name, 'foo'
+    assert_nil hosts(:one).os_minor_version
+    assert_nil hosts(:one).os_major_version
+
+    Rake::Task['sync_with_inventory'].execute
+
+    assert_equal hosts(:one).reload.name, 'foo'
+    assert_equal hosts(:one).os_major_version, 7
+    assert_equal hosts(:one).os_minor_version, 5
+  end
+end


### PR DESCRIPTION
I'm not sure how this ever worked without saving the host to the DB. Now with a test!

https://projects.engineering.redhat.com/browse/RHICOMPL-574

Signed-off-by: Andrew Kofink <akofink@redhat.com>