### PR TITLE
[RHICOMPL-1070] Allow unsetting the business objective via GQL

### DIFF
--- a/app/graphql/mutations/profile/edit.rb
+++ b/app/graphql/mutations/profile/edit.rb
@@ -19,7 +19,7 @@ module Mutations
 
       def resolve(args = {})
         profile = authorized_profile(args)
-        profile.policy_object.update(args.compact.slice(*POLICY_ATTRIBUTES))
+        profile.policy_object.update(args.slice(*POLICY_ATTRIBUTES))
         { profile: profile }
       end
 

--- a/test/graphql/mutations/edit_policy_mutation_test.rb
+++ b/test/graphql/mutations/edit_policy_mutation_test.rb
@@ -36,4 +36,33 @@ class EditPolicyMutationTest < ActiveSupport::TestCase
     assert_equal business_objectives(:one).id, result['businessObjectiveId']
     assert_equal 80.0, result['complianceThreshold']
   end
+
+  test 'unset the business objective' do
+    query = <<-GRAPHQL
+        mutation updateProfile($input: UpdateProfileInput!) {
+            updateProfile(input: $input) {
+                profile {
+                    businessObjectiveId
+                }
+            }
+        }
+    GRAPHQL
+
+    users(:test).update account: accounts(:test)
+    policies(:one).update!(business_objective: business_objectives(:one))
+    profiles(:one).update(account: accounts(:test),
+                          hosts: [hosts(:one)],
+                          policy_object: policies(:one))
+
+    Schema.execute(
+      query,
+      variables: { input: {
+        id: profiles(:one).id,
+        businessObjectiveId: nil
+      } },
+      context: { current_user: users(:test) }
+    )['data']['updateProfile']['profile']
+
+    assert_nil policies(:one).reload.business_objective
+  end
 end


### PR DESCRIPTION
via GraphQL. Sending null as the business_objective_id will now unset
the business objective from the profile's policy.

Signed-off-by: Andrew Kofink <akofink@redhat.com>