### PR TITLE
fix(RHICOMPL-1054): Host profiles are assigned_profiles

### DIFF
--- a/app/models/concerns/system_like.rb
+++ b/app/models/concerns/system_like.rb
@@ -14,7 +14,7 @@ module SystemLike
 
   def compliant
     result = {}
-    profiles.map do |profile|
+    test_result_profiles.map do |profile|
       result[profile.ref_id] = profile.compliant?(self)
     end
     result
@@ -29,7 +29,7 @@ module SystemLike
   def last_scan_results(profile = nil)
     return profile.results(self) if profile.present?
 
-    profiles.flat_map do |p|
+    test_result_profiles.flat_map do |p|
       p.results(self)
     end
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -19,10 +19,10 @@ class Host < ApplicationRecord
   has_many :test_result_profiles, through: :test_results, dependent: :destroy
   include SystemLike
 
-  has_many :profiles, through: :test_results
   has_many :profile_host_profiles, through: :profile_hosts, source: :profile
   has_many :test_result_profiles, through: :test_results, source: :profile
   has_many :policies, through: :policy_hosts
+  has_many :profiles, through: :policies, source: :profiles
   has_many :assigned_profiles, through: :policies, source: :profiles
 
   validates :name, presence: true

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -6,12 +6,12 @@ class HostTest < ActiveSupport::TestCase
   should have_many(:rule_results)
   should have_many(:rules).through(:rule_results).source(:rule)
   should have_many(:profile_hosts)
-  should have_many(:profiles).through(:test_results)
   should have_many(:profile_host_profiles).through(:profile_hosts)
                                           .source(:profile)
   should have_many(:policy_hosts)
   should have_many(:test_results)
   should have_many(:policies).through(:policy_hosts)
+  should have_many(:profiles).through(:policies).source(:profiles)
   should have_many(:assigned_profiles).through(:policies).source(:profiles)
   should validate_presence_of :name
   should validate_presence_of :account


### PR DESCRIPTION
The REST API should return a host's assigned profiles (via its policies)
not profiles via test_results.

Validate by running `test_rest_api.py::test_associate_systems_policy` smoke test

Signed-off-by: Andrew Kofink <akofink@redhat.com>