### PR TITLE
[RHICOMPL-1074] Internal/main policy profile deletes whole policy via callback

### DIFF
--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -5,6 +5,7 @@ module ProfilePolicyAssociation
   extend ActiveSupport::Concern
 
   included do
+    after_destroy :destroy_policy_with_internal
     after_destroy :destroy_empty_policy
 
     belongs_to :policy_object, class_name: :Policy, foreign_key: :policy_id,
@@ -25,6 +26,10 @@ module ProfilePolicyAssociation
     def compliance_threshold
       policy_object&.compliance_threshold ||
         Policy::DEFAULT_COMPLIANCE_THRESHOLD
+    end
+
+    def destroy_policy_with_internal
+      policy_object&.destroy unless external?
     end
 
     def destroy_empty_policy

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -151,6 +151,21 @@ module V1
                      'Profile ID did not match deleted profile'
       end
 
+      test 'destroing internal profile detroys its policy with profiles' do
+        profiles(:two).update!(account: accounts(:one),
+                               external: true,
+                               policy_id: policies(:one).id)
+
+        profile_id = profiles(:one).id
+        assert_difference('Profile.count' => -2, 'Policy.count' => -1) do
+          delete v1_profile_path(profile_id)
+        end
+        assert_response :success
+        assert_equal 202, response.status, 'Response should be 202 accepted'
+        assert_equal profile_id, JSON.parse(response.body).dig('data', 'id'),
+                     'Profile ID did not match deleted profile'
+      end
+
       test 'destroy a non-existant profile' do
         profile_id = profiles(:one).id
         profiles(:one).destroy

--- a/test/graphql/mutations/delete_profile_mutation_test.rb
+++ b/test/graphql/mutations/delete_profile_mutation_test.rb
@@ -28,4 +28,68 @@ class DeleteProfileMutationTest < ActiveSupport::TestCase
       assert_equal profiles(:one).id, result['id']
     end
   end
+
+  test 'deleting internal profile detroys its policy with profiles' do
+    query = <<-GRAPHQL
+        mutation DeleteProfile($input: deleteProfileInput!) {
+            deleteProfile(input: $input) {
+                profile {
+                    id
+                }
+            }
+        }
+    GRAPHQL
+
+    users(:test).update account: accounts(:test)
+    profiles(:one).update!(account: accounts(:test),
+                           policy_id: policies(:one).id)
+
+    profiles(:two).update!(account: accounts(:test),
+                           external: true,
+                           policy_id: policies(:one).id)
+
+    profile_id = profiles(:one).id
+    assert_difference('Profile.count' => -2, 'Policy.count' => -1) do
+      result = Schema.execute(
+        query,
+        variables: { input: {
+          id: profile_id
+        } },
+        context: { current_user: users(:test) }
+      )['data']['deleteProfile']['profile']
+      assert_equal profile_id, result['id']
+    end
+  end
+
+  test 'deleting other policy profile keeps policy and its profiles' do
+    query = <<-GRAPHQL
+        mutation DeleteProfile($input: deleteProfileInput!) {
+            deleteProfile(input: $input) {
+                profile {
+                    id
+                }
+            }
+        }
+    GRAPHQL
+
+    users(:test).update account: accounts(:test)
+    profiles(:one).update!(account: accounts(:test),
+                           policy_id: policies(:one).id)
+
+    profiles(:two).update!(account: accounts(:test),
+                           external: true,
+                           policy_id: policies(:one).id)
+
+    profile_id = profiles(:two).id
+    assert_difference('Profile.count' => -1, 'Policy.count' => 0) do
+      result = Schema.execute(
+        query,
+        variables: { input: {
+          id: profile_id
+        } },
+        context: { current_user: users(:test) }
+      )['data']['deleteProfile']['profile']
+      assert_equal profile_id, result['id']
+    end
+  end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -190,6 +190,16 @@ class ProfileTest < ActiveSupport::TestCase
       end
     end
 
+    should 'also destroys its policy having more profiles' do
+      profiles(:two).update!(account: accounts(:one),
+                             external: true,
+                             policy_id: policies(:one).id)
+
+      assert_difference('Profile.count' => -2, 'Policy.count' => -1) do
+        profiles(:one).destroy
+      end
+    end
+
     should 'also destroys its related test results' do
       test_results(:one).update profile: profiles(:one), host: hosts(:one)
       assert_difference('Profile.count' => -1, 'TestResult.count' => -1) do


### PR DESCRIPTION
**Option 1** (via callback)

Removal of an internal/main profile (`external=false`) of a policy would
remove its policy with all dependent profiles (`external=true`).

The callback is used to guarantee data sanity, eg. when a benchmark is destroyed.

Pros:
* no change needed for UI
* other SSG profiles (with tailoring) on a policy could be removed individually

Cons:
* more than one (same-type) REST resource would be removed
* IQE would need to know which profiles are part of which policy (RHICOMPL-1078)
* main policy profile/SSG could not be removed individually without removing all policy profiles
* this behavior would likely change if the v2 API would be created with real policy type/resource

