### PR TITLE
[RHICOMPL-1037] Use default headers also on API controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 # General controller to include all-encompassing behavior
 class ApplicationController < ActionController::API
   include ActionController::Helpers
+  include DefaultHeaders
   include Pundit
   include Authentication
   include ExceptionNotifierCustomData

--- a/app/controllers/concerns/default_headers.rb
+++ b/app/controllers/concerns/default_headers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Original Author: Kevin Deisz
+# https://github.com/rails/rails/commit/f22bc41a92e8f51d6f6da5b840f3364474d6aaba
+# https://github.com/rails/rails/pull/32484
+
+# The ActionController::DefaultHeaders is available from Rails 6.0
+unless defined? ActionController::DefaultHeaders
+  # Allows configuring default headers that will be automatically merged into
+  # each response.
+  module DefaultHeaders
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def make_response!(request)
+        ActionDispatch::Response.create.tap do |res|
+          res.request = request
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/concerns/default_headers_test.rb
+++ b/test/controllers/concerns/default_headers_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DefaultHeadersTest < ActionDispatch::IntegrationTest
+  setup do
+    ApplicationController.any_instance.expects(:authenticate_user)
+    ApplicationController.any_instance.stubs(:index).returns('Response Body')
+    Rails.application.routes.draw do
+      root 'application#index'
+    end
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+  end
+
+  test 'response includes default headers' do
+    get '/'
+    default_headers = Rails.application.config
+                           .action_dispatch.default_headers
+                           .keys.to_set
+    assert default_headers.subset?(response.header.keys.to_set)
+  end
+end


### PR DESCRIPTION
Default headers were not being set for an API only controllers. This
issue has been fixed in Rails 6.0.

References:

https://github.com/rails/rails/commit/f22bc41a92e8f51d6f6da5b840f3364474d6aaba
https://github.com/rails/rails/pull/32484