### PR TITLE
[RHICOMPL-1042] Use BO id on Profile test setup

### DIFF
--- a/test/services/copy_profiles_to_policies_test.rb
+++ b/test/services/copy_profiles_to_policies_test.rb
@@ -11,7 +11,7 @@ class CopyProfilesToPoliciesTest < ActiveSupport::TestCase
     profiles(:one).update!(parent_profile: profiles(:two),
                            account: accounts(:test),
                            compliance_threshold: 75.0,
-                           business_objective: business_objectives(:two))
+                           business_objective_id: business_objectives(:two).id)
   end
 
   test 'copies profile attributes to new policies' do


### PR DESCRIPTION
As the business_objective is going to be delegated to Policy from a Profile.