### PR TITLE
fix(Test result deletion): RHICOMPL-1109 keeps policy profile

### DIFF
--- a/app/graphql/mutations/test_result/delete.rb
+++ b/app/graphql/mutations/test_result/delete.rb
@@ -14,8 +14,9 @@ module Mutations
 
       def resolve(args = {})
         profile = scoped_profiles.find(args[:profile_id])
-        test_results = scoped_test_results(args).destroy_all
-        profile.destroy! if profile.external
+        profiles = profile.external ? [profile] : profile.policy_object.profiles
+        test_results = scoped_test_results(profile_id: profiles).destroy_all
+        profile.destroy! unless profile.policy_id
 
         { profile: profile, test_results: test_results }
       end


### PR DESCRIPTION
The test we had for this case relied on `external=true` rather than the
policy association existing, thus not catching the bug. I've updated the
test and the code to delete the profile only if no policy exists; for
internal policies, deleting the test results for the initial profile
deletes test results for the entire policy's profiles.

Signed-off-by: Andrew Kofink <akofink@redhat.com>