### PR TITLE
Dev: Bind redis to localhost

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,5 +7,5 @@ rbac_url: https://ci.cloud.redhat.com
 #   - password
 prometheus_exporter_host: prometheus
 prometheus_exporter_port: 9394
-redis_url: redis:6379
-redis_cache_url: redis:6379
+redis_url: localhost:6379
+redis_cache_url: localhost:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,3 +269,5 @@ services:
       - SIDEKIQ_CONCURRENCY=1
   redis:
     image: redis:latest
+    ports:
+      - 6379:6379


### PR DESCRIPTION
Expect redis to be listening on localhost in development environment.
This allows to have redis running locally or in container with bounded
port.