### PR TITLE
[RHICOMPL-544] Validate OS major version of uploaded report

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -34,7 +34,7 @@ class ParseReportJob
     notify_remediation
     notify_payload_tracker(:success, "Job #{jid} has completed successfully")
   rescue ::MissingIdError, ::WrongFormatError, ::InventoryHostNotFound,
-         ::ActiveRecord::RecordInvalid => e
+         ::OSVersionMismatch, ::ActiveRecord::RecordInvalid => e
     error_message = "Cannot parse report: #{e} - #{@msg_value.to_json}"
     notify_payload_tracker(:error, error_message)
     Sidekiq.logger.error(error_message)

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -30,7 +30,6 @@ module Xccdf
       end
 
       def save_all_test_result_info
-        save_host
         save_profile_host
         save_test_result
         save_rule_results

--- a/test/fixtures/files/xccdf_report.xml
+++ b/test/fixtures/files/xccdf_report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_org.ssgproject.content_benchmark_FEDORA" resolved="1" xml:lang="en-US" style="SCAP_1.2">
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_org.ssgproject.content_benchmark_RHEL-8" resolved="1" xml:lang="en-US" style="SCAP_1.2">
   <status date="2018-07-25">draft</status>
-  <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Guide to the Secure Configuration of Fedora</title>
+  <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Guide to the Secure Configuration of RHEL 8</title>
   <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">This guide presents a catalog of security-relevant
 configuration settings for Fedora. It is a rendering of
 content structured in the eXtensible Configuration Checklist Description Format (XCCDF)


### PR DESCRIPTION
Raise `OSVersionMismatch` if the major OS version does not match benchmark's.

Example error:
```
ERROR: Cannot parse report: OS major version (7) does not match with benchmark xccdf_org.ssgproject.content_benchmark_RHEL-8 (8)
```

