### PR TITLE
[RHICOMPL-1042] Profile is not yet uniq by a policy

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,9 +18,6 @@ class Profile < ApplicationRecord
   validates :ref_id, uniqueness: {
     scope: %i[account_id benchmark_id external]
   }, presence: true
-  validates :ref_id, uniqueness: {
-    scope: %i[account_id benchmark_id policy_id]
-  }, presence: true
   validates :name, presence: true
   validates :benchmark_id, presence: true
   validates :compliance_threshold, numericality: true

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -9,8 +9,6 @@ class ProfileTest < ActiveSupport::TestCase
   should have_many(:assigned_hosts).through(:policy_hosts).source(:host)
   should belong_to(:policy_object).optional
   should validate_uniqueness_of(:ref_id)
-    .scoped_to(%i[account_id benchmark_id policy_id])
-  should validate_uniqueness_of(:ref_id)
     .scoped_to(%i[account_id benchmark_id external])
   should validate_presence_of :ref_id
   should validate_presence_of :name


### PR DESCRIPTION
Having a profile unique by a policy before the policy model is fully
used breaks creation of new internal profiles that already have an
`external: true` variant.

Response with the constraint:
```
Response not successful: Received status code 422
<ActiveRecord::RecordInvalid: Validation failed: Ref has already been taken>
```

References: https://github.com/RedHatInsights/compliance-backend/pull/604#discussion_r505419339