### PR TITLE
[RHICOMPL-1042] Fix Profile scope with_policy

### DIFF
--- a/app/models/concerns/profile_searching.rb
+++ b/app/models/concerns/profile_searching.rb
@@ -28,8 +28,8 @@ module ProfileSearching
         where.not(parent_profile_id: nil)
     }
     scope :with_policy, lambda { |with_policy = true|
-      with_policy && where.not(policy: nil) ||
-        where(policy: nil)
+      with_policy && where.not(policy_id: nil) ||
+        where(policy_id: nil)
     }
     scope :external, lambda { |external = true|
       where(external: external)


### PR DESCRIPTION
Profile's policy association is temporarily named `policy_object`
therefore the previous scope with `policy` did not work.  Lets use the
field name `policy_id` so it works also after the temporary name is
changed back.