### PR TITLE
feat(Rules): RHICOMPL-992 expose remeditation issue ID

### DIFF
--- a/app/controllers/v1/rules_controller.rb
+++ b/app/controllers/v1/rules_controller.rb
@@ -29,6 +29,10 @@ module V1
       RuleSerializer
     end
 
+    def includes
+      [profiles: :benchmark]
+    end
+
     def search_by_id
       pundit_scope.friendly.find(params[:id])
     end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -355,6 +355,7 @@ type Rule implements Node {
   refId: String!
   references: String
   remediationAvailable: Boolean!
+  remediationIssueId: String
   severity: String!
   title: String!
 }

--- a/app/graphql/types/rule.rb
+++ b/app/graphql/types/rule.rb
@@ -9,6 +9,7 @@ module Types
     field :id, ID, null: false
     field :title, String, null: false
     field :ref_id, String, null: false
+    field :remediation_issue_id, String, null: true
     field :rationale, String, null: true
     field :description, String, null: true
     field :severity, String, null: false

--- a/app/serializers/rule_serializer.rb
+++ b/app/serializers/rule_serializer.rb
@@ -3,7 +3,8 @@
 # JSON API serialization for an OpenSCAP Rule
 class RuleSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :ref_id, :title, :rationale, :description, :severity, :slug
+  attributes :ref_id, :remediation_issue_id, :title, :rationale, :description,
+             :severity, :slug
   belongs_to :benchmark
   has_many :profiles
   has_many :rule_references

--- a/spec/api/v1/schemas/rules.rb
+++ b/spec/api/v1/schemas/rules.rb
@@ -21,6 +21,11 @@ module Api
               example: 'xccdf_org.ssgproject.content_rule_directory_access_'\
               'var_log_audit'
             },
+            remediation_issue_id: {
+              type: 'string',
+              example: 'ssg:rhel7|rhelh-stig|xccdf_org.ssgproject.content_'\
+              'rule_no_empty_passwords'
+            },
             severity: {
               type: 'string',
               example: 'Low'

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -3087,6 +3087,10 @@
             "type": "string",
             "example": "xccdf_org.ssgproject.content_rule_directory_access_var_log_audit"
           },
+          "remediation_issue_id": {
+            "type": "string",
+            "example": "ssg:rhel7|rhelh-stig|xccdf_org.ssgproject.content_rule_no_empty_passwords"
+          },
           "severity": {
             "type": "string",
             "example": "Low"


### PR DESCRIPTION
on REST and GraphQL API.  UI can consume it to send requests to Remediation service.  It would keep the ID generation in backend, on one place.