### PR TITLE
fix(sync_with_inventory): RHICOMPL-1126 handle all Faraday errors

### DIFF
--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -13,7 +13,7 @@ task sync_with_inventory: [:environment] do
             account, ::Settings.host_inventory_url, account.b64_identity
           ).inventory_host(host.id)
         )
-      rescue Faraday::ServerError => e
+      rescue Faraday::Error => e
         puts 'Inventory API error while syncing account '\
           "#{account.account_number}: System #{host.id} - #{host.name}. "
         puts e.full_message

--- a/test/tasks/sync_with_inventory_test.rb
+++ b/test/tasks/sync_with_inventory_test.rb
@@ -32,4 +32,31 @@ class SyncWithInventoryTest < ActiveSupport::TestCase
       Rake::Task['sync_with_inventory'].execute
     end
   end
+
+  test 'sync_with_inventory handles Forbidden errors' do
+    HostInventoryAPI.any_instance.stubs(:inventory_host)
+                    .raises(Faraday::ForbiddenError.new(''))
+
+    assert_nothing_raised do
+      Rake::Task['sync_with_inventory'].execute
+    end
+  end
+
+  test 'sync_with_inventory handles Client errors' do
+    HostInventoryAPI.any_instance.stubs(:inventory_host)
+                    .raises(Faraday::ClientError.new(''))
+
+    assert_nothing_raised do
+      Rake::Task['sync_with_inventory'].execute
+    end
+  end
+
+  test 'sync_with_inventory handles ConnectionFailed errors' do
+    HostInventoryAPI.any_instance.stubs(:inventory_host)
+                    .raises(Faraday::ConnectionFailed.new(''))
+
+    assert_nothing_raised do
+      Rake::Task['sync_with_inventory'].execute
+    end
+  end
 end


### PR DESCRIPTION
We're getting `Faraday::ForbbidenError`s in the sync_with_inventory job in prod. It's most likely related to the new RBAC changes and some accounts that don't have inventory:read access. In any case, we should handle this and any other Faraday errors (any issue related to the inventory request) by just skipping over the account and continuing the job to completion. Hopefully rescuing [`Faraday::Error`](https://www.rubydoc.info/github/lostisland/faraday/Faraday/Error) will accomplish this for good. It includes the following direct known subclasses: `ClientError, ConnectionFailed, ParsingError, RetriableResponse, SSLError, ServerError`

Signed-off-by: Andrew Kofink <akofink@redhat.com>