### PR TITLE
[RHICOMPL-1035] GraphQL: Pseudo-policy should inherit name and desc

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -67,10 +67,18 @@ module Types
 
     field :major_os_version, String, null: false
 
+    # Pseudo policy with a Profile type
+    # inheriting most of the attributes form the policy.
     def policy
-      return if object.canonical?
+      return if object.canonical? || object.policy_object.nil?
 
-      object.policy_object&.initial_profile
+      policy = object.policy_object
+      policy_profile = object.policy_object.initial_profile
+      policy_profile.assign_attributes(
+        name: policy.name,
+        description: policy.description
+      )
+      policy_profile
     end
 
     def compliant_host_count

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -91,10 +91,10 @@ class ProfileQueryTest < ActiveSupport::TestCase
 
     assert_equal profiles(:one).id,
                  result['data']['profile']['policy']['id']
-    assert_equal profiles(:one).name,
-                 result['data']['profile']['policy']['name']
     assert_equal profiles(:one).ref_id,
                  result['data']['profile']['policy']['refId']
+    assert_equal policies(:one).name,
+                 result['data']['profile']['policy']['name']
   end
 
   test 'query all profiles' do


### PR DESCRIPTION
The pseudo-policy returned on the GraphQL for a profile should inherint
name and description from the policy.
The database records of profiles are keeping the original names and
descriptions (from their parent profiles).
This allows to use the `Profile.name` as policy/profile type, and
`Profile.policy.name` as the policy title (user defined).

Note, that REST API returns name and description of profiles from their
policies.  The policy/profile type on the REST API can be retrieved by
requesting canonical profiles based using the `parent_profile_id`.