### PR TITLE
[RHICOMPL-1042] Fix Policy to allow duplicate names

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -18,7 +18,7 @@ class Policy < ApplicationRecord
 
   validates :compliance_threshold, numericality: true
   validates :account, presence: true
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true
 
   def self.attrs_from(profile:)
     profile.attributes.slice(*PROFILE_ATTRS)


### PR DESCRIPTION
Policy names can be the same across account.