### PR TITLE
[RHICOMPL-927] REST API for supported RHEL and SSG version

### DIFF
--- a/app/controllers/v1/supported_ssgs_controller.rb
+++ b/app/controllers/v1/supported_ssgs_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module V1
+  # API for Supported SSGs mapped to RHEL minor versions
+  class SupportedSsgsController < ApplicationController
+    def index
+      render_json supported_ssgs
+    end
+
+    private
+
+    def metadata(opts = {})
+      opts[:total] ||= supported_ssgs.count
+      {
+        meta: {
+          total: opts[:total],
+          revision: resource.revision
+        }
+      }
+    end
+
+    def resource
+      SupportedSsg
+    end
+
+    def serializer
+      SupportedSsgSerializer
+    end
+
+    def supported_ssgs
+      @supported_ssgs ||= resource.all
+    end
+  end
+end

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -38,7 +38,8 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def raw_supported
-      YAML.load_file(self::SUPPORTED_FILE)
+      # cached for the whole runtime
+      @raw_supported ||= YAML.load_file(self::SUPPORTED_FILE)
     end
   end
 end

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -30,7 +30,6 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
 
     def map_attributes(values)
       attrs = values.slice(*members.map(&:to_s))
-      attrs['profiles'] = attrs['profiles']&.keys
       attrs.symbolize_keys
     end
 

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+# rubocop:disable Metrics/BlockLength
+SupportedSsg = Struct.new(:id, :package, :version, :profiles,
+                          :os_major_version, :os_minor_version,
+                          keyword_init: true) do
+  self::SUPPORTED_FILE = Rails.root.join('config/supported_ssg.yaml')
+
+  class << self
+    def all
+      raw_supported['supported'].map do |rhel, values|
+        major, minor = os_version(rhel)
+
+        new(
+          id: rhel,
+          os_major_version: major,
+          os_minor_version: minor,
+          **map_attributes(values)
+        )
+      end
+    end
+
+    def revision
+      raw_supported['revision']
+    end
+
+    private
+
+    def map_attributes(values)
+      attrs = values.slice(*members.map(&:to_s))
+      attrs['profiles'] = attrs['profiles']&.keys
+      attrs.symbolize_keys
+    end
+
+    def os_version(rhel)
+      rhel.scan(/(\d+)\.(\d+)$/)[0]
+    end
+
+    def raw_supported
+      YAML.load_file(self::SUPPORTED_FILE)
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/app/serializers/supported_ssg_serializer.rb
+++ b/app/serializers/supported_ssg_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# JSON API serialization of Supported SSGs
+class SupportedSsgSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :package, :version, :os_major_version, :os_minor_version
+
+  attribute :profiles do |obj|
+    obj.profiles&.keys
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,28 +3,26 @@
 Rails.application.routes.draw do
   def draw_routes(prefix)
     scope "#{prefix}/#{Settings.app_name}" do
-      namespace :v1 do
-        resources :benchmarks, only: [:index, :show]
-        resources :business_objectives, only: [:index, :show]
-        resources :profiles do
-          member do
-            get 'tailoring_file'
+      concern :rest_api_v1 do
+        scope module: 'v1' do
+          resources :benchmarks, only: [:index, :show]
+          resources :business_objectives, only: [:index, :show]
+          resources :profiles do
+            member do
+              get 'tailoring_file'
+            end
           end
-        end
-        resources :rule_results, only: [:index]
-        resources :systems, only: [:index, :show, :destroy]
-        resources :rules, only: [:index, :show]
-      end
-      resources :benchmarks, controller: 'v1/benchmarks', only: [:index, :show]
-      resources :business_objectives, controller: 'v1/business_objectives', only: [:index, :show]
-      resources :profiles, controller: 'v1/profiles' do
-        member do
-          get 'tailoring_file'
+          resources :rule_results, only: [:index]
+          resources :systems, only: [:index, :show, :destroy]
+          resources :rules, only: [:index, :show]
         end
       end
-      resources :rule_results, controller: 'v1/rule_results', only: [:index]
-      resources :systems, controller: 'v1/systems', only: [:index, :show, :destroy]
-      resources :rules, controller: 'v1/rules', only: [:index, :show]
+
+      concerns :rest_api_v1
+      scope 'v1', as: 'v1' do
+        concerns :rest_api_v1
+      end
+
       mount Rswag::Api::Engine => '/',
         as: "#{prefix}/#{Settings.app_name}/rswag_api"
       mount Rswag::Ui::Engine => '/',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
           resources :rule_results, only: [:index]
           resources :systems, only: [:index, :show, :destroy]
           resources :rules, only: [:index, :show]
+          resources :supported_ssgs, only: [:index]
         end
       end
 

