### PR TITLE
[RHICOMPL-1083] Host policy_id filter finds external profile via results 

### DIFF
--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -88,7 +88,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     result = Schema.execute(
       query,
-      variables: { search: "profile_id = #{profiles(:one).id}" },
+      variables: { search: "policy_id = #{profiles(:one).id}" },
       context: { current_user: users(:test) }
     )['data']['systems']['edges']
 
@@ -250,7 +250,7 @@ class SystemQueryTest < ActiveSupport::TestCase
     setup_two_hosts
     result = Schema.execute(
       query,
-      variables: { search: "profile_id = #{profiles(:one).id}" },
+      variables: { search: "policy_id = #{profiles(:one).id}" },
       context: { current_user: users(:test) }
     )['data']
     graphql_host = Host.find(result['systems']['edges'].first['node']['id'])


### PR DESCRIPTION
This fixes a bug for the frontend, where the policy_id is used to
retrieve hosts for an external profile.