### PR TITLE
[RHICOMPL-662] Migration of old profile data into new policy records

### DIFF
--- a/app/services/copy_profiles_to_policies.rb
+++ b/app/services/copy_profiles_to_policies.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# A service class to copy Profile data to new Policy objects
+class CopyProfilesToPolicies
+  class << self
+    delegate :run!, to: :new
+  end
+
+  def run!
+    create_policies
+  end
+
+  private
+
+  def profiles
+    Profile.canonical(false)
+           .with_policy(false)
+  end
+
+  # Create a Policy for each non-canonical internal Profile,
+  # assign the same hosts set.
+  def create_policies
+    profiles.where(external: false).find_each do |profile|
+      policy = Policy.create!(Policy.attrs_from(profile: profile))
+      profile.update(policy_id: policy.id)
+
+      host_ids = profile.profile_hosts.distinct.pluck(:host_id)
+      PolicyHost.create(
+        host_ids.map do |host_id|
+          { policy_id: policy.id, host_id: host_id }
+        end
+      )
+    end
+  end
+end

--- a/db/migrate/20201015174517_copy_data_to_policy_first_pass.rb
+++ b/db/migrate/20201015174517_copy_data_to_policy_first_pass.rb
@@ -1,0 +1,7 @@
+class CopyDataToPolicyFirstPass < ActiveRecord::Migration[5.2]
+  def up
+    CopyProfilesToPolicies.run!
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_153704) do
+ActiveRecord::Schema.define(version: 2020_10_15_174517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/test/services/copy_profiles_to_policies_test.rb
+++ b/test/services/copy_profiles_to_policies_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# A class to test importing from a Datastream file
+class CopyProfilesToPoliciesTest < ActiveSupport::TestCase
+  fixtures :accounts, :profiles
+
+  setup do
+    Policy.destroy_all
+    profiles(:one).update!(parent_profile: profiles(:two),
+                           account: accounts(:test),
+                           compliance_threshold: 75.0,
+                           business_objective: business_objectives(:two))
+  end
+
+  test 'copies profile attributes to new policies' do
+    assert_difference('Policy.count' => 1) do
+      CopyProfilesToPolicies.run!
+    end
+    assert_not_nil(policy = profiles(:one).reload.policy_object)
+
+    assert_equal profiles(:one).name, policy.name
+    assert_equal profiles(:one).description, policy.description
+    assert_equal profiles(:one).account_id, policy.account_id
+    assert_equal profiles(:one).compliance_threshold,
+                 policy.compliance_threshold
+    assert_equal profiles(:one).business_objective_id,
+                 policy.business_objective_id
+
+    assert_equal Policy.count, Profile.external(false).canonical(false).count
+  end
+
+  test 'copies profile hosts to new policies' do
+    profiles(:one).profile_hosts << hosts.map do |host|
+      ProfileHost.create!(profile: profiles(:one), host: host)
+    end
+    assert_difference('Policy.count' => 1, 'PolicyHost.count' => hosts.count) do
+      CopyProfilesToPolicies.run!
+    end
+    assert_not_nil(policy = profiles(:one).reload.policy_object)
+    assert_equal Set.new(policy.hosts), Set.new(hosts)
+    assert_equal Policy.count, Profile.external(false).canonical(false).count
+  end
+
+  test 'copies two similar internal profiles with to two new policies' do
+    first = profiles(:one)
+    (bm = benchmarks(:one).dup).update!(version: '0.1.46')
+    (second = profiles(:one).dup).update!(parent_profile: profiles(:two),
+                                          account: accounts(:test),
+                                          benchmark: bm)
+    assert_difference('Policy.count' => 2) do
+      CopyProfilesToPolicies.run!
+    end
+    assert_not_nil first.reload.policy_object
+    assert_equal 1, first.policy_object.profiles.count
+    assert_not_nil second.reload.policy_object
+    assert_equal 1, second.policy_object.profiles.count
+    assert_equal Profile.external(false).canonical(false).count,
+                 Policy.count
+  end
+
+  test 'does not create policy for external profile ' do
+    # (bm = benchmarks(:one).dup).update!(version: '0.1.46')
+    profiles(:one).dup.update!(external: true)
+    assert_difference('Policy.count' => 1) do
+      CopyProfilesToPolicies.run!
+    end
+    assert_not_nil profiles(:one).reload.policy_object
+    assert_equal 1, profiles(:one).policy_object.profiles.count
+    assert_equal Profile.external(false).canonical(false).uniq(&:ref_id).count,
+                 Policy.count
+  end
+
+  test 'idempotency' do
+    assert_difference('Policy.count' => 1) do
+      CopyProfilesToPolicies.run!
+      CopyProfilesToPolicies.run!
+    end
+  end
+end


### PR DESCRIPTION
Creates a service for copying profiles into Policies.
The service creates new Policy models for Profiles that are internal and
that do not have a Policy.  It copies some of the attributes from the
profile.  It assigns the same host set from the internal profile.

The first pass for migration of profile data to policies is mostly intended for testing the migration.
Production should be migrated only when the whole feature is complete.

**IMPORTANT**

We first need to decide whether to do a simpler migration (this PR) or migrate it by using a virtual policy.

Original virtual policy lookup for external profiles:
```
Profile.includes(:benchmark)
        .older_than(created_at)
        .find_by(account: account_id, external: false, ref_id: ref_id,
                benchmarks: { ref_id: benchmark.ref_id })
```
