### PR TITLE
[RHICOMPL-922] Allow setting platform basic auth

### DIFF
--- a/app/services/platform.rb
+++ b/app/services/platform.rb
@@ -4,6 +4,7 @@ require 'faraday'
 
 # Methods related to connecting to other platform services
 module Platform
+  BASIC_AUTH = Settings.platform_basic_auth
   RETRY_OPTIONS = {
     max: 3,
     interval: 0.05,
@@ -21,6 +22,7 @@ module Platform
       f.request :retry, RETRY_OPTIONS
       f.adapter Faraday.default_adapter # this must be the last middleware
       f.ssl[:verify] = Rails.env.production?
+      f.basic_auth(*BASIC_AUTH) if BASIC_AUTH
     end
     faraday
   end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,6 +2,9 @@ host_inventory_url: http://inventory-web:8081
 remediations_url: https://ci.cloud.redhat.com
 rbac_url: https://ci.cloud.redhat.com
 # disable_rbac: true
+# platform_basic_auth:
+#   - username
+#   - password
 prometheus_exporter_host: prometheus
 prometheus_exporter_port: 9394
 redis_url: redis:6379


### PR DESCRIPTION
This is required for local development. In deployed environments, 3Scale
generates the X_RH_IDENTITY header from different auth types (basic,
jwt, etc); locally, we must pass the header directly. For platform
services that are running in CI behind 3Scale (rbac, remediations, etc.),
the header will not work, so basic auth must be set.

Signed-off-by: Andrew Kofink <akofink@redhat.com>