### PR TITLE
[RHICOMPL-987] Do not delete orphaned hosts

### DIFF
--- a/app/models/profile_host.rb
+++ b/app/models/profile_host.rb
@@ -9,18 +9,7 @@ class ProfileHost < ApplicationRecord
   validates :profile, presence: true
   validates :host, presence: true, uniqueness: { scope: :profile }
 
-  after_destroy :destroy_orphaned_host
   after_destroy :destroy_orphaned_external_profile
-
-  def destroy_orphaned_host
-    return unless host.profiles.empty?
-
-    if Settings.async
-      DeleteHost.perform_async(id: host.id)
-    else
-      DeleteHost.new.perform(id: host.id)
-    end
-  end
 
   def destroy_orphaned_external_profile
     return unless profile.external && profile.hosts.empty?

--- a/test/models/profile_host_test.rb
+++ b/test/models/profile_host_test.rb
@@ -4,25 +4,6 @@ require 'test_helper'
 require 'sidekiq/testing'
 
 class ProfileHostTest < ActiveSupport::TestCase
-  setup do
-    DeleteHost.clear
-  end
-
-  test 'destroys associated hosts if host has no more policies assigned' do
-    profile = Profile.create(name: 'foo', benchmark: benchmarks(:one),
-                             ref_id: 'foo')
-    host = Host.create(profiles: [profile], name: 'bar',
-                       account: accounts(:one))
-    assert_equal 0, DeleteHost.jobs.size
-    profile.destroy
-    assert_equal 1, DeleteHost.jobs.size
-    assert_difference('Host.count', -1) do
-      DeleteHost.drain
-    end
-    assert_empty Host.where(id: host.id)
-    assert_equal 0, DeleteHost.jobs.size
-  end
-
   test 'destroy associated external policies if they have no more hosts' do
     internal_profile = Profile.create(name: 'foo', benchmark: benchmarks(:one),
                                       ref_id: 'foo', account: accounts(:one))


### PR DESCRIPTION
Before this change, deleting a profile with hosts associated may have
deleted the hosts as well if they were not associated with any other
profiles. After this change, we will only remove hosts from our database
during an Inventory culling message in kafka.

Signed-off-by: Andrew Kofink <akofink@redhat.com>