### PR TITLE
[RHICOMPL-1048] Allow rendering multiple model errors

### DIFF
--- a/app/controllers/concerns/rendering.rb
+++ b/app/controllers/concerns/rendering.rb
@@ -11,13 +11,23 @@ module Rendering
       render({ json: serializer.new(model, opts) }.merge(args))
     end
 
-    def render_error(model, **args)
+    def render_error(models, **args)
       render({ json: {
-        errors: model.errors.full_messages
+        errors: model_errors(models)
       }, status: :not_acceptable }.merge(args))
     end
 
     private
+
+    def model_errors(models = [])
+      models = [models].flatten
+      models.flat_map do |model|
+        model.errors.full_messages.map do |error|
+          error[0] = error[0].downcase
+          "#{model.class.name} #{error}"
+        end
+      end
+    end
 
     def serializer
       raise NotImplementedError

--- a/test/controllers/concerns/rendering_test.rb
+++ b/test/controllers/concerns/rendering_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Tests related to REST API rendering
+class RenderingTest < ActionDispatch::IntegrationTest
+  class DummySerializer; include FastJsonapi::ObjectSerializer; end
+  class DummyController < OpenStruct
+    include Rendering
+
+    def initialize
+      super(action_name: 'show',
+            params: ActionController::Parameters.new,
+            serializer: DummySerializer)
+    end
+  end
+
+  context '#render_error' do
+    setup do
+      @model = OpenStruct.new(
+        errors: OpenStruct.new(full_messages: [:foo.to_s, :bar.to_s])
+      )
+      @controller = DummyController.new
+    end
+
+    should 'accept a single model' do
+      @controller.expects(:render)
+      @controller.render_error(@model)
+    end
+
+    should 'accept multiple models' do
+      @controller.expects(:render)
+      @controller.render_error([@model, @model])
+    end
+  end
+end


### PR DESCRIPTION
This is in support of RHICOMPL-661 and is a non-breaking change. It will allow rendering the errors of multiple models instead of just one. The ProfilesController will require this when creating multiple different records in one HTTP request.

Signed-off-by: Andrew Kofink <akofink@redhat.com>