### PR TITLE
[RHICOMPL-1049] Internal profiles should be unique for an account

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -22,6 +22,11 @@ class Profile < ApplicationRecord
     scope: %i[account_id benchmark_id policy_id],
     message: 'must be unique in a policy'
   }, if: :policy_id
+  validates :ref_id, uniqueness: {
+    scope: %i[account_id benchmark_id],
+    conditions: -> { where(external: false) },
+    message: 'must be unique for an internal profile'
+  }, unless: :external
   validates :external, uniqueness: {
     scope: %i[ref_id account_id benchmark_id],
     conditions: -> { where(policy_id: nil) }

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -32,6 +32,14 @@ class ProfileTest < ActiveSupport::TestCase
     end
   end
 
+  test 'unqiness by ref_id for an internal profile' do
+    profiles(:one).update!(external: false)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      profiles(:one).dup.update!(policy_id: policies(:one).id)
+    end
+  end
+
   test 'uniqness by ref_id in a policy, the same external boolean value' do
     profiles(:one).update!(policy_id: policies(:one).id)
     assert profiles(:one).policy_id
@@ -64,12 +72,19 @@ class ProfileTest < ActiveSupport::TestCase
     assert dupe2.policy_id
   end
 
-  test 'allows profiles with same ref_id in two policies' do
-    profiles(:one).update!(policy_id: policies(:one).id)
+  test 'allows external profiles with same ref_id in two policies' do
+    profiles(:one).update!(external: true, policy_id: policies(:one).id)
     assert profiles(:one).policy_id
 
     dupe = profiles(:one).dup
     dupe.update!(policy_id: policies(:two).id)
+    assert dupe.policy_id
+  end
+
+  test 'creation of internal profile with a policy, external profile exists' do
+    profiles(:one).update!(external: true)
+    dupe = profiles(:one).dup
+    dupe.update!(external: false, policy_id: policies(:one).id)
     assert dupe.policy_id
   end
 


### PR DESCRIPTION
There should not be two internal profiles with the same ref_id, benchmark and account.
This keeps the constraint/expectation as it was before Policy model.