### PR TITLE
[RHICOMPL-1054] Hosts API returns assigned and test_result profiles

### DIFF
--- a/app/serializers/host_serializer.rb
+++ b/app/serializers/host_serializer.rb
@@ -11,5 +11,7 @@ class HostSerializer
   end
 
   has_many :test_results
-  has_many :profiles
+  has_many :profiles do |host|
+    (host.assigned_profiles + host.test_result_profiles).uniq
+  end
 end


### PR DESCRIPTION
This is how this API behaved before we removed the ProfileHost
relationship. It's not super useful IMO, but it keeps the API
expectations unbroken.

Signed-off-by: Andrew Kofink <akofink@redhat.com>