### PR TITLE
[RHICOMPL-948] Sync SSGs out of supported matrix 

### DIFF
--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -3,7 +3,7 @@
 require 'yaml'
 
 # rubocop:disable Metrics/BlockLength
-SupportedSsg = Struct.new(:id, :package, :version, :profiles,
+SupportedSsg = Struct.new(:id, :package, :version, :upstream_version, :profiles,
                           :os_major_version, :os_minor_version,
                           keyword_init: true) do
   self::SUPPORTED_FILE = Rails.root.join('config/supported_ssg.yaml')

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -26,6 +26,13 @@ SupportedSsg = Struct.new(:id, :package, :version, :upstream_version, :profiles,
       raw_supported['revision']
     end
 
+    # Collection of supported SSGs that have ZIP available upstream
+    def available_upstream
+      all.reject do |ssg|
+        ssg.upstream_version&.upcase == 'N/A'
+      end
+    end
+
     private
 
     def map_attributes(values)

--- a/config/supported_ssg.yaml
+++ b/config/supported_ssg.yaml
@@ -4,6 +4,7 @@ supported:
   RHEL-6.6:
     package: scap-security-guide-0.1.18-3.el6
     version: 0.1.18
+    upstream_version: N/A
     profiles:
       C2S:
       common:
@@ -17,6 +18,7 @@ supported:
   RHEL-6.7:
     package: scap-security-guide-0.1.21-3.el6
     version: 0.1.21
+    upstream_version: N/A
     profiles:
       C2S:
       common:
@@ -74,6 +76,7 @@ supported:
   RHEL-7.1:
     package: scap-security-guide-0.1.19-2.el7
     version: 0.1.19
+    upstream_version: N/A
     profiles:
       rht-ccp:
   RHEL-7.2:

--- a/config/supported_ssg.yaml
+++ b/config/supported_ssg.yaml
@@ -206,7 +206,9 @@ supported:
           - stig-rhel7-disa
   RHEL-7.9:
     package: scap-security-guide-0.1.49-13.el7
+    # RHEL 7 with CIS backported to 0.1.49 in downstream
     version: 0.1.49
+    upstream_version: 0.1.50
     profiles:
       anssi_nt28_enhanced:
       anssi_nt28_high:

--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -27,9 +27,8 @@ namespace :ssg do
   desc 'Update compliance DB with the supported SCAP Security Guide versions'
   task import_rhel_supported: [:environment] do
     # DATASTREAM_FILENAMES from openscap_parser's ssg:sync
-    ENV['DATASTREAMS'] = ::Xccdf::Benchmark::
-      LATEST_SUPPORTED_VERSIONS.map do |ref_id, version|
-      "v#{version}:rhel#{ref_id[/\d+$/]}"
+    ENV['DATASTREAMS'] = ::SupportedSsg.available_upstream.map do |ssg|
+      "v#{ssg.upstream_version || ssg.version}:rhel#{ssg.os_major_version}"
     end.join(',')
     Rake::Task['ssg:sync'].invoke
     DATASTREAM_FILENAMES.flatten.each do |filename|

--- a/test/models/supported_ssg_test.rb
+++ b/test/models/supported_ssg_test.rb
@@ -10,4 +10,25 @@ class SupportedSsgTest < ActiveSupport::TestCase
   test 'provides revision' do
     assert SupportedSsg.revision
   end
+
+  context 'loaded supported SSGs' do
+    setup do
+      loaded = [
+        SupportedSsg.new(version: '0.1.50'),
+        SupportedSsg.new(version: '0.1.24'),
+        SupportedSsg.new(upstream_version: '0.1.25', version: '0.1.22'),
+        SupportedSsg.new(upstream_version: 'N/A', version: '0.1.1')
+      ]
+      SupportedSsg.stubs(:all).returns(loaded)
+    end
+
+    should 'provide models available upstream' do
+      in_upstream = SupportedSsg.available_upstream
+      versions = in_upstream.map(&:version)
+      assert_includes versions, '0.1.50'
+      assert_includes versions, '0.1.24'
+      assert_includes versions, '0.1.22' # upstream version is higher
+      assert_equal in_upstream.count, 3
+    end
+  end
 end


### PR DESCRIPTION
Syncs uptream SSGs from the supported matrix mapped to RHEL minor version.

Note, that downstream might backport rules to the older versions of SSGs. Currently this app handles/syncs SSGs from upstream, therefore it needs to store both versions.  Downstream version for checking supportability and upstream for syncing benchmarks.
