### PR TITLE
[RHICOMPL-778] Rule updates never happen to existing profiles

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -70,10 +70,11 @@ class Profile < ApplicationRecord
       (new_profile = dup).update!(account: account, hosts: [host],
                                   parent_profile: self,
                                   external: external)
+      new_profile.update_rules(ref_ids: rules.pluck(:ref_id))
     else
       new_profile.hosts << host unless new_profile.hosts.include?(host)
     end
-    new_profile.update_rules(ref_ids: rules.pluck(:ref_id))
+
     new_profile
   end
 

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -405,6 +405,23 @@ class ProfileTest < ActiveSupport::TestCase
         assert_not cloned_profile.external
       end
     end
+
+    should 'not add rules to existing profiles' do
+      assert_not_empty(profiles(:one).rules)
+      profiles(:one).update!(account: nil, hosts: [])
+      existing_profile = profiles(:one).clone_to(account: accounts(:one),
+                                                 host: hosts(:one))
+      existing_profile.update!(rules: [])
+      assert_difference('ProfileHost.count' => 0,
+                        'Profile.count' => 0,
+                        'ProfileRule.count' => 0) do
+        cloned_profile = profiles(:one).clone_to(
+          account: accounts(:one), host: hosts(:one)
+        )
+        assert hosts(:one).profiles.include?(cloned_profile)
+      end
+      assert_empty(existing_profile.rules)
+    end
   end
 
   context 'profile tailoring' do


### PR DESCRIPTION
When parsing a test result upload, rules of existing profiles should
never be updated.

https://projects.engineering.redhat.com/browse/RHICOMPL-778

Signed-off-by: Andrew Kofink <akofink@redhat.com>