### PR TITLE
[RHICOMPL-965] Fix remediation import for rules w/o canonical profile

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -64,5 +64,6 @@ class ParseReportJob
     parser.failed_rules
           .includes(:profiles)
           .collect(&:remediation_issue_id)
+          .compact
   end
 end

--- a/app/models/concerns/rule_remediation.rb
+++ b/app/models/concerns/rule_remediation.rb
@@ -5,13 +5,19 @@ module RuleRemediation
   extend ActiveSupport::Concern
 
   def remediation_issue_id
-    "ssg:rhel7|#{short_profile_ref_id}|#{ref_id}"
+    profile_ref = short_profile_ref_id
+    return unless profile_ref
+
+    "ssg:rhel7|#{profile_ref}|#{ref_id}"
   end
 
   private
 
   def short_profile_ref_id
-    profile = profiles.canonical.first
+    # FIXME: Nondetermenistic canonical selection
+    profile = profiles.select(&:canonical?)&.first
+    return unless profile
+
     short_ref_id = profile.ref_id.downcase.split(
       'xccdf_org.ssgproject.content_profile_'
     )[1]

--- a/app/services/remediations_api.rb
+++ b/app/services/remediations_api.rb
@@ -27,7 +27,10 @@ class RemediationsAPI
   end
 
   def build_issues_list(rules)
-    ::Rule.where(id: rules).includes(:profiles).collect(&:remediation_issue_id)
+    ::Rule.where(id: rules)
+          .includes(:profiles)
+          .map(&:remediation_issue_id)
+          .compact
   end
 
   def remediations_available(response)

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -59,4 +59,19 @@ class RuleTest < ActiveSupport::TestCase
     )
     assert_equal [rules(:one)], Rule.canonical
   end
+
+  test 'rule generates remediation issue id' do
+    rule = rules(:one)
+    profiles(:one).update!(
+      ref_id: 'xccdf_org.ssgproject.content_profile_profile1'
+    )
+    rule.profiles << profiles(:one)
+
+    assert_equal rule.remediation_issue_id, 'ssg:rhel7|profile1|MyStringOne'
+  end
+
+  test 'rule empty remediation issue id for a rule without a profile' do
+    rule = rules(:one)
+    assert_nil rule.remediation_issue_id
+  end
 end


### PR DESCRIPTION
Generation of `remediation_issue_id`s dependent on having a rule with
a canonical profile.  This expectation has been broken, and this fix
allows the generation of issue ids without needing a canonical profile
for a rule.