--- a/spec/api/v1/schemas.rb
+++ b/spec/api/v1/schemas.rb
@@ -9,6 +9,7 @@ require './spec/api/v1/schemas/business_objectives'
 require './spec/api/v1/schemas/profiles'
 require './spec/api/v1/schemas/rule_results'
 require './spec/api/v1/schemas/rules'
+require './spec/api/v1/schemas/supported_ssgs'
 
 module Api
   module V1
@@ -22,6 +23,7 @@ module Api
       include Profiles
       include RuleResults
       include Rules
+      include SupportedSggs
 
       SCHEMAS = {
         uuid: UUID,
@@ -41,7 +43,8 @@ module Api
         rule_result: RULE_RESULT,
         rule_result_relationships: RULE_RESULT_RELATIONSHIPS,
         rule: RULE,
-        rule_relationships: RULE_RELATIONSHIPS
+        rule_relationships: RULE_RELATIONSHIPS,
+        supported_ssg: SUPPORTED_SSG
       }.freeze
     end
   end

--- a/spec/api/v1/schemas/supported_ssgs.rb
+++ b/spec/api/v1/schemas/supported_ssgs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require './spec/api/v1/schemas/util'
+
+module Api
+  module V1
+    module Schemas
+      module SupportedSggs
+        extend Api::V1::Schemas::Util
+
+        SUPPORTED_SSG = {
+          type: 'object',
+          required: %w[package version],
+          properties: {
+            package: {
+              type: 'string',
+              example: 'scap-security-guide-0.1.30-5.el7_3'
+            },
+            version: {
+              type: 'string',
+              example: '0.1.30'
+            },
+            os_major_version: {
+              type: 'string',
+              example: '7'
+            },
+            os_minor_version: {
+              type: 'string',
+              example: '3'
+            },
+            profiles: {
+              type: 'array',
+              items: {
+                type: 'string'
+              }
+            }
+          }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/integration/supported_ssgs_spec.rb
+++ b/spec/integration/supported_ssgs_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'SupportedSsgs API' do
+  fixtures :accounts
+
+  path "#{Settings.path_prefix}/#{Settings.app_name}/supported_ssgs" do
+    get 'List all supported SSGs' do
+      tags 'supported_ssg'
+      description 'List all supported SSGs mapped to RHEL minor version'
+      operationId 'ListSupportedSsgs'
+
+      content_types
+      auth_header
+
+      include_param
+
+      response '200', 'lists all supported_ssgs requested' do
+        let(:'X-RH-IDENTITY') { encoded_header(accounts(:test)) }
+        let(:include) { '' } # work around buggy rswag
+        schema type: :object,
+               properties: {
+                 meta: ref_schema('metadata'),
+                 data: {
+                   type: :array,
+                   items: {
+                     properties: {
+                       type: { type: :string },
+                       id: { type: :string },
+                       attributes: ref_schema('supported_ssg')
+                     }
+                   }
+                 }
+               }
+
+        after { |e| autogenerate_examples(e) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -1922,6 +1922,460 @@
         }
       }
     },
+    "/api/compliance/supported_ssgs": {
+      "get": {
+        "summary": "List all supported SSGs",
+        "tags": [
+          "supported_ssg"
+        ],
+        "description": "List all supported SSGs mapped to RHEL minor version",
+        "operationId": "ListSupportedSsgs",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma seperated list of resources to include in the response"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "lists all supported_ssgs requested",
+            "examples": {
+              "application/vnd.api+json": {
+                "data": [
+                  {
+                    "id": "RHEL-6.6",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.18-3.el6",
+                      "version": "0.1.18",
+                      "os_major_version": "6",
+                      "os_minor_version": "6",
+                      "profiles": [
+                        "C2S",
+                        "common",
+                        "CS2",
+                        "CSCF-RHEL6-MLS",
+                        "rht-ccp",
+                        "server",
+                        "stig-rhel6-server-upstream",
+                        "test",
+                        "usgcb-rhel6-server"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-6.7",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.21-3.el6",
+                      "version": "0.1.21",
+                      "os_major_version": "6",
+                      "os_minor_version": "7",
+                      "profiles": [
+                        "C2S",
+                        "common",
+                        "CS2",
+                        "CSCF-RHEL6-MLS",
+                        "rht-ccp",
+                        "server",
+                        "stig-rhel6-server-upstream",
+                        "usgcb-rhel6-server"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-6.8",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.28-2.el6",
+                      "version": "0.1.28",
+                      "os_major_version": "6",
+                      "os_minor_version": "8",
+                      "profiles": [
+                        "C2S",
+                        "common",
+                        "CS2",
+                        "CSCF-RHEL6-MLS",
+                        "nist-cl-il-al",
+                        "pci-dss",
+                        "rht-ccp",
+                        "server",
+                        "standard",
+                        "stig-rhel6-server-upstream",
+                        "usgcb-rhel6-server"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-6.9",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.28-3.el6",
+                      "version": "0.1.28",
+                      "os_major_version": "6",
+                      "os_minor_version": "9",
+                      "profiles": [
+                        "C2S",
+                        "common",
+                        "CS2",
+                        "CSCF-RHEL6-MLS",
+                        "nist-cl-il-al",
+                        "pci-dss",
+                        "rht-ccp",
+                        "server",
+                        "standard",
+                        "stig-rhel6-server-upstream",
+                        "usgcb-rhel6-server"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-6.10",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.28-4.el6",
+                      "version": "0.1.28",
+                      "os_major_version": "6",
+                      "os_minor_version": "10",
+                      "profiles": [
+                        "C2S",
+                        "common",
+                        "CS2",
+                        "CSCF-RHEL6-MLS",
+                        "nist-cl-il-al",
+                        "pci-dss",
+                        "rht-ccp",
+                        "server",
+                        "standard",
+                        "stig-rhel6-server-upstream",
+                        "usgcb-rhel6-server"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.1",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.19-2.el7",
+                      "version": "0.1.19",
+                      "os_major_version": "7",
+                      "os_minor_version": "1",
+                      "profiles": [
+                        "rht-ccp"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.2",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.25-3.el7",
+                      "version": "0.1.25",
+                      "os_major_version": "7",
+                      "os_minor_version": "2",
+                      "profiles": [
+                        "common",
+                        "pci-dss",
+                        "rht-ccp",
+                        "standard",
+                        "stig-rhel7-server-upstream"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.3",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.30-5.el7_3",
+                      "version": "0.1.30",
+                      "os_major_version": "7",
+                      "os_minor_version": "3",
+                      "profiles": [
+                        "C2S",
+                        "cjis-rhel7-server",
+                        "common",
+                        "nist-cl-il-al",
+                        "ospp-rhel7-server",
+                        "pci-dss",
+                        "rht-ccp",
+                        "standard",
+                        "stig-rhel7-server-gui-upstream",
+                        "stig-rhel7-server-upstream",
+                        "stig-rhel7-workstation-upstream"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.4",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.33-6.el7_4",
+                      "version": "0.1.33",
+                      "os_major_version": "7",
+                      "os_minor_version": "4",
+                      "profiles": [
+                        "C2S",
+                        "cjis-rhel7-server",
+                        "common",
+                        "docker-host",
+                        "nist-800-171-cui",
+                        "ospp-rhel7",
+                        "pci-dss_centric",
+                        "pci-dss",
+                        "rht-ccp",
+                        "standard",
+                        "stig-rhel7-disa",
+                        "stig-rhevh-upstream"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.5",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.36-10.el7_5",
+                      "version": "0.1.36",
+                      "os_major_version": "7",
+                      "os_minor_version": "5",
+                      "profiles": [
+                        "C2S",
+                        "cjis-rhel7-server",
+                        "common",
+                        "docker-host",
+                        "nist-800-171-cui",
+                        "ospp-rhel7",
+                        "pci-dss_centric",
+                        "pci-dss",
+                        "rht-ccp",
+                        "standard",
+                        "stig-rhel7-disa",
+                        "stig-rhevh-upstream"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.6",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.40-13.el7_6",
+                      "version": "0.1.40",
+                      "os_major_version": "7",
+                      "os_minor_version": "6",
+                      "profiles": [
+                        "C2S",
+                        "cjis",
+                        "hipaa",
+                        "nist-800-171-cui",
+                        "ospp42",
+                        "ospp",
+                        "pci-dss_centric",
+                        "pci-dss",
+                        "rht-ccp",
+                        "standard",
+                        "stig-rhel7-disa"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.7",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.43-13.el7",
+                      "version": "0.1.43",
+                      "os_major_version": "7",
+                      "os_minor_version": "7",
+                      "profiles": [
+                        "C2S",
+                        "cjis",
+                        "hipaa",
+                        "nist-800-171-cui",
+                        "ospp42",
+                        "ospp",
+                        "pci-dss_centric",
+                        "pci-dss",
+                        "rhelh-vpp",
+                        "rht-ccp",
+                        "standard",
+                        "stig-rhel7-disa"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.8",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.46-11.el7",
+                      "version": "0.1.46",
+                      "os_major_version": "7",
+                      "os_minor_version": "8",
+                      "profiles": [
+                        "anssi_nt28_enhanced",
+                        "anssi_nt28_high",
+                        "anssi_nt28_intermediary",
+                        "anssi_nt28_minimal",
+                        "C2S",
+                        "cjis",
+                        "cui",
+                        "e8",
+                        "hipaa",
+                        "ncp",
+                        "ospp",
+                        "pci-dss_centric",
+                        "pci-dss",
+                        "rhelh-stig",
+                        "rhelh-vpp",
+                        "rht-ccp",
+                        "standard",
+                        "stig"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-7.9",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.49-13.el7",
+                      "version": "0.1.49",
+                      "os_major_version": "7",
+                      "os_minor_version": "9",
+                      "profiles": [
+                        "anssi_nt28_enhanced",
+                        "anssi_nt28_high",
+                        "anssi_nt28_intermediary",
+                        "anssi_nt28_minimal",
+                        "C2S",
+                        "cis",
+                        "cjis",
+                        "cui",
+                        "e8",
+                        "hipaa",
+                        "ncp",
+                        "ospp",
+                        "pci-dss_centric",
+                        "pci-dss",
+                        "rhelh-stig",
+                        "rhelh-vpp",
+                        "rht-ccp",
+                        "standard",
+                        "stig"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-8.0",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.42-11.el8",
+                      "version": "0.1.42",
+                      "os_major_version": "8",
+                      "os_minor_version": "0",
+                      "profiles": [
+                        "ospp",
+                        "pci-dss"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-8.1",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.46-1.el8",
+                      "version": "0.1.46",
+                      "os_major_version": "8",
+                      "os_minor_version": "1",
+                      "profiles": [
+                        "ospp",
+                        "pci-dss"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-8.2",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.48-7.el8",
+                      "version": "0.1.48",
+                      "os_major_version": "8",
+                      "os_minor_version": "2",
+                      "profiles": [
+                        "e8",
+                        "ospp",
+                        "pci-dss",
+                        "stig"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "RHEL-8.3",
+                    "type": "supported_ssg",
+                    "attributes": {
+                      "package": "scap-security-guide-0.1.50-14.el8",
+                      "version": "0.1.50",
+                      "os_major_version": "8",
+                      "os_minor_version": "3",
+                      "profiles": [
+                        "cis",
+                        "cui",
+                        "e8",
+                        "hipaa",
+                        "ospp",
+                        "pci-dss",
+                        "stig"
+                      ]
+                    }
+                  }
+                ],
+                "meta": {
+                  "total": 18,
+                  "revision": "2020-09-24"
+                }
+              }
+            },
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "attributes": {
+                            "$ref": "#/components/schemas/supported_ssg"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/compliance/systems": {
       "get": {
         "summary": "List all hosts",
@@ -2533,6 +2987,37 @@
           },
           "rule_references": {
             "$ref": "#/components/schemas/relationship_collection"
+          }
+        }
+      },
+      "supported_ssg": {
+        "type": "object",
+        "required": [
+          "package",
+          "version"
+        ],
+        "properties": {
+          "package": {
+            "type": "string",
+            "example": "scap-security-guide-0.1.30-5.el7_3"
+          },
+          "version": {
+            "type": "string",
+            "example": "0.1.30"
+          },
+          "os_major_version": {
+            "type": "string",
+            "example": "7"
+          },
+          "os_minor_version": {
+            "type": "string",
+            "example": "3"
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/test/controllers/v1/supported_ssgs_controller_test.rb
+++ b/test/controllers/v1/supported_ssgs_controller_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module V1
+  class SupportedSsgsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      SupportedSsgsController.any_instance.stubs(:authenticate_user)
+    end
+
+    context 'index' do
+      should 'lists all supported SSGs' do
+        get v1_supported_ssgs_url
+
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/models/supported_ssg_test.rb
+++ b/test/models/supported_ssg_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SupportedSsgTest < ActiveSupport::TestCase
+  test 'loads supported SSGs' do
+    assert SupportedSsg.all
+  end
+
+  test 'provides revision' do
+    assert SupportedSsg.revision
+  end
+end


### PR DESCRIPTION
Mapping of RHEL minor version release to a supported SSG version package available on REST API.

Example of one record:
```
{
  "id": "RHEL-7.3",
  "type": "supported_ssg",
  "attributes": {
    "package": "scap-security-guide-0.1.30-5.el7_3",
    "version": "0.1.30",
    "os_major_version": "7",
    "os_minor_version": "3",
    "profiles": [
      "C2S",
      "cjis-rhel7-server",
      "common",
      "nist-cl-il-al",
      "ospp-rhel7-server",
      "pci-dss",
      "rht-ccp",
      "standard",
      "stig-rhel7-server-gui-upstream",
      "stig-rhel7-server-upstream",
      "stig-rhel7-workstation-upstream"
    ]
  }
}
```

