### PR TITLE
[RHICOMPL-841] Prevent creating policies with duplicate types

### DIFF
--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -59,6 +59,18 @@ class ProfileTest < ActiveSupport::TestCase
     end
   end
 
+  test 'uniqness of policy profiles by policy type' do
+    (bm = benchmarks(:one).dup).update!(version: '123')
+    profiles(:one).update!(policy_id: policies(:one).id,
+                           parent_profile: profiles(:two))
+    assert profiles(:one).policy_id
+    assert_not profiles(:one).external
+
+    p = profiles(:one).dup
+    assert_not p.update(policy_id: policies(:two).id, benchmark: bm)
+    assert  p.errors.full_messages.join['Policy type must be unique']
+  end
+
   test 'coexistence of external profiles with and without a policy' do
     dupe1 = profiles(:one).dup
     dupe1.update!(external: true, policy_id: policies(:one).id)

--- a/test/services/copy_profiles_to_policies_test.rb
+++ b/test/services/copy_profiles_to_policies_test.rb
@@ -45,7 +45,7 @@ class CopyProfilesToPoliciesTest < ActiveSupport::TestCase
 
   test 'copies two similar internal profiles with to two new policies' do
     first = profiles(:one)
-    (bm = benchmarks(:one).dup).update!(version: '0.1.46')
+    (bm = benchmarks(:one).dup).update!(version: '0.1.46', ref_id: 'bm1')
     (second = profiles(:one).dup).update!(parent_profile: profiles(:two),
                                           account: accounts(:test),
                                           benchmark: bm)

--- a/test/services/duplicate_benchmark_resolver_test.rb
+++ b/test/services/duplicate_benchmark_resolver_test.rb
@@ -112,7 +112,7 @@ class DuplicateBenchmarkResolverTest < ActiveSupport::TestCase
     assert_difference('Profile.count' => 4) do
       parent.update!(ref_id: 'foo', benchmark: benchmarks(:one))
       p.update!(ref_id: 'foo2', benchmark: benchmarks(:one),
-                account: accounts(:one), parent_profile_id: parent.id)
+                account: accounts(:test), parent_profile_id: parent.id)
 
       dup_parent.update!(ref_id: 'foo',
                          benchmark: @dup_benchmark)


### PR DESCRIPTION
A new validation that happens only on create that ensures no other policy exists in the same account with the same policy type. Policy type is currently just the associated profiles' ref_ids. To test:

1. Create a RHEL 7 HIPAA policy in the UI
2. Import another RHEL 7 benchmark with a different SSG version
3. Create another policy via the REST API and select the new benchmark's HIPAA canonical profile as the parent profile

Before:
The API allows the action, and the policies UI displays two HIPAA policies

After:
The API detects a duplicate policy type and errors

Signed-off-by: Andrew Kofink <akofink@redhat.com>