### PR TITLE
[RHICOMPL-1049] Fix external Profile uniqueness outside of a policy

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -23,7 +23,8 @@ class Profile < ApplicationRecord
     message: 'must be unique in a policy'
   }, if: :policy_id
   validates :external, uniqueness: {
-    scope: %i[ref_id account_id benchmark_id]
+    scope: %i[ref_id account_id benchmark_id],
+    conditions: -> { where(policy_id: nil) }
   }, unless: :policy_id
   validates :name, presence: true
   validates :benchmark_id, presence: true

--- a/app/services/copy_profiles_to_policies.rb
+++ b/app/services/copy_profiles_to_policies.rb
@@ -22,7 +22,7 @@ class CopyProfilesToPolicies
   def create_policies
     profiles.where(external: false).find_each do |profile|
       policy = Policy.create!(Policy.attrs_from(profile: profile))
-      profile.update(policy_id: policy.id)
+      profile.update!(policy_id: policy.id)
 
       host_ids = profile.profile_hosts.distinct.pluck(:host_id)
       PolicyHost.create(

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -50,6 +50,20 @@ class ProfileTest < ActiveSupport::TestCase
     end
   end
 
+  test 'coexistence of external profiles with and without a policy' do
+    dupe1 = profiles(:one).dup
+    dupe1.update!(external: true, policy_id: policies(:one).id)
+    assert dupe1.policy_id
+
+    profiles(:one).update!(external: true)
+    assert_not profiles(:one).policy_id
+    assert profiles(:one).external
+
+    dupe2 = profiles(:one).dup
+    dupe2.update!(external: true, policy_id: policies(:two).id)
+    assert dupe2.policy_id
+  end
+
   test 'allows profiles with same ref_id in two policies' do
     profiles(:one).update!(policy_id: policies(:one).id)
     assert profiles(:one).policy_id


### PR DESCRIPTION
The external uniqueness for profiles outside of a policy has to include the validation condition also in the duplicate/relation lookup.

Ensure that profile data migration validates policy assignment.

