### PR TITLE
[RHICOMPL-1049] Profile uniqueness in a policy

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,6 +18,10 @@ class Profile < ApplicationRecord
   validates :ref_id, uniqueness: {
     scope: %i[account_id benchmark_id external policy_id]
   }, presence: true
+  validates :ref_id, uniqueness: {
+    scope: %i[account_id benchmark_id policy_id],
+    message: 'must be unique in a policy'
+  }, if: :policy_id
   validates :external, uniqueness: {
     scope: %i[ref_id account_id benchmark_id]
   }, unless: :policy_id

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,6 +18,9 @@ class Profile < ApplicationRecord
   validates :ref_id, uniqueness: {
     scope: %i[account_id benchmark_id external policy_id]
   }, presence: true
+  validates :external, uniqueness: {
+    scope: %i[ref_id account_id benchmark_id]
+  }, unless: :policy_id
   validates :name, presence: true
   validates :benchmark_id, presence: true
   validates :compliance_threshold, numericality: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,7 +16,7 @@ class Profile < ApplicationRecord
   belongs_to :parent_profile, class_name: 'Profile', optional: true
 
   validates :ref_id, uniqueness: {
-    scope: %i[account_id benchmark_id external]
+    scope: %i[account_id benchmark_id external policy_id]
   }, presence: true
   validates :name, presence: true
   validates :benchmark_id, presence: true

--- a/db/migrate/20201021083148_change_uniq_on_profiles.rb
+++ b/db/migrate/20201021083148_change_uniq_on_profiles.rb
@@ -1,0 +1,15 @@
+class ChangeUniqOnProfiles < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :profiles, name: 'uniqueness'
+    add_index :profiles,
+              %i[ref_id account_id benchmark_id external policy_id],
+              unique: true, name: 'uniqueness'
+  end
+
+  def down
+    remove_index :profiles, name: 'uniqueness'
+    add_index :profiles,
+              %i[ref_id account_id benchmark_id external],
+              unique: true, name: 'uniqueness'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_15_174517) do
+ActiveRecord::Schema.define(version: 2020_10_21_083148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2020_10_15_174517) do
     t.index ["name"], name: "index_profiles_on_name"
     t.index ["parent_profile_id"], name: "index_profiles_on_parent_profile_id"
     t.index ["policy_id"], name: "index_profiles_on_policy_id"
-    t.index ["ref_id", "account_id", "benchmark_id", "external"], name: "uniqueness", unique: true
+    t.index ["ref_id", "account_id", "benchmark_id", "external", "policy_id"], name: "uniqueness", unique: true
   end
 
   create_table "rule_identifiers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -32,6 +32,33 @@ class ProfileTest < ActiveSupport::TestCase
     end
   end
 
+  test 'uniqness by ref_id in a policy, the same external boolean value' do
+    profiles(:one).update!(policy_id: policies(:one).id)
+    assert profiles(:one).policy_id
+
+    assert_raises ActiveRecord::RecordInvalid do
+      profiles(:one).dup.save!
+    end
+  end
+
+  test 'uniqness by ref_id in a policy, different external boolean value' do
+    profiles(:one).update!(policy_id: policies(:one).id)
+    assert profiles(:one).policy_id
+
+    assert_raises ActiveRecord::RecordInvalid do
+      profiles(:one).dup.update!(external: !profiles(:one).external)
+    end
+  end
+
+  test 'allows profiles with same ref_id in two policies' do
+    profiles(:one).update!(policy_id: policies(:one).id)
+    assert profiles(:one).policy_id
+
+    dupe = profiles(:one).dup
+    dupe.update!(policy_id: policies(:two).id)
+    assert dupe.policy_id
+  end
+
   test 'host is not compliant there are no results for all rules' do
     assert_not profiles(:one).compliant?(hosts(:one))
   end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -19,6 +19,19 @@ class ProfileTest < ActiveSupport::TestCase
                            hosts: [hosts(:one)], account: accounts(:one))
   end
 
+  test 'uniqness by external without a policy' do
+    orig = profiles(:one)
+    assert_nil orig.policy_id
+
+    (dupe = orig.dup).update!(external: !orig.external)
+    assert_nil dupe.policy_id
+    assert dupe.external != orig.external
+
+    assert_raises ActiveRecord::RecordInvalid do
+      orig.dup.save!
+    end
+  end
+
   test 'host is not compliant there are no results for all rules' do
     assert_not profiles(:one).compliant?(hosts(:one))
   end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -9,7 +9,7 @@ class ProfileTest < ActiveSupport::TestCase
   should have_many(:assigned_hosts).through(:policy_hosts).source(:host)
   should belong_to(:policy_object).optional
   should validate_uniqueness_of(:ref_id)
-    .scoped_to(%i[account_id benchmark_id external])
+    .scoped_to(%i[account_id benchmark_id external policy_id])
   should validate_presence_of :ref_id
   should validate_presence_of :name
   should belong_to(:business_objective).optional


### PR DESCRIPTION
To support the new Policy model, the db unique constraint must be changed to include `policy_id`. Policies can have the same profiles (ref_id and benchmark), but need a different rule set.

It adds a validation, to ensure that a policy has only one profile for an SSG (ref_id and benchmark) regardless of an `external` boolean field value.

To keep the previous uniqueness by `external` field, there is a validation added for profiles that are outside of a policy. This is an intermid solution, before the Policy model is fully used. All internal profiles are expected to have a policy. Note, that the `external` field will be deprecated soon.

/cc @Victoremepunto to check the assumptions/conditions (ty!)