### PR TITLE
[RHICOMPL-1051] Lookup policy on profile clone

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -73,7 +73,6 @@ class Profile < ApplicationRecord
                                   policy_object: policy)
       new_profile.update_rules(ref_ids: rules.pluck(:ref_id))
     end
-    policy.hosts << host if policy && !policy.hosts.include?(host)
 
     new_profile
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -63,9 +63,10 @@ class Profile < ApplicationRecord
     parent_profile_id.blank?
   end
 
-  def clone_to(account: nil, host: nil, external: true,
-               policy: old_policy&.policy_object)
-    new_profile = in_account(account)
+  def clone_to(account: nil, host: nil, external: true, policy: nil)
+    policy ||= find_policy(hosts: [host], account: account)&.policy_object
+
+    new_profile = in_account(account, policy)
     if new_profile.nil?
       (new_profile = dup).update!(account: account,
                                   parent_profile: self,
@@ -77,8 +78,9 @@ class Profile < ApplicationRecord
     new_profile
   end
 
-  def in_account(account)
+  def in_account(account, policy)
     Profile.find_by(account: account, ref_id: ref_id,
+                    policy_object: policy,
                     benchmark_id: benchmark_id)
   end
 

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -399,36 +399,6 @@ class ProfileTest < ActiveSupport::TestCase
       profiles(:one).update!(policy_id: policies(:one).id)
     end
 
-    should 'create host relation when the profile is created' do
-      assert_difference('PolicyHost.count', 1) do
-        cloned_profile = profiles(:one).clone_to(
-          account: accounts(:one), host: hosts(:one),
-          policy: policies(:one).reload
-        )
-        assert hosts(:one).assigned_profiles.include?(cloned_profile)
-      end
-    end
-
-    should 'create host relation even if profile is already created' do
-      assert_difference('PolicyHost.count', 1) do
-        cloned_profile = profiles(:two).clone_to(
-          account: accounts(:one), host: hosts(:one),
-          policy: policies(:one).reload
-        )
-        assert hosts(:one).assigned_profiles.include?(cloned_profile)
-      end
-    end
-
-    should 'not create host relation if host is already in profile' do
-      PolicyHost.create!(policy: policies(:one), host: hosts(:one))
-      assert_difference('PolicyHost.count', 0) do
-        cloned_profile = profiles(:one).clone_to(
-          account: accounts(:one), host: hosts(:one),
-          policy: policies(:one).reload
-        )
-        assert hosts(:one).profiles.include?(cloned_profile)
-      end
-    end
 
     should 'set the parent profile ID to the original profile' do
       assert profiles(:one).canonical?


### PR DESCRIPTION
Lookup policy based on the host(s). Assign newly created profile into the found policy.

For Profile.clone_to it first finds the policy of the passed account.
The policy lookup up starts with the internal profile.

The internal profile:
* must have a policy that have the host assigned
* must be part of the account
* must match the ref_id of the (canonical) profile being cloned
* must match the benchmark ref_id of the profile being cloned

The last benchmark condition is there to ensure that the internal profile is
for the same major OS version.

The policy object is then retrieved from the internal profile.

The second step of the clone_to is to find an existing profile on that
policy.  The existing profile has to match the benchmark id.