### PR TITLE
[RHICOMPL-1053] Return policy profiles on GraphQL

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -102,6 +102,7 @@ type Profile implements Node & RulesPreload {
   majorOsVersion: String!
   name: String!
   policy: Profile
+  profiles: [Profile!]
   refId: String!
   rules(
     """

--- a/app/graphql/types/concerns/profile_pseudo_policy.rb
+++ b/app/graphql/types/concerns/profile_pseudo_policy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  # Methods related to support pseudo-policy
+  module ProfilePseudoPolicy
+    extend ActiveSupport::Concern
+
+    # Pseudo policy with a Profile type
+    # inheriting most of the attributes form the policy.
+    def policy
+      return if object.canonical? || object.policy_object.nil?
+
+      policy = object.policy_object
+      policy_profile = object.policy_object.initial_profile
+      policy_profile.assign_attributes(
+        name: policy.name,
+        description: policy.description
+      )
+      policy_profile
+    end
+  end
+end

--- a/app/graphql/types/concerns/profile_pseudo_policy.rb
+++ b/app/graphql/types/concerns/profile_pseudo_policy.rb
@@ -18,5 +18,12 @@ module Types
       )
       policy_profile
     end
+
+    # policy profiles
+    def profiles
+      return if object.canonical?
+
+      object.policy_object&.profiles
+    end
   end
 end

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -2,11 +2,13 @@
 
 require_relative 'interfaces/rules_preload'
 require_relative 'concerns/test_results'
+require_relative 'concerns/profile_pseudo_policy'
 
 module Types
   # Definition of the Profile type in GraphQL
   class Profile < Types::BaseObject
     include TestResults
+    include ProfilePseudoPolicy
 
     implements(::RulesPreload)
 
@@ -66,20 +68,6 @@ module Types
     field :compliant_host_count, Int, null: false
 
     field :major_os_version, String, null: false
-
-    # Pseudo policy with a Profile type
-    # inheriting most of the attributes form the policy.
-    def policy
-      return if object.canonical? || object.policy_object.nil?
-
-      policy = object.policy_object
-      policy_profile = object.policy_object.initial_profile
-      policy_profile.assign_attributes(
-        name: policy.name,
-        description: policy.description
-      )
-      policy_profile
-    end
 
     def compliant_host_count
       ::CollectionLoader.for(object.class, :hosts).load(object).then do |hosts|

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -23,6 +23,7 @@ module Types
     field :benchmark_id, ID, null: false
     field :account_id, ID, null: false
     field :policy, Types::Profile, null: true
+    field :profiles, [::Types::Profile], null: true
     field :rules, [::Types::Rule], null: true, extras: [:lookahead] do
       argument :system_id, String,
                'System ID to filter by', required: false


### PR DESCRIPTION
Policy profiles are to be queried on a profile's policy.
All policy profiles are returned including the internal/initial profile.

Recommended way of querying:
```
  query Profile($anyPolicyProfileId: String!){
      profile(id: $anyPolicyProfileId) {
          policy {
              profiles {
		  id
                  ssgVersion  # to be added
                  rules {
                      id
                  }
              }
          }
      }
  }
```

Note, that there can be a case when an internal profile would be the same
as its policy (since there is no Policy GraphQL type, yet) and would be
also found in the list of policy profiles.