### PR TITLE
[RHICOMPL-904] Move InventoryHostNotFound back to HostInventoryAPI

### DIFF
--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# Error to raise if the inventory host could not be found
-class InventoryHostNotFound < StandardError; end
-
 module Xccdf
   # Methods related to saving Hosts from openscap_parser
   module Hosts

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -6,6 +6,9 @@ require 'json'
 # Error to raise if the OS release contains an invalid major or minor
 class InventoryInvalidOsRelease < StandardError; end
 
+# Error to raise if the inventory host could not be found
+class InventoryHostNotFound < StandardError; end
+
 # Interact with the Insights Host Inventory. Usually HTTP calls
 # are all that's needed.
 class HostInventoryAPI


### PR DESCRIPTION
This was not caught by our tests because Xccdf::Hosts was referenced and loaded. You can check it in the console:

```rb
# Before
[1] pry(main)> InventoryHostNotFound
NameError: uninitialized constant InventoryHostNotFound
from /usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `block in load_missing_constant'
Caused by NameError: uninitialized constant InventoryHostNotFound
from /usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:61:in `block in load_missing_constant'
[2] pry(main)> Xccdf::Hosts
=> Xccdf::Hosts
[3] pry(main)> InventoryHostNotFound
=> InventoryHostNotFound

# After
[1] pry(main)> InventoryHostNotFound
NameError: uninitialized constant InventoryHostNotFound
from /usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `block in load_missing_constant'
Caused by NameError: uninitialized constant InventoryHostNotFound
from /usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/active_support.rb:61:in `block in load_missing_constant'
[2] pry(main)> HostInventoryAPI
=> HostInventoryAPI
[3] pry(main)> InventoryHostNotFound
=> InventoryHostNotFound
```

I'm not sure why it got moved; it may have been a mistake. `InventoryHostNotFound` definitely makes the most sense on `HostInventoryAPI`.

https://projects.engineering.redhat.com/browse/RHICOMPL-904

Signed-off-by: Andrew Kofink <akofink@redhat.com>