### PR TITLE
[RHICOMPL-991] Major OS ver for remediation issue id

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -62,7 +62,7 @@ class ParseReportJob
 
   def remediation_issue_ids
     parser.failed_rules
-          .includes(:profiles)
+          .includes(profiles: :benchmark)
           .collect(&:remediation_issue_id)
           .compact
   end

--- a/app/models/concerns/rule_remediation.rb
+++ b/app/models/concerns/rule_remediation.rb
@@ -4,11 +4,15 @@
 module RuleRemediation
   extend ActiveSupport::Concern
 
+  # It is recommended to prefetch profiles with their benchmarks:
+  #
+  #  `.includes(profiles: :benchmark)`
+  #
   def remediation_issue_id
     # FIXME: Nondetermenistic canonical selection
     profile = profiles.select(&:canonical?)&.first
     return unless profile
 
-    "ssg:rhel7|#{profile.short_ref_id}|#{ref_id}"
+    "ssg:rhel#{profile.os_major_version}|#{profile.short_ref_id}|#{ref_id}"
   end
 end

--- a/app/models/concerns/rule_remediation.rb
+++ b/app/models/concerns/rule_remediation.rb
@@ -5,22 +5,10 @@ module RuleRemediation
   extend ActiveSupport::Concern
 
   def remediation_issue_id
-    profile_ref = short_profile_ref_id
-    return unless profile_ref
-
-    "ssg:rhel7|#{profile_ref}|#{ref_id}"
-  end
-
-  private
-
-  def short_profile_ref_id
     # FIXME: Nondetermenistic canonical selection
     profile = profiles.select(&:canonical?)&.first
     return unless profile
 
-    short_ref_id = profile.ref_id.downcase.split(
-      'xccdf_org.ssgproject.content_profile_'
-    )[1]
-    short_ref_id || profile.ref_id
+    "ssg:rhel7|#{profile.short_ref_id}|#{ref_id}"
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -87,4 +87,10 @@ class Profile < ApplicationRecord
     benchmark ? benchmark.inferred_os_major_version : 'N/A'
   end
   alias os_major_version major_os_version
+
+  def short_ref_id
+    ref_id.downcase.split(
+      'xccdf_org.ssgproject.content_profile_'
+    )[1] || ref_id
+  end
 end

--- a/app/services/remediations_api.rb
+++ b/app/services/remediations_api.rb
@@ -28,7 +28,7 @@ class RemediationsAPI
 
   def build_issues_list(rules)
     ::Rule.where(id: rules)
-          .includes(:profiles)
+          .includes(profiles: :benchmark)
           .map(&:remediation_issue_id)
           .compact
   end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -233,6 +233,15 @@ class ProfileTest < ActiveSupport::TestCase
                  Set.new([p8] + profiles)
   end
 
+  test 'short_ref_id' do
+    profile1 = profiles(:one)
+    profile1.update!(ref_id: 'xccdf_org.ssgproject.content_profile_one')
+    assert_equal profile1.short_ref_id, 'one'
+
+    profile2 = profiles(:two)
+    assert_equal profile2.short_ref_id, 'xccdf_org.ssgproject.profile2'
+  end
+
   context 'fill_from_parent' do
     NAME = 'Customized profile'
     DESCRIPTION = 'The best profile ever'

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -70,6 +70,19 @@ class RuleTest < ActiveSupport::TestCase
     assert_equal rule.remediation_issue_id, 'ssg:rhel7|profile1|MyStringOne'
   end
 
+  test 'rule generates remediation issue id for RHEL8' do
+    benchmark = benchmarks(:one)
+    benchmark.update!(ref_id: 'xccdf_org.ssgproject.content_benchmark_RHEL-8')
+
+    rule = rules(:one)
+    profiles(:one).update!(
+      ref_id: 'xccdf_org.ssgproject.content_profile_profile1'
+    )
+    rule.profiles << profiles(:one)
+
+    assert_equal rule.remediation_issue_id, 'ssg:rhel8|profile1|MyStringOne'
+  end
+
   test 'rule empty remediation issue id for a rule without a profile' do
     rule = rules(:one)
     assert_nil rule.remediation_issue_id


### PR DESCRIPTION
Generate remediation issue id's OS part based on its profile/benchmark. Do not hardcode the "rhel7" value, in order to support different major OS versions.

