### PR TITLE
[RHICOMPL-574] Ensure host inventory API uses string hashes

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -56,8 +56,8 @@ class Host < ApplicationRecord
   end
 
   def update_from_inventory_host!(i_host)
-    update!(name: i_host['display_name'],
-            os_major_version: i_host['os_major_version'],
-            os_minor_version: i_host['os_minor_version'])
+    update!({ name: i_host['display_name'],
+              os_major_version: i_host['os_major_version'],
+              os_minor_version: i_host['os_minor_version'] }.compact)
   end
 end

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -29,8 +29,8 @@ class HostInventoryAPI
     raise ::InventoryHostNotFound if @inventory_host.blank?
 
     if (os_release = system_profile([host_id]).first)
-      @inventory_host[:os_major_version] = os_release[:os_major_version]
-      @inventory_host[:os_minor_version] = os_release[:os_minor_version]
+      @inventory_host['os_major_version'] = os_release['os_major_version']
+      @inventory_host['os_minor_version'] = os_release['os_minor_version']
     end
     @inventory_host
   end
@@ -42,9 +42,9 @@ class HostInventoryAPI
     )
     JSON.parse(response.body)['results'].inject([]) do |acc, host|
       os_major, os_minor = find_os_release(host['system_profile'])
-      acc << { id: host['id'],
-               os_major_version: os_major,
-               os_minor_version: os_minor }
+      acc << { 'id' => host['id'],
+               'os_major_version' => os_major,
+               'os_minor_version' => os_minor }
     end
   end
 

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -25,6 +25,17 @@ class HostTest < ActiveSupport::TestCase
     assert_equal hosts(:one).os_minor_version, 5
   end
 
+  test 'update_from_inventory_host with nil fields' do
+    hosts(:one).update!(os_major_version: 7, os_minor_version: 5)
+
+    hosts(:one).update_from_inventory_host!('display_name' => 'foo',
+                                            'os_major_version' => nil,
+                                            'os_minor_version' => nil)
+    assert_equal hosts(:one).name, 'foo'
+    assert_equal hosts(:one).os_major_version, 7
+    assert_equal hosts(:one).os_minor_version, 5
+  end
+
   context 'external methods for search' do
     setup do
       @host = hosts(:one)

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -6,9 +6,9 @@ require 'host_inventory_api'
 class HostInventoryApiTest < ActiveSupport::TestCase
   setup do
     @account = accounts(:one)
-    @inventory_host = { 'id': hosts(:one).id,
-                        'display_name': hosts(:one).name,
-                        'account': @account.account_number }
+    @inventory_host = { 'id' => hosts(:one).id,
+                        'display_name' => hosts(:one).name,
+                        'account' => @account.account_number }
     @host = hosts(:one)
     @url = 'http://localhost'
     @b64_identity = '1234abcd'
@@ -33,16 +33,17 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   end
 
   test 'inventory_host for host already in inventory' do
-    @api.expects(:host_already_in_inventory).returns(@host)
+    @api.expects(:host_already_in_inventory).returns(@inventory_host)
     @connection.expects(:get).with(
       "#{@url}#{Settings.path_prefix}/inventory/v1/hosts/"\
       "#{@host.id}/system_profile",
       { per_page: 50, page: 1 },
       X_RH_IDENTITY: @b64_identity
     ).returns(@system_profile_response)
-    assert_equal @host, @api.inventory_host(@host.id)
-    assert_equal 8, @host.os_major_version
-    assert_equal 2, @host.os_minor_version
+    i_host = @api.inventory_host(@host.id)
+    assert_equal @host.id, i_host['id']
+    assert_equal '8', i_host['os_major_version']
+    assert_equal '2', i_host['os_minor_version']
   end
 
   test 'inventory_host for host not already in inventory' do
@@ -76,9 +77,9 @@ class HostInventoryApiTest < ActiveSupport::TestCase
       X_RH_IDENTITY: @b64_identity
     ).returns(@system_profile_response)
     system_profile_results = @api.system_profile([@host.id])
-    assert_equal '8', system_profile_results.first[:os_major_version]
-    assert_equal '2', system_profile_results.first[:os_minor_version]
-    assert_equal @host.id, system_profile_results.first[:id]
+    assert_equal '8', system_profile_results.first['os_major_version']
+    assert_equal '2', system_profile_results.first['os_minor_version']
+    assert_equal @host.id, system_profile_results.first['id']
   end
 
   test 'system_profile returns a hash without OS info if not found' do
@@ -92,8 +93,8 @@ class HostInventoryApiTest < ActiveSupport::TestCase
       X_RH_IDENTITY: @b64_identity
     ).returns(wrong_system_profile_response)
     system_profile_results = @api.system_profile([@host.id])
-    assert_nil system_profile_results.first[:os_major_version]
-    assert_nil system_profile_results.first[:os_minor_version]
-    assert_equal @host.id, system_profile_results.first[:id]
+    assert_nil system_profile_results.first['os_major_version']
+    assert_nil system_profile_results.first['os_minor_version']
+    assert_equal @host.id, system_profile_results.first['id']
   end
 end


### PR DESCRIPTION
JSON always comes in as string keys, not symbols, in hashes from the
inventory API.

To test:

Start with a host that doesn't have OS information in the Compliance DB
```rb
[11] pry(main)> Host.find('73050cfc-52bb-4f8a-87d5-ba2b1b1be4be')
  Host Load (0.4ms)  SELECT  "hosts".* FROM "hosts" WHERE "hosts"."id" = $1 LIMIT $2  [["id", "73050cfc-52bb-4f8a-87d5-ba2b1b1be4be"], ["LIMIT", 1]]
=> #<Host:0x0000564284446e80
 id: "73050cfc-52bb-4f8a-87d5-ba2b1b1be4be",
 name: "rhel7-insights-client.virbr0.akofink-desktop",
 created_at: Tue, 01 Sep 2020 13:54:46 UTC +00:00,
 updated_at: Tue, 01 Sep 2020 15:18:06 UTC +00:00,
 account_id: "a8477b45-60f1-4ccf-8f64-0934ca2e2aab",
 os_major_version: nil,
 os_minor_version: nil>
```

Run sync_with_inventory:
```
podman exec -it  compliance-backend_rails_1 bundle exec rake sync_with_inventory
```

Check that the host has OS information:
```rb
[12] pry(main)> Host.find('73050cfc-52bb-4f8a-87d5-ba2b1b1be4be')
  Host Load (1.2ms)  SELECT  "hosts".* FROM "hosts" WHERE "hosts"."id" = $1 LIMIT $2  [["id", "73050cfc-52bb-4f8a-87d5-ba2b1b1be4be"], ["LIMIT", 1]]
=> #<Host:0x0000564284497240
 id: "73050cfc-52bb-4f8a-87d5-ba2b1b1be4be",
 name: "rhel7-insights-client.virbr0.akofink-desktop",
 created_at: Tue, 01 Sep 2020 13:54:46 UTC +00:00,
 updated_at: Tue, 01 Sep 2020 15:22:43 UTC +00:00,
 account_id: "a8477b45-60f1-4ccf-8f64-0934ca2e2aab",
 os_major_version: 7,
 os_minor_version: 7>
```

https://projects.engineering.redhat.com/browse/RHICOMPL-574

Signed-off-by: Andrew Kofink <akofink@redhat.com>