### PR TITLE
[RHICOMPL-890] Load dotenv before Settings are initialized

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,11 @@ require 'sprockets/railtie' if Rails.env.development?
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# (Development/Test env only)
+# Load .env* variables before the config (Settings) initializer is
+# being run.
+Dotenv::Railtie.load unless Rails.env.production?
+
 module ComplianceBackend
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
Environment variables from `.env` (dotenv-rails) are loaded too late, after `Settings` are already set up. They should be evaluated before the settings.

To test:
```
# .env
export SETTINGS__REDIS_URL=redis_from_dotenv
```
```shell
DISABLE_SPRING=true bundle exec rails c
> Settings.redis_url
=> "redis_from_dotenv"
```