### PR TITLE
[RHICOMPL-1042] Add policy related non-breaking model changes

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -5,6 +5,7 @@ class Account < ApplicationRecord
   has_many :users, dependent: :nullify
   has_many :hosts, dependent: :nullify
   has_many :profiles, dependent: :destroy
+  has_many :policies, dependent: :destroy
   has_many :business_objectives, through: :profiles
 
   validates :account_number, presence: true

--- a/app/models/business_objective.rb
+++ b/app/models/business_objective.rb
@@ -3,12 +3,17 @@
 # Business objectives are arbitrary strings to tag profiles in the UI
 class BusinessObjective < ApplicationRecord
   has_many :profiles, dependent: :nullify
+  has_many :policies, dependent: :nullify
   has_many :accounts, through: :profiles
 
   validates :title, presence: true
 
   scope :in_account, lambda { |account_or_account_id|
     joins(:accounts).where(accounts: { id: account_or_account_id }).distinct
+  }
+
+  scope :without_policies, lambda {
+    includes(:policies).where(policies: { id: nil })
   }
 
   scope :without_profiles, lambda {

--- a/app/models/concerns/profile_hosts.rb
+++ b/app/models/concerns/profile_hosts.rb
@@ -5,7 +5,10 @@ module ProfileHosts
   extend ActiveSupport::Concern
 
   included do
+    has_many :test_result_hosts, through: :test_results, source: :host
     has_many :profile_hosts, dependent: :destroy
+    has_many :policy_hosts, through: :policy_object
+    has_many :assigned_hosts, through: :policy_hosts, source: :host
     has_many :hosts, through: :profile_hosts, source: :host
 
     def update_hosts(new_host_ids)

--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -5,7 +5,11 @@ module ProfilePolicyAssociation
   extend ActiveSupport::Concern
 
   included do
+    after_destroy :destroy_empty_policy
     after_destroy :destroy_policy_test_results
+
+    belongs_to :policy_object, class_name: :Policy, foreign_key: :policy_id,
+                               optional: true, inverse_of: :profiles
 
     def policy
       return self unless external
@@ -42,6 +46,10 @@ module ProfilePolicyAssociation
       else
         DestroyProfilesJob.new.perform(policy_profiles.pluck(:id))
       end
+    end
+
+    def destroy_empty_policy
+      policy_object.destroy if policy_object&.profiles&.empty?
     end
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -14,10 +14,14 @@ class Host < ApplicationRecord
   has_many :rule_results, dependent: :delete_all
   has_many :rules, through: :rule_results, source: :rule
   has_many :profile_hosts, dependent: :destroy
+  has_many :policy_hosts, dependent: :destroy
   has_many :test_results, dependent: :destroy
   include SystemLike
 
   has_many :profiles, through: :profile_hosts, source: :profile
+  has_many :test_result_profiles, through: :test_results, source: :profile
+  has_many :policies, through: :policy_hosts
+  has_many :assigned_profiles, through: :policies, source: :profiles
 
   validates :name, presence: true
   validates :account, presence: true

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Compliance policy
+class Policy < ApplicationRecord
+  DEFAULT_COMPLIANCE_THRESHOLD = 100.0
+  PROFILE_ATTRS = %w[name description account_id compliance_threshold
+                     business_objective_id].freeze
+
+  has_many :profiles, dependent: :destroy, inverse_of: :policy_object
+  has_many :benchmarks, through: :profiles
+  has_many :test_results, through: :profiles, dependent: :destroy
+
+  has_many :policy_hosts, dependent: :destroy
+  has_many :hosts, through: :policy_hosts, source: :host
+
+  belongs_to :business_objective, optional: true
+  belongs_to :account
+
+  validates :compliance_threshold, numericality: true
+  validates :account, presence: true
+  validates :name, presence: true, uniqueness: true
+
+  def self.attrs_from(profile:)
+    profile.attributes.slice(*PROFILE_ATTRS)
+  end
+
+  def fill_from(profile:)
+    self.name ||= profile.name
+    self.description ||= profile.description
+
+    self
+  end
+
+  def update_hosts(new_host_ids)
+    return unless new_host_ids
+
+    policy_hosts.where.not(host_id: new_host_ids).destroy_all
+    PolicyHost.import((new_host_ids - host_ids).map do |host_id|
+      { host_id: host_id, policy_id: id }
+    end)
+  end
+
+  def os_major_version
+    benchmarks.first.os_major_version
+  end
+
+  def destroy_orphaned_business_objective
+    bo_changes = (previous_changes.fetch(:business_objective_id, []) +
+                  changes.fetch(:business_objective_id, [])).compact
+    return if bo_changes.blank?
+
+    BusinessObjective.without_policies.where(id: bo_changes).destroy_all
+  end
+end

--- a/app/models/policy_host.rb
+++ b/app/models/policy_host.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Join table between Policy and Host
+class PolicyHost < ApplicationRecord
+  belongs_to :policy
+  belongs_to :host
+
+  validates :policy, presence: true
+  validates :host, presence: true, uniqueness: { scope: :policy }
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,6 +18,9 @@ class Profile < ApplicationRecord
   validates :ref_id, uniqueness: {
     scope: %i[account_id benchmark_id external]
   }, presence: true
+  validates :ref_id, uniqueness: {
+    scope: %i[account_id benchmark_id policy_id]
+  }, presence: true
   validates :name, presence: true
   validates :benchmark_id, presence: true
   validates :compliance_threshold, numericality: true

--- a/test/fixtures/policies.yml
+++ b/test/fixtures/policies.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: policy1
+  account: test
+
+two:
+  name: policy2
+  account: test

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -6,6 +6,7 @@ class AccountTest < ActiveSupport::TestCase
   should have_many :users
   should have_many :hosts
   should have_many :profiles
-  should have_many :business_objectives
+  should have_many :policies
+  should have_many(:business_objectives).through(:profiles)
   should validate_presence_of :account_number
 end

--- a/test/models/business_objective_test.rb
+++ b/test/models/business_objective_test.rb
@@ -3,16 +3,27 @@
 require 'test_helper'
 
 class BusinessObjectiveTest < ActiveSupport::TestCase
-  fixtures :profiles, :business_objectives
+  fixtures :policies, :profiles, :business_objectives
+
+  should have_many :policies
   should have_many :profiles
+  should have_many(:accounts).through(:profiles)
   should validate_presence_of :title
 
   context 'without_accounts' do
-    should 'return orphaned business objectives' do
+    should 'return orphaned profile business objectives' do
       profiles(:one).update! business_objective: business_objectives(:one)
       assert_includes BusinessObjective.without_profiles,
                       business_objectives(:two)
       assert_not_includes BusinessObjective.without_profiles,
+                          business_objectives(:one)
+    end
+
+    should 'return orphaned policy business objectives' do
+      policies(:one).update! business_objective: business_objectives(:one)
+      assert_includes BusinessObjective.without_policies,
+                      business_objectives(:two)
+      assert_not_includes BusinessObjective.without_policies,
                           business_objectives(:one)
     end
   end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3,6 +3,16 @@
 require 'test_helper'
 
 class HostTest < ActiveSupport::TestCase
+  should have_many(:rule_results)
+  should have_many(:rules).through(:rule_results).source(:rule)
+  should have_many(:profile_hosts)
+  should have_many(:profiles).through(:profile_hosts).source(:profile)
+  should have_many(:policy_hosts)
+  should have_many(:test_results)
+  should have_many(:policies).through(:policy_hosts)
+  should have_many(:assigned_profiles).through(:policies).source(:profiles)
+  should have_many(:test_result_profiles).through(:test_results)
+                                         .source(:profile)
   should validate_presence_of :name
   should validate_presence_of :account
 

--- a/test/models/policy_host_test.rb
+++ b/test/models/policy_host_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PolicyHostTest < ActiveSupport::TestCase
+  should belong_to(:policy)
+  should belong_to(:host)
+end

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PolicyTest < ActiveSupport::TestCase
+  should have_many(:profiles)
+  should have_many(:benchmarks)
+  should have_many(:test_results).through(:profiles)
+  should have_many(:policy_hosts)
+  should have_many(:hosts).through(:policy_hosts).source(:host)
+  should belong_to(:business_objective).optional
+  should belong_to(:account)
+
+  should '#attrs_from(profile:)' do
+    Policy::PROFILE_ATTRS.each do |attr|
+      assert_equal profiles(:one).send(attr),
+                   Policy.attrs_from(profile: profiles(:one))[attr]
+    end
+  end
+
+  context 'fill_from' do
+    should 'copy attributes from the profile' do
+      policy = Policy.new.fill_from(profile: profiles(:one))
+      assert_equal profiles(:one).name, policy.name
+      assert_equal profiles(:one).description, policy.description
+    end
+  end
+
+  context 'update_hosts' do
+    should 'add new hosts to an empty host set' do
+      policies(:one).update!(hosts: [])
+      assert_empty(policies(:one).hosts)
+      assert_difference('policies(:one).hosts.count', hosts.count) do
+        policies(:one).update_hosts(hosts.pluck(:id))
+      end
+    end
+
+    should 'add new hosts to an existing host set' do
+      policies(:one).update!(hosts: hosts[0...-1])
+      assert_not_empty(policies(:one).hosts)
+      assert_difference('policies(:one).hosts.count', 1) do
+        policies(:one).update_hosts(hosts.pluck(:id))
+      end
+    end
+
+    should 'remove old hosts from an existing host set' do
+      policies(:one).update!(hosts: hosts)
+      assert_equal hosts.count, policies(:one).hosts.count
+      assert_difference('policies(:one).reload.hosts.count', -hosts.count) do
+        policies(:one).update_hosts([])
+      end
+    end
+
+    should 'add new and remove old hosts from an existing host set' do
+      policies(:one).update!(host_ids: hosts.pluck(:id)[0...-1])
+      assert_not_empty(policies(:one).hosts)
+      assert_difference('policies(:one).hosts.count', 0) do
+        policies(:one).update_hosts(hosts.pluck(:id)[1..-1])
+      end
+    end
+  end
+
+  should 'return an OS major version' do
+    profiles(:one).update!(policy_object: policies(:one),
+                           account: accounts(:test))
+    assert_equal '7', policies(:one).os_major_version
+  end
+
+  context 'destroy_orphaned_business_objective' do
+    setup do
+      assert_empty business_objectives(:one).policies
+      policies(:one).update!(business_objective: business_objectives(:one))
+    end
+
+    should 'destroy business objectives without policies on update' do
+      assert_difference('BusinessObjective.count' => -1) do
+        policies(:one).update!(business_objective: nil)
+        policies(:one).destroy_orphaned_business_objective
+      end
+    end
+
+    should 'destroy business objectives without policies on destroy' do
+      assert_difference('BusinessObjective.count' => -1) do
+        policies(:one).destroy
+        policies(:one).destroy_orphaned_business_objective
+      end
+    end
+  end
+end

--- a/test/models/test_result_test.rb
+++ b/test/models/test_result_test.rb
@@ -11,4 +11,28 @@ class TestResultTest < ActiveSupport::TestCase
   should validate_presence_of(:profile)
   should validate_presence_of(:end_time)
   should validate_uniqueness_of(:end_time).scoped_to(%i[host_id profile_id])
+
+  test 'destroy associated external profiles if they have no test results' do
+    profiles(:one).update!(hosts: [hosts(:one)], external: true,
+                           account: accounts(:test))
+    assert_equal test_results(:one).host, hosts(:one)
+    assert_equal test_results(:one).profile, profiles(:one)
+    assert profiles(:one).test_results.one?
+    assert_nil profiles(:one).policy_object
+
+    assert_difference('Profile.count', -1) { hosts(:one).destroy }
+  end
+
+  test 'does not destroy external policies if they still have hosts' do
+    test_results(:two).update! host: hosts(:two), profile: profiles(:one)
+    assert_equal test_results(:two).host, hosts(:two)
+    assert_equal test_results(:two).profile, profiles(:one)
+    assert_equal test_results(:one).host, hosts(:one)
+    assert_equal test_results(:one).profile, profiles(:one)
+    assert 2, profiles(:one).test_results.count
+    assert_nil profiles(:one).policy_object
+    assert_nil profiles(:two).policy_object
+
+    assert_difference('Profile.count', 0) { hosts(:one).destroy }
+  end
 end


### PR DESCRIPTION
Adapted all non-breaking model changes from https://github.com/RedHatInsights/compliance-backend/pull/572

Smoke test result run locally (3 failures related to rbac that also exist on master):

```
3 failed, 85 passed, 1 skipped, 126 deselected, 333 warnings in 329.08s (0:05:29)
```