### PR TITLE
[RHICOMPL-1063] Return all system's profiles on GraphQL

### DIFF
--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -27,7 +27,7 @@ module Types
 
     def profiles
       context_parent
-      object.profiles
+      object.all_profiles
     end
 
     def rules_passed(args = {})

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -28,6 +28,10 @@ class Host < ApplicationRecord
   validates :name, presence: true
   validates :account, presence: true
 
+  def all_profiles
+    (assigned_profiles + test_result_profiles).uniq
+  end
+
   class << self
     def filter_by_compliance(_filter, operator, value)
       ids = Host.includes(test_results: :profile).select do |host|

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -22,7 +22,6 @@ class Host < ApplicationRecord
   has_many :profile_host_profiles, through: :profile_hosts, source: :profile
   has_many :test_result_profiles, through: :test_results, source: :profile
   has_many :policies, through: :policy_hosts
-  has_many :profiles, through: :policies, source: :profiles
   has_many :assigned_profiles, through: :policies, source: :profiles
 
   validates :name, presence: true
@@ -49,7 +48,7 @@ class Host < ApplicationRecord
     end
 
     def filter_by_compliance_score(_filter, operator, score)
-      ids = Host.includes(:profiles).select do |host|
+      ids = Host.includes(:test_result_profiles).select do |host|
         host.compliance_score.public_send(operator, score.to_f)
       end
       ids = ids.pluck(:id).map { |id| "'#{id}'" }

--- a/app/serializers/host_serializer.rb
+++ b/app/serializers/host_serializer.rb
@@ -11,7 +11,10 @@ class HostSerializer
   end
 
   has_many :test_results
+
+  # rubocop:disable Style/SymbolProc
   has_many :profiles do |host|
-    (host.assigned_profiles + host.test_result_profiles).uniq
+    host.all_profiles
   end
+  # rubocop:enable Style/SymbolProc
 end

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -133,7 +133,8 @@ class SystemQueryTest < ActiveSupport::TestCase
     hosts.each do |graphql_host|
       host = Host.find(graphql_host['node']['id'])
       graphql_host['node']['profiles'].each do |graphql_profile|
-        assert host.profiles.map(&:name).include? graphql_profile['name']
+        assert_includes host.assigned_profiles.map(&:name),
+                        graphql_profile['name']
         profile = Profile.find(graphql_profile['id'])
         assert_equal host.rules_passed(profile), graphql_profile['rulesPassed']
         assert_equal host.rules_failed(profile), graphql_profile['rulesFailed']
@@ -256,7 +257,7 @@ class SystemQueryTest < ActiveSupport::TestCase
     assert_not_equal users(:test).account.hosts.count,
                      result['systems']['totalCount']
     assert_equal 1, result['systems']['totalCount']
-    assert graphql_host.profiles.pluck(:id).include?(profiles(:one).id)
+    assert graphql_host.assigned_profiles.pluck(:id).include?(profiles(:one).id)
   end
 
   test 'query system rules when results contain wrong rule_ids' do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -11,10 +11,23 @@ class HostTest < ActiveSupport::TestCase
   should have_many(:policy_hosts)
   should have_many(:test_results)
   should have_many(:policies).through(:policy_hosts)
-  should have_many(:profiles).through(:policies).source(:profiles)
   should have_many(:assigned_profiles).through(:policies).source(:profiles)
+  should have_many(:test_result_profiles).through(:test_results)
   should validate_presence_of :name
   should validate_presence_of :account
+
+  test 'host provides all profiles, assigned and from test results' do
+    host = hosts(:one)
+    policies(:one).update!(account: host.account)
+    policies(:one).hosts << host
+
+    profiles(:one).update!(account: host.account, policy_object: policies(:one))
+    test_results(:two).update!(host: host, profile: profiles(:two))
+
+    assert_equal host.all_profiles.count, 2
+    assert_includes host.all_profiles.map(&:id), profiles(:one).id
+    assert_includes host.all_profiles.map(&:id), profiles(:two).id
+  end
 
   test 'compliant returns a hash with all compliance statuses' do
     host = hosts(:one)


### PR DESCRIPTION
GraphQL will return all system profiles, consisting of assigned profiles (through a policy) and profiles from test results. 
This should fix showing failed rules on external reports.

Redundant `Host.profiles` association is being dropped in favor of `associated_profiles`, `test_result_profiles` and combined
`all_profiles`.

