### PR TITLE
[RHICOMPL-1051] Fix policy association during report parse

### DIFF
--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -28,6 +28,11 @@ module Xccdf
       )
     end
 
+    def associate_policy_to_test_result_profile
+      policy_id = host_profile.old_policy&.policy_id
+      host_profile.update!(policy_id: policy_id) if policy_id
+    end
+
     private
 
     def test_result_profile

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -32,6 +32,7 @@ module Xccdf
       def save_all_test_result_info
         save_profile_host
         save_test_result
+        associate_policy_to_test_result_profile
         save_rule_results
         associate_rules_from_rule_results
         invalidate_cache

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -193,6 +193,25 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     end
   end
 
+  context 'policy association' do
+    setup do
+      @report_parser.save_host
+      @report_parser.save_all_benchmark_info
+      test_result_profile = @report_parser.send(:test_result_profile)
+      Profile.new(parent_profile: test_result_profile,
+                  policy_id: policies(:one).id,
+                  account: accounts(:test)).fill_from_parent.save!
+      @report_parser.save_profile_host
+    end
+
+    should 'associate a policy to test results' do
+      @report_parser.save_test_result
+      @report_parser.associate_policy_to_test_result_profile
+
+      assert_equal policies(:one).id, @report_parser.host_profile.policy_id
+    end
+  end
+
   context 'rule results' do
     should 'save them, associate them with a rule and a host' do
       assert_difference('RuleResult.count', 59) do


### PR DESCRIPTION
Before this change, uploads of a different SSG version would not associate the newly created profile to the policy. To test:

1. Create a policy in the UI, verify 1 policy and 1 associated external=false profile is created
3. Assign a host to the policy
2. Upload a report for that host against a different SSG version than the original profile
3. Check that a new profile is created and that it's associated to the policy (and external=true)

Signed-off-by: Andrew Kofink <akofink@redhat.com>