### PR TITLE
[RHICOMPL-1074] Internal/main policy profile deletes whole policy

### DIFF
--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -26,7 +26,15 @@ module V1
 
     def destroy
       authorize profile
-      render_json profile.destroy, status: :accepted
+
+      destroyed =
+        if profile.external?
+          profile.destroy
+        else
+          profile.destroy_with_policy
+        end
+
+      render_json destroyed, status: :accepted
     end
 
     def create

--- a/app/graphql/mutations/profile/delete.rb
+++ b/app/graphql/mutations/profile/delete.rb
@@ -10,13 +10,18 @@ module Mutations
       field :profile, Types::Profile, null: false
 
       def resolve(args = {})
-        profile = Pundit.authorize(
-          context[:current_user],
-          ::Profile.find(args[:id]),
-          :destroy?
-        )
-        profile.destroy!
-        { profile: profile }
+        profile = Pundit.authorize(context[:current_user],
+                                   ::Profile.find(args[:id]),
+                                   :destroy?)
+
+        destroyed =
+          if profile.external?
+            profile.destroy
+          else
+            profile.destroy_with_policy
+          end
+
+        { profile: destroyed }
       end
     end
   end

--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -27,6 +27,14 @@ module ProfilePolicyAssociation
         Policy::DEFAULT_COMPLIANCE_THRESHOLD
     end
 
+    def destroy_with_policy
+      transaction do
+        destroyed = destroy
+        destroyed&.policy_object&.destroy
+        destroyed
+      end
+    end
+
     def destroy_empty_policy
       policy_object.destroy if policy_object&.profiles&.empty?
     end

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -151,6 +151,21 @@ module V1
                      'Profile ID did not match deleted profile'
       end
 
+      test 'destroing internal profile detroys its policy with profiles' do
+        profiles(:two).update!(account: accounts(:one),
+                               external: true,
+                               policy_id: policies(:one).id)
+
+        profile_id = profiles(:one).id
+        assert_difference('Profile.count' => -2, 'Policy.count' => -1) do
+          delete v1_profile_path(profile_id)
+        end
+        assert_response :success
+        assert_equal 202, response.status, 'Response should be 202 accepted'
+        assert_equal profile_id, JSON.parse(response.body).dig('data', 'id'),
+                     'Profile ID did not match deleted profile'
+      end
+
       test 'destroy a non-existant profile' do
         profile_id = profiles(:one).id
         profiles(:one).destroy

--- a/test/graphql/mutations/delete_profile_mutation_test.rb
+++ b/test/graphql/mutations/delete_profile_mutation_test.rb
@@ -28,4 +28,68 @@ class DeleteProfileMutationTest < ActiveSupport::TestCase
       assert_equal profiles(:one).id, result['id']
     end
   end
+
+  test 'deleting internal profile detroys its policy with profiles' do
+    query = <<-GRAPHQL
+        mutation DeleteProfile($input: deleteProfileInput!) {
+            deleteProfile(input: $input) {
+                profile {
+                    id
+                }
+            }
+        }
+    GRAPHQL
+
+    users(:test).update account: accounts(:test)
+    profiles(:one).update!(account: accounts(:test),
+                           policy_id: policies(:one).id)
+
+    profiles(:two).update!(account: accounts(:test),
+                           external: true,
+                           policy_id: policies(:one).id)
+
+    profile_id = profiles(:one).id
+    assert_difference('Profile.count' => -2, 'Policy.count' => -1) do
+      result = Schema.execute(
+        query,
+        variables: { input: {
+          id: profile_id
+        } },
+        context: { current_user: users(:test) }
+      )['data']['deleteProfile']['profile']
+      assert_equal profile_id, result['id']
+    end
+  end
+
+  test 'deleting other policy profile keeps policy and its profiles' do
+    query = <<-GRAPHQL
+        mutation DeleteProfile($input: deleteProfileInput!) {
+            deleteProfile(input: $input) {
+                profile {
+                    id
+                }
+            }
+        }
+    GRAPHQL
+
+    users(:test).update account: accounts(:test)
+    profiles(:one).update!(account: accounts(:test),
+                           policy_id: policies(:one).id)
+
+    profiles(:two).update!(account: accounts(:test),
+                           external: true,
+                           policy_id: policies(:one).id)
+
+    profile_id = profiles(:two).id
+    assert_difference('Profile.count' => -1, 'Policy.count' => 0) do
+      result = Schema.execute(
+        query,
+        variables: { input: {
+          id: profile_id
+        } },
+        context: { current_user: users(:test) }
+      )['data']['deleteProfile']['profile']
+      assert_equal profile_id, result['id']
+    end
+  end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -196,6 +196,33 @@ class ProfileTest < ActiveSupport::TestCase
         profiles(:one).destroy
       end
     end
+
+    should 'destroy with policy having one profile' do
+      assert_difference('Profile.count' => -1, 'Policy.count' => -1) do
+        destroyed = profiles(:one).destroy_with_policy
+        assert_equal destroyed, profiles(:one)
+      end
+    end
+
+    should 'destroy with policy having more profiles' do
+      profiles(:two).update!(account: accounts(:one),
+                             external: true,
+                             policy_id: policies(:one).id)
+
+      assert_difference('Profile.count' => -2, 'Policy.count' => -1) do
+        destroyed = profiles(:one).destroy_with_policy
+        assert_equal destroyed, profiles(:one)
+      end
+    end
+
+    should 'destroy with policy when profile has no policy' do
+      profiles(:one).update!(policy_id: nil)
+
+      assert_difference('Profile.count' => -1, 'Policy.count' => 0) do
+        destroyed = profiles(:one).destroy_with_policy
+        assert_equal destroyed, profiles(:one)
+      end
+    end
   end
 
   test 'canonical profiles have no parent_profile_id' do


### PR DESCRIPTION
**Option 1**

Removal of an internal/main profile (`external=false`) of a policy would
remove its policy with all dependent profiles (`external=true`).

Pros:
* no change needed for UI
* other SSG profiles (with tailoring) on a policy could be removed individually

Cons:
* more than one (same-type) REST resource would be removed
* IQE would need to know which profiles are part of which policy (RHICOMPL-1078)
* main policy profile/SSG could not be removed individually without removing all policy profiles
* this behavior would likely change if the v2 API would be created with real policy type/resource
