### PR TITLE
[RHICOMPL-1062] GraphQL to use profile policy association

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -68,7 +68,9 @@ module Types
     field :major_os_version, String, null: false
 
     def policy
-      object.old_policy
+      return if object.canonical?
+
+      object.policy_object&.initial_profile
     end
 
     def compliant_host_count

--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -22,18 +22,6 @@ module ProfilePolicyAssociation
                       benchmarks: { ref_id: benchmark.ref_id })
     end
 
-    def old_policy(hosts: test_result_hosts)
-      find_policy(hosts: hosts) unless canonical?
-    end
-
-    def old_policy_profiles
-      return Profile.none if account_id.nil?
-
-      Profile.includes(:benchmark)
-             .where(account: account_id, ref_id: ref_id,
-                    benchmarks: { ref_id: benchmark.ref_id })
-    end
-
     def compliance_threshold
       policy_object&.compliance_threshold ||
         Policy::DEFAULT_COMPLIANCE_THRESHOLD

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -48,6 +48,11 @@ class Policy < ApplicationRecord
     benchmarks.first.os_major_version
   end
 
+  def initial_profile
+    # assuming that there is only one external=false profile in a policy
+    profiles.external(false).first
+  end
+
   def destroy_orphaned_business_objective
     bo_changes = (previous_changes.fetch(:business_objective_id, []) +
                   changes.fetch(:business_objective_id, [])).compact


### PR DESCRIPTION
The GraphQL Profile.policy will return the initial profile of the associated policy.

See also: https://github.com/RedHatInsights/compliance-backend/pull/622#discussion_r510953270