### PR TITLE
[RHICOMPL-1027] Filter System profiles by policyId on GraphQL

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -368,7 +368,12 @@ type System implements Node {
   name: String!
   osMajorVersion: Int
   osMinorVersion: Int
-  profiles: [Profile!]
+  profiles(
+    """
+    Filter results by policy or profile ID
+    """
+    policyId: ID
+  ): [Profile!]
   rulesFailed(
     """
     Filter results by profile ID

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -11,7 +11,10 @@ module Types
     field :name, String, null: false
     field :os_major_version, Int, null: true
     field :os_minor_version, Int, null: true
-    field :profiles, [::Types::Profile], null: true
+    field :profiles, [::Types::Profile], null: true do
+      argument :policy_id, ID, 'Filter results by policy or profile ID',
+               required: false
+    end
     field :rules_passed, Int, null: false do
       argument :profile_id, String, 'Filter results by profile ID',
                required: false
@@ -25,9 +28,11 @@ module Types
                required: false
     end
 
-    def profiles
+    def profiles(policy_id: nil)
       context_parent
-      object.all_profiles
+      all_profiles = object.all_profiles
+      all_profiles = all_profiles.in_policy(policy_id) if policy_id
+      all_profiles
     end
 
     def rules_passed(args = {})

--- a/app/models/concerns/profile_searching.rb
+++ b/app/models/concerns/profile_searching.rb
@@ -59,6 +59,24 @@ module ProfileSearching
     scope :os_major_version, lambda { |major, equals = true|
       where(benchmark: Xccdf::Benchmark.os_major_version(major, equals))
     }
+    scope :in_policy, lambda { |policy_or_profile_id|
+      return none unless UUID.validate(policy_or_profile_id)
+
+      policy_cond = { policy_id: policy_or_profile_id }
+      profile_cond = {
+        policy_object: {
+          profiles_policies: {
+            id: policy_or_profile_id
+          }
+        }
+      }
+
+      search = left_outer_joins(policy_object: :profiles)
+      search.where(id: policy_or_profile_id)
+            .or(search.where(policy_cond))
+            .or(search.where(profile_cond))
+            .distinct
+    }
   end
 
   class_methods do

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -30,7 +30,9 @@ class Host < ApplicationRecord
   validates :account, presence: true
 
   def all_profiles
-    (assigned_profiles + test_result_profiles).uniq
+    Profile.where(id: assigned_profiles)
+           .or(Profile.where(id: test_result_profiles))
+           .distinct
   end
 
   class << self

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -60,6 +60,7 @@ class SystemQueryTest < ActiveSupport::TestCase
                     id
                     name
                     profiles {
+                        id
                         rulesPassed
                         rulesFailed
                         lastScanned
@@ -93,11 +94,19 @@ class SystemQueryTest < ActiveSupport::TestCase
     )['data']['systems']['edges']
 
     result_profiles = result.first['node']['profiles']
+    assert_equal 2, result_profiles.length
 
-    assert_equal 1, result_profiles.first['rulesPassed']
-    assert_equal 0, result_profiles.first['rulesFailed']
-    assert result_profiles.first['lastScanned']
-    assert result_profiles.first['compliant']
+    passed_profile = result_profiles.find { |p| p['id'] == profiles(:one).id }
+    assert_equal 1, passed_profile['rulesPassed']
+    assert_equal 0, passed_profile['rulesFailed']
+    assert passed_profile
+    assert passed_profile
+
+    failed_profile = result_profiles.find { |p| p['id'] == profiles(:two).id }
+    assert_equal 0, failed_profile['rulesPassed']
+    assert_equal 1, failed_profile['rulesFailed']
+    assert failed_profile
+    assert failed_profile
   end
 
   test 'query children profile only returns profiles owned by host' do


### PR DESCRIPTION
First, it introduces scope `in_policy` on Profile for querying profiles under a policy, by providing:
* the exact profile id
* any policy profile id (returns/scopes all policy profiles)
* policy id (returns/scopes all policy profiles)

Adds possibility to custom scoping of Host.all_profiles by returning an `ActiveRecord::Relation`.

And finally it adds an argument `policyId` on field `profiles` of `Systems` GraphQL type.
Provided `policyId` would filter system's assigned profiles and profiles from test results.
The behavior of filtering is the same as for the scope `policy_bunch` (on `Profile` model).

Review Recommendation: go by commits.
