### PR TITLE
feat: RHICOMPL-724 Mark test results as (un)supported

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -72,12 +72,6 @@ module Types
     field :major_os_version, String, null: false
     field :policy_type, String, null: false
 
-    def ssg_version
-      ::RecordLoader.for(::Xccdf::Benchmark)
-                    .load(object.benchmark_id)
-                    .then(&:version)
-    end
-
     def compliant_host_count
       ::CollectionLoader.for(object.class, :hosts).load(object).then do |hosts|
         hosts.count { |host| object.compliant?(host) }

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -50,6 +50,10 @@ class Profile < ApplicationRecord
     end
   end
 
+  def ssg_version
+    benchmark.version
+  end
+
   def policy_type
     (parent_profile || self).name
   end

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -9,6 +9,16 @@ SupportedSsg = Struct.new(:id, :package, :version, :upstream_version, :profiles,
   self::SUPPORTED_FILE = Rails.root.join('config/supported_ssg.yaml')
 
   class << self
+    def supported?(ssg_version:, os_major_version:, os_minor_version:)
+      ssg_version == ssg_for_os(os_major_version, os_minor_version)
+    end
+
+    def ssg_for_os(os_major_version, os_minor_version)
+      raw_supported.dig('supported',
+                        "RHEL-#{os_major_version}.#{os_minor_version}",
+                        'version')
+    end
+
     def all
       raw_supported['supported'].map do |rhel, values|
         major, minor = os_version(rhel)

--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -7,6 +7,7 @@ module Xccdf
       @test_result = ::TestResult.create!(
         host: @host,
         profile: @host_profile,
+        supported: supported?,
         score: @op_test_result.score,
         start_time: @op_test_result.start_time.in_time_zone,
         end_time: @op_test_result.end_time.in_time_zone
@@ -23,6 +24,16 @@ module Xccdf
                          host: @host)
                   .where.not(id: @test_result.id)
                   .destroy_all
+    end
+
+    private
+
+    def supported?
+      SupportedSsg.supported?(
+        ssg_version: @host_profile.ssg_version,
+        os_major_version: @host.os_major_version,
+        os_minor_version: @host.os_minor_version
+      )
     end
   end
 end

--- a/db/migrate/20201116160531_add_supported_to_test_results.rb
+++ b/db/migrate/20201116160531_add_supported_to_test_results.rb
@@ -1,0 +1,6 @@
+class AddSupportedToTestResults < ActiveRecord::Migration[5.2]
+  def change
+    add_column :test_results, :supported, :boolean, default: true
+    add_index :test_results, :supported
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_083148) do
+ActiveRecord::Schema.define(version: 2020_11_16_160531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -187,9 +187,11 @@ ActiveRecord::Schema.define(version: 2020_10_21_083148) do
     t.uuid "host_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "supported", default: true
     t.index ["host_id", "profile_id", "end_time"], name: "index_test_results_on_host_id_and_profile_id_and_end_time", unique: true
     t.index ["host_id"], name: "index_test_results_on_host_id"
     t.index ["profile_id"], name: "index_test_results_on_profile_id"
+    t.index ["supported"], name: "index_test_results_on_supported"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/models/supported_ssg_test.rb
+++ b/test/models/supported_ssg_test.rb
@@ -31,4 +31,35 @@ class SupportedSsgTest < ActiveSupport::TestCase
       assert_equal in_upstream.count, 3
     end
   end
+
+  context 'supported?' do
+    should 'return true for OS/SSG matches' do
+      SupportedSsg.stubs(:ssg_for_os).returns('1.2.3')
+      assert SupportedSsg.supported?(ssg_version: '1.2.3',
+                                     os_major_version: '7',
+                                     os_minor_version: '4')
+      assert_not SupportedSsg.supported?(ssg_version: '1.2.4',
+                                         os_major_version: '7',
+                                         os_minor_version: '4')
+    end
+  end
+
+  context 'ssg_for_os' do
+    should 'return true for OS/SSG matches' do
+      SupportedSsg.stubs(:raw_supported).returns(
+        'supported' => {
+          'RHEL-7.4' => {
+            'version' => '1.2.3'
+          },
+          'RHEL-6.9' => {
+            'version' => '0.1.2'
+          }
+        }
+      )
+
+      assert_equal '1.2.3', SupportedSsg.ssg_for_os(7, 4)
+      assert_equal '0.1.2', SupportedSsg.ssg_for_os(6, 9)
+      assert_nil SupportedSsg.ssg_for_os(8, 1)
+    end
+  end
 end


### PR DESCRIPTION
For each test result that we save, we will compare the host's OS to the
supported SSG matrix and appropriately mark the test result as supported
or not.

Old test results will be shown as supported (see DB migration default).
Reports associated to a host with valid OS information and a matching SSG
version in the report's profile will be marked as supported.

For hosts without OS information or for mismatched OS/SSG, the test
result is marked as unsupported.

Signed-off-by: Andrew Kofink <akofink@redhat.com>