### PR TITLE
feat(RHICOMPL-1088): Bump RHEL 8 to SSG 0.1.50

### DIFF
--- a/app/models/xccdf/benchmark.rb
+++ b/app/models/xccdf/benchmark.rb
@@ -24,7 +24,7 @@ module Xccdf
       'xccdf_org.ssgproject.content_benchmark_RHEL-6': '0.1.28',
       # RHEL 7 with CIS backported to 0.1.49 in downstream
       'xccdf_org.ssgproject.content_benchmark_RHEL-7': '0.1.50',
-      'xccdf_org.ssgproject.content_benchmark_RHEL-8': '0.1.48'
+      'xccdf_org.ssgproject.content_benchmark_RHEL-8': '0.1.50'
     }.freeze
 
     scope :os_major_version, lambda { |major, equals = true|


### PR DESCRIPTION
CIS is introduced in 0.1.50 both downstream and upstream for RHEL 8. See https://docs.google.com/spreadsheets/d/1erpNef7jVedqTN8x64N50Z4gFIYPUtiAbD28nHJB6fs/edit#gid=0.

Signed-off-by: Andrew Kofink <akofink@redhat.com>