### PR TITLE
[RHICOMPL-759] Issue updates to Remediation service

### DIFF
--- a/app/models/concerns/rule_remediation.rb
+++ b/app/models/concerns/rule_remediation.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Remediation necessities for a Rule
+module RuleRemediation
+  extend ActiveSupport::Concern
+
+  def remediation_issue_id
+    "ssg:rhel7|#{short_profile_ref_id}|#{ref_id}"
+  end
+
+  private
+
+  def short_profile_ref_id
+    profile = profiles.canonical.first
+    short_ref_id = profile.ref_id.downcase.split(
+      'xccdf_org.ssgproject.content_profile_'
+    )[1]
+    short_ref_id || profile.ref_id
+  end
+end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -9,6 +9,7 @@ class Rule < ApplicationRecord
   scoped_search relation: :rule_references, on: :label, aliases: %i[reference]
   scoped_search relation: :rule_identifier, on: :label, aliases: %i[identifier]
   include OpenscapParserDerived
+  include RuleRemediation
 
   has_many :profile_rules, dependent: :delete_all
   has_many :profiles, through: :profile_rules, source: :profile

--- a/app/producers/remediation_updates.rb
+++ b/app/producers/remediation_updates.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# A Kafka producer client for payload-tracker
+class RemediationUpdates < ApplicationProducer
+  TOPIC = 'platform.remediation-updates.compliance'
+
+  def self.deliver(host_id:, issue_ids:)
+    deliver_message(
+      host_id: host_id,
+      issues: issue_ids || []
+    )
+  rescue Kafka::DeliveryFailed => e
+    logger.error("Failed to report updates to Remediation service: #{e}")
+  end
+end

--- a/app/services/concerns/xccdf/rule_results.rb
+++ b/app/services/concerns/xccdf/rule_results.rb
@@ -4,15 +4,17 @@ module Xccdf
   # Methods related to saving RuleResults from openscap_parser
   module RuleResults
     def save_rule_results
-      @rule_results = selected_op_rule_results.map do |op_rule_result|
+      ::RuleResult.import!(rule_results.select(&:new_record?), ignore: true)
+    end
+
+    def rule_results
+      @rule_results ||= selected_op_rule_results.map do |op_rule_result|
         ::RuleResult.from_openscap_parser(
           op_rule_result,
           test_result_id: @test_result.id, rule_id: rule_ids[op_rule_result.id],
           host_id: @host.id
         )
       end
-
-      ::RuleResult.import!(@rule_results.select(&:new_record?), ignore: true)
     end
 
     def selected_op_rule_results

--- a/app/services/concerns/xccdf/rule_results.rb
+++ b/app/services/concerns/xccdf/rule_results.rb
@@ -17,6 +17,16 @@ module Xccdf
       end
     end
 
+    def failed_rule_results
+      ::RuleResult.where(id: rule_results).failed
+    end
+
+    def failed_rules
+      ::Rule.joins(:rule_results)
+            .where(rule_results: failed_rule_results)
+            .distinct
+    end
+
     def selected_op_rule_results
       @op_rule_results.reject do |rule_result|
         ::RuleResult::NOT_SELECTED.include? rule_result.result

--- a/app/services/remediations_api.rb
+++ b/app/services/remediations_api.rb
@@ -26,28 +26,8 @@ class RemediationsAPI
     end
   end
 
-  def remove_ref_id_prefix(ref_id)
-    short_ref_id = ref_id.downcase.split(
-      'xccdf_org.ssgproject.content_profile_'
-    )[1]
-    short_ref_id || ref_id
-  end
-
   def build_issues_list(rules)
-    profile_rules = profile_for_rules(rules)
-
-    rules.map do |rule|
-      "ssg:rhel7|#{remove_ref_id_prefix(profile_rules[rule.id])}"\
-        "|#{rule.ref_id}"
-    end
-  end
-
-  def profile_for_rules(rules)
-    profile_rules = ProfileRule.where(rule_id: rules.pluck(:id))
-                               .pluck(:rule_id, :profile_id).to_h
-    profile_ref_ids = Profile.where(id: profile_rules.values.uniq)
-                             .pluck(:id, :ref_id).to_h
-    profile_rules.transform_values! { |profile_id| profile_ref_ids[profile_id] }
+    ::Rule.where(id: rules).includes(:profiles).collect(&:remediation_issue_id)
   end
 
   def remediations_available(response)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,6 +260,7 @@ services:
       - MALLOC_ARENA_MAX=2
       - SETTINGS__REDIS_URL=redis:6379
       - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - KAFKAMQ=kafka:29092
       - DATABASE_SERVICE_NAME=postgres
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev

--- a/test/producers/remediation_updates_test.rb
+++ b/test/producers/remediation_updates_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RemediationUpdatesTest < ActiveSupport::TestCase
+  setup do
+    @issue_id = 'ssg:rhel7|short_profile_ref_id|rule_ref_id'
+  end
+
+  test 'handles missing kafka config' do
+    assert_nil RemediationUpdates.deliver(
+      host_id: '0001', issue_ids: [@issue_id]
+    )
+  end
+
+  test 'delivers messages to the remediation updates topic' do
+    kafka = mock('kafka')
+    RemediationUpdates.stubs(:kafka).returns(kafka)
+    kafka.expects(:deliver_message)
+         .with(anything, topic: RemediationUpdates::TOPIC)
+    RemediationUpdates.deliver(host_id: '0001', issue_ids: [@issue_id])
+  end
+
+  test 'handles delivery issues' do
+    kafka = mock('kafka')
+    Kafka.stubs(:new).returns(kafka)
+    RemediationUpdates.stubs(:kafka).returns(kafka)
+    kafka.expects(:deliver_message)
+         .with(anything, topic: RemediationUpdates::TOPIC)
+         .raises(Kafka::DeliveryFailed.new(nil, nil))
+
+    assert_nothing_raised do
+      RemediationUpdates.deliver(host_id: '0001', issue_ids: [@issue_id])
+    end
+  end
+end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -6,7 +6,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
   class TestParser < ::XccdfReportParser
     attr_accessor :op_benchmark, :op_test_result, :op_profiles, :op_rules,
                   :op_rule_results, :rules
-    attr_reader :test_result_file, :host, :rule_results, :profiles
+    attr_reader :test_result_file, :host, :profiles
   end
 
   setup do

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -193,6 +193,21 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         end
       end
     end
+
+    should 'provide failed results' do
+      @report_parser.save_all
+      failed_rule_results = @report_parser.failed_rule_results
+      assert_equal failed_rule_results.count, 45
+      assert failed_rule_results.all? do |rr|
+        ::RuleResult::FAIL.include?(rr.result)
+      end
+    end
+
+    should 'provide failed rules' do
+      @report_parser.save_all
+      assert_equal @report_parser.failed_rules.count,
+                   @report_parser.failed_rule_results.count
+    end
   end
 
   context 'missing ID' do


### PR DESCRIPTION
Reports issues from failed IDs on every report parse to the Remediation
service via Kafka.  The used topic is
`platform.remediation-updates.compliance`.

Also refactors generation of remediation issue ids.