### PR TITLE
feat(RHICOMPL-1086): Delete old test results within a policy

### DIFF
--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -18,7 +18,9 @@ module Xccdf
     end
 
     def delete_old_test_results
-      ::TestResult.where(host: @host, profile: @host_profile)
+      ::TestResult.left_outer_joins(profile: :policy_object)
+                  .where(profiles: { policy_object: @host_profile.policy_id },
+                         host: @host)
                   .where.not(id: @test_result.id)
                   .destroy_all
     end

--- a/test/services/concerns/xccdf/test_result_test.rb
+++ b/test/services/concerns/xccdf/test_result_test.rb
@@ -7,7 +7,7 @@ class TestResultTest < ActiveSupport::TestCase
   class Mock
     include Xccdf::TestResult
 
-    attr_accessor :host, :host_profile, :op_test_result
+    attr_accessor :host, :host_profile, :op_test_result, :test_result
   end
 
   setup do
@@ -37,5 +37,49 @@ class TestResultTest < ActiveSupport::TestCase
     assert_difference('TestResult.count' => -1) do
       @mock.save_test_result
     end
+  end
+
+  test 'old test results within a policy replaced by the new test result' do
+    profiles(:two).update!(policy_object: policies(:one),
+                           account: accounts(:test))
+    profiles(:one).update!(policy_object: policies(:one),
+                           account: accounts(:test))
+    TestResult.where(host: hosts(:one), profile: profiles(:one)).destroy_all
+
+    assert_difference('TestResult.count' => 2) do
+      TestResult.create!(host: hosts(:one),
+                         profile: profiles(:one),
+                         end_time: @end_time - 3.minutes)
+
+      TestResult.create!(host: hosts(:one),
+                         profile: profiles(:two),
+                         end_time: @end_time - 8.minutes)
+    end
+
+    assert_difference('TestResult.count' => -1) do
+      @mock.save_test_result
+    end
+    assert_equal TestResult.find_by(host: hosts(:one)), @mock.test_result
+  end
+
+  test 'old external test results are replaced by the new test result' do
+    profiles(:two).update!(policy_object: nil, account: accounts(:test))
+    profiles(:one).update!(policy_object: nil, account: accounts(:test))
+    TestResult.where(host: hosts(:one), profile: profiles(:one)).destroy_all
+
+    assert_difference('TestResult.count' => 2) do
+      TestResult.create!(host: hosts(:one),
+                         profile: profiles(:one),
+                         end_time: @end_time - 3.minutes)
+
+      TestResult.create!(host: hosts(:one),
+                         profile: profiles(:two),
+                         end_time: @end_time - 8.minutes)
+    end
+
+    assert_difference('TestResult.count' => -1) do
+      @mock.save_test_result
+    end
+    assert_equal TestResult.find_by(host: hosts(:one)), @mock.test_result
   end
 end


### PR DESCRIPTION
Old test results that are within the same policy for a host will now be
removed when new test results are imported for that host. The same will
happen outside of a policy (i.e. with external reports). The old
behavior would not clean up test reports across SSG versions, but this
new version does.

Signed-off-by: Andrew Kofink <akofink@redhat.com>