### PR TITLE
feat(RHICOMPL-1078): Expose policy profile ID on profile

### DIFF
--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -14,6 +14,14 @@ module ProfilePolicyAssociation
              to: :policy_object, allow_nil: true
     validate :no_duplicate_policy_types, on: :create
 
+    def policy_profile
+      policy_object&.initial_profile
+    end
+
+    def policy_profile_id
+      policy_profile&.id
+    end
+
     def no_duplicate_policy_types
       return if canonical? || external
 

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -13,7 +13,8 @@ class ProfileSerializer
   end
   has_many :test_results
   attributes :ref_id, :score, :parent_profile_id,
-             :external, :compliance_threshold, :os_major_version
+             :external, :compliance_threshold, :os_major_version,
+             :policy_profile_id
   attribute :parent_profile_ref_id do |profile|
     profile.parent_profile&.ref_id
   end

--- a/spec/api/v1/schemas/profiles.rb
+++ b/spec/api/v1/schemas/profiles.rb
@@ -65,6 +65,10 @@ module Api
               type: 'boolean',
               example: false
             },
+            policy_profile_id: {
+              type: 'uuid',
+              example: '374399b7-e6ba-49b7-a405-9b620a2bd0b3'
+            },
             total_host_count: {
               type: 'integer',
               example: 5

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -621,6 +621,7 @@
                       "external": false,
                       "compliance_threshold": 100.0,
                       "os_major_version": "7",
+                      "policy_profile_id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
                       "parent_profile_ref_id": null,
                       "name": "profile1",
                       "description": null,
@@ -670,6 +671,7 @@
                       "external": false,
                       "compliance_threshold": 100.0,
                       "os_major_version": "7",
+                      "policy_profile_id": "37f7eeff-831b-5c41-984a-254965f58c0f",
                       "parent_profile_ref_id": null,
                       "name": "profile2",
                       "description": null,
@@ -781,7 +783,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "4bde0dc1-a96a-4620-b8d0-57b9d0c55b31",
+                  "id": "ec7932de-2dbe-429a-98cf-f74731daf39c",
                   "type": "profile",
                   "attributes": {
                     "ref_id": "xccdf_org.ssgproject.profile2",
@@ -790,6 +792,7 @@
                     "external": false,
                     "compliance_threshold": 93.5,
                     "os_major_version": "7",
+                    "policy_profile_id": "ec7932de-2dbe-429a-98cf-f74731daf39c",
                     "parent_profile_ref_id": "xccdf_org.ssgproject.profile2",
                     "name": "A custom name",
                     "description": null,
@@ -1006,6 +1009,7 @@
                     "external": false,
                     "compliance_threshold": 100.0,
                     "os_major_version": "7",
+                    "policy_profile_id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
                     "parent_profile_ref_id": null,
                     "name": "profile1",
                     "description": null,
@@ -1019,7 +1023,7 @@
                   "relationships": {
                     "account": {
                       "data": {
-                        "id": "015a9962-782d-40d0-8c02-f5e7ec3eac11",
+                        "id": "23725ef6-056d-417f-88ea-75697529f51e",
                         "type": "account"
                       }
                     },
@@ -1196,7 +1200,7 @@
             "examples": {
               "application/vnd.api+json": {
                 "data": {
-                  "id": "ab51ba5a-8434-44be-a070-34f15acfd406",
+                  "id": "df2943f9-eb01-4964-aa0e-cf1d1e4614e2",
                   "type": "profile",
                   "attributes": {
                     "ref_id": "xccdf_org.ssgproject.profile2",
@@ -1205,6 +1209,7 @@
                     "external": false,
                     "compliance_threshold": 93.5,
                     "os_major_version": "7",
+                    "policy_profile_id": "df2943f9-eb01-4964-aa0e-cf1d1e4614e2",
                     "parent_profile_ref_id": "xccdf_org.ssgproject.profile2",
                     "name": "An updated custom name",
                     "description": null,
@@ -1427,6 +1432,7 @@
                     "external": false,
                     "compliance_threshold": 100.0,
                     "os_major_version": "7",
+                    "policy_profile_id": "aa67c98c-d81f-5a9c-b0bc-26caa0051aea",
                     "parent_profile_ref_id": "xccdf_org.ssgproject.profile2",
                     "name": "profile1",
                     "description": null,
@@ -2898,6 +2904,10 @@
           "tailored": {
             "type": "boolean",
             "example": false
+          },
+          "policy_profile_id": {
+            "type": "uuid",
+            "example": "374399b7-e6ba-49b7-a405-9b620a2bd0b3"
           },
           "total_host_count": {
             "type": "integer",

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -49,6 +49,19 @@ module V1
     end
 
     class IndexTest < ProfilesControllerTest
+      test 'policy_profile_id is exposed' do
+        profiles(:one).update!(external: false,
+                               parent_profile: profiles(:two),
+                               account: accounts(:test))
+        get v1_profiles_url
+        assert_response :success
+
+        profiles = JSON.parse(response.body)
+        assert_equal 1, profiles['data'].length
+        assert_equal profiles(:one).policy_profile_id,
+                     profiles.dig('data', 0, 'attributes', 'policy_profile_id')
+      end
+
       test 'external profiles can be requested' do
         profiles(:one).update! external: true
         search_query = 'external=true'

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -94,6 +94,16 @@ class ProfileTest < ActiveSupport::TestCase
     assert dupe.policy_id
   end
 
+  test 'policy_profile finds the initial profile of a policy' do
+    profiles(:two).update!(account: accounts(:test), policy_object: nil)
+    assert_nil profiles(:two).policy_profile
+    profiles(:one).update!(policy_object: policies(:one), external: false)
+    assert_equal profiles(:one), profiles(:one).policy_profile
+    profiles(:two).update!(policy_object: policies(:one), external: true)
+    assert_equal profiles(:one), profiles(:one).policy_profile
+    assert_equal profiles(:one), profiles(:two).policy_profile
+  end
+
   test 'creation of internal profile with a policy, external profile exists' do
     profiles(:one).update!(external: true)
     dupe = profiles(:one).dup


### PR DESCRIPTION
For both graphql and REST. The policy profile is the initial profile on
a policy. Profiles without policies will return their own ID as the
policy profile ID to support 'external policies'.

Signed-off-by: Andrew Kofink <akofink@redhat.com>