### PR TITLE
[RHICOMPL-840] Include os_major_version in benchmarks API

### DIFF
--- a/app/serializers/benchmark_serializer.rb
+++ b/app/serializers/benchmark_serializer.rb
@@ -3,7 +3,7 @@
 # JSON API serialization for an OpenSCAP Benchmark
 class BenchmarkSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :ref_id, :title, :version, :description
+  attributes :ref_id, :title, :version, :description, :os_major_version
   has_many :rules
   has_many :profiles do |benchmark|
     Pundit.policy_scope(User.current, Profile).where(benchmark: benchmark)

--- a/spec/api/v1/schemas/benchmarks.rb
+++ b/spec/api/v1/schemas/benchmarks.rb
@@ -27,6 +27,9 @@ module Api
             },
             description: {
               type: 'string'
+            },
+            os_major_version: {
+              type: 'string'
             }
           }
         }.freeze

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -82,7 +82,8 @@
                       "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
                       "title": "Benchmark One",
                       "version": "0.1.45",
-                      "description": "The first benchmark"
+                      "description": "The first benchmark",
+                      "os_major_version": "7"
                     },
                     "relationships": {
                       "rules": {
@@ -218,7 +219,8 @@
                     "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
                     "title": "Benchmark One",
                     "version": "0.1.45",
-                    "description": "The first benchmark"
+                    "description": "The first benchmark",
+                    "os_major_version": "7"
                   },
                   "relationships": {
                     "rules": {
@@ -777,7 +779,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "90392693-82fb-4e78-bf06-00f988d5b545",
+                  "id": "6bf986d7-ca23-4c1e-99ea-9f1e42267615",
                   "type": "profile",
                   "attributes": {
                     "name": "A custom name",
@@ -1013,7 +1015,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "14ea2548-e89b-4749-b948-947a7632ab68",
+                        "id": "a4ca12c4-3d3c-41ec-8c1b-aeceb94fe71c",
                         "type": "account"
                       }
                     },
@@ -1055,7 +1057,8 @@
                       "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
                       "title": "Benchmark One",
                       "version": "0.1.45",
-                      "description": "The first benchmark"
+                      "description": "The first benchmark",
+                      "os_major_version": "7"
                     },
                     "relationships": {
                       "rules": {
@@ -1194,7 +1197,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "170537e4-7111-4675-973e-3a9a9fb73057",
+                  "id": "4eca960b-69f4-47d9-bee8-fd9b539bc192",
                   "type": "profile",
                   "attributes": {
                     "name": "An updated custom name",
@@ -2337,6 +2340,9 @@
             "example": "0.1.46"
           },
           "description": {
+            "type": "string"
+          },
+          "os_major_version": {
             "type": "string"
           }
         }


### PR DESCRIPTION
```json
GET /compliance/api/v1/benchmarks

{
  "data": [
    {
      "id": "8036e3a9-9e97-4658-ac1f-5a0c03daac5d",
      "type": "benchmark",
      "attributes": {   
        "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-6",
        "title": "Guide to the Secure Configuration of Red Hat Enterprise Linux 6",
        "version": "0.1.28",
        "description": "This guide presents a catalog of security-relevant configuration settings for Red Hat Enterprise Linux 6. It is a rendering of content structured in the eXtensible Configuration          
Checklist Description Format (XCCDF) in order to support security automation.  The SCAP content is is available in the scap-security-guide package which is developed at http://fedorahosted.org/scap-security-guid
e. Providing system administrators with such guidance informs them how to securely configure systems under their control in a variety of network roles.  Policy makers and baseline creators can use this catalog  
of settings, with its associated references to higher-level security control catalogs, in order to assist them in security baseline creation.  This guide is a catalog, not a checklist, and satisfaction of every 
item is not likely to be possible or sensible in any operational scenario.  However, the XCCDF format enables granular selection and adjustment of settings, and their association with OVAL and OCIL content      
provides an automated checking capability.  Transformations of this document, and its associated automated checking content, are capable of providing baselines that meet a diverse set of policy objectives.      
Some example XCCDF Profiles, which are selections of items that form checklists and can be used as baselines, are available with this guide.  They can be processed, in an automated fashion, with tools that      
support the Security Content Automation Protocol (SCAP).  The DISA STIG for Red Hat Enterprise Linux 6, which provides required settings for US Department of Defense systems, is one example of a baseline        
created from this guidance.",
        "os_major_version": "6"
      },
      "relationships": {  
        "rules": {…},
        "profiles": {…}
      }
    },
    {…},      
    {…}       
  ],
  "meta": {…},
  "links": {…} 
} 
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>