### PR TITLE
[RHICOMPL-875] Docker-compose: Clean up duplicate params and sdin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,9 +107,6 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - INVENTORY_LOG_LEVEL=ERROR
       - KAFKA_SECONDARY_TOPIC_ENABLED=True
-    links:
-      - db
-      - kafka
     depends_on:
       - db
       - kafka
@@ -129,8 +126,6 @@ services:
       - LISTEN_PORT=8081
     ports:
       - 8081:8081
-    links:
-      - db
     depends_on:
       - db
       - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,6 @@ services:
   prometheus:
     image: compliance-backend-rails
     tty: true
-    stdin_open: true
     environment:
       - DATABASE_SERVICE_NAME=postgres
       - POSTGRES_SERVICE_HOST=db


### PR DESCRIPTION
Remove duplicate `links` declarations, and leave only `rails` service having SDIN opened.

(RHICOMPL-875)