### PR TITLE
fix(Profile): RHICOMPL-1077 RHICOMPL-1116 RHICOMPL-1115 GraphQL to return policy name and desc

### DIFF
--- a/app/graphql/types/concerns/profile_pseudo_policy.rb
+++ b/app/graphql/types/concerns/profile_pseudo_policy.rb
@@ -5,18 +5,19 @@ module Types
   module ProfilePseudoPolicy
     extend ActiveSupport::Concern
 
+    def name
+      object == policy ? object.policy_object.name : object.name
+    end
+
+    def description
+      object == policy ? object.policy_object.description : object.description
+    end
+
     # Pseudo policy with a Profile type
-    # inheriting most of the attributes form the policy.
     def policy
       return if object.canonical? || object.policy_object.nil?
 
-      policy = object.policy_object
-      policy_profile = object.policy_object.initial_profile
-      policy_profile.assign_attributes(
-        name: policy.name,
-        description: policy.description
-      )
-      policy_profile
+      object.policy_object.initial_profile
     end
 
     # policy profiles

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -101,95 +101,147 @@ class ProfileQueryTest < ActiveSupport::TestCase
     end
   end
 
-  test 'query profile with a policy owned by the user' do
-    query = <<-GRAPHQL
-      query Profile($id: String!){
-          profile(id: $id) {
-              id
-              name
-              refId
-              policy {
+  context 'policy profiles' do
+    setup do
+      policies(:one).update!(account: accounts(:test),
+                             hosts: [hosts(:one), hosts(:two)])
+
+      (parent = profiles(:one).dup).update!(account: nil, hosts: [])
+      profiles(:one).update!(policy_object: policies(:one),
+                             external: false,
+                             parent_profile: parent)
+      profiles(:two).update!(account: accounts(:test),
+                             external: true,
+                             parent_profile: parent,
+                             policy_object: policies(:one))
+    end
+
+    should 'query profile with a policy owned by the user' do
+      query = <<-GRAPHQL
+        query Profile($id: String!){
+            profile(id: $id) {
                 id
                 name
                 refId
-              }
-          }
-      }
-    GRAPHQL
+                policy {
+                  id
+                  name
+                  refId
+                }
+            }
+        }
+      GRAPHQL
 
-    policies(:one).update!(account: accounts(:test),
-                           hosts: [hosts(:one), hosts(:two)])
+      result = Schema.execute(
+        query,
+        variables: { id: profiles(:two).id },
+        context: { current_user: users(:test) }
+      )
 
-    (parent = profiles(:one).dup).update!(account: nil, hosts: [])
-    profiles(:one).update!(policy_object: policies(:one),
-                           parent_profile: parent)
-    profiles(:two).update!(account: accounts(:test),
-                           external: true,
-                           parent_profile: parent,
-                           policy_object: policies(:one))
+      assert_equal profiles(:two).name, result['data']['profile']['name']
+      assert_equal profiles(:two).ref_id, result['data']['profile']['refId']
 
-    result = Schema.execute(
-      query,
-      variables: { id: profiles(:two).id },
-      context: { current_user: users(:test) }
-    )
+      assert_equal profiles(:one).id,
+                   result['data']['profile']['policy']['id']
+      assert_equal profiles(:one).ref_id,
+                   result['data']['profile']['policy']['refId']
+      assert_equal policies(:one).name,
+                   result['data']['profile']['policy']['name']
+    end
 
-    assert_equal profiles(:two).name, result['data']['profile']['name']
-    assert_equal profiles(:two).ref_id, result['data']['profile']['refId']
-
-    assert_equal profiles(:one).id,
-                 result['data']['profile']['policy']['id']
-    assert_equal profiles(:one).ref_id,
-                 result['data']['profile']['policy']['refId']
-    assert_equal policies(:one).name,
-                 result['data']['profile']['policy']['name']
-  end
-
-  test 'query profile with a policy policy profiles owned by the user' do
-    query = <<-GRAPHQL
+    should 'query profile with a policy profiles using first policy profile' \
+    ' owned by the user' do
+      query = <<-GRAPHQL
       query Profile($id: String!){
           profile(id: $id) {
               id
               name
+              description
               refId
               policy {
                 profiles {
                   id
                   refId
+                  name
+                  description
                 }
               }
           }
       }
-    GRAPHQL
+      GRAPHQL
 
-    policies(:one).update!(account: accounts(:test),
-                           hosts: [hosts(:one), hosts(:two)])
+      result = Schema.execute(
+        query,
+        variables: { id: profiles(:one).id },
+        context: { current_user: users(:test) }
+      )
 
-    (parent = profiles(:one).dup).update!(account: nil, hosts: [])
-    profiles(:one).update!(policy_object: policies(:one),
-                           parent_profile: parent)
-    profiles(:two).update!(account: accounts(:test),
-                           external: true,
-                           parent_profile: parent,
-                           policy_object: policies(:one))
+      assert_equal policies(:one).name, result['data']['profile']['name']
+      assert_equal policies(:one).description,
+                   result['data']['profile']['description']
+      assert_equal profiles(:one).ref_id, result['data']['profile']['refId']
 
-    result = Schema.execute(
-      query,
-      variables: { id: profiles(:two).id },
-      context: { current_user: users(:test) }
-    )
+      returned_profiles = result['data']['profile']['policy']['profiles']
+      assert_equal returned_profiles.count, 2
 
-    assert_equal profiles(:two).name, result['data']['profile']['name']
-    assert_equal profiles(:two).ref_id, result['data']['profile']['refId']
+      policy_profile =
+        returned_profiles.find { |rp| rp['id'] == profiles(:one).id }
+      assert_equal profiles(:one).ref_id, policy_profile['refId']
+      assert_equal policies(:one).name, policy_profile['name']
+      assert_equal policies(:one).description, policy_profile['description']
 
-    returned_profiles = result['data']['profile']['policy']['profiles']
-    assert_equal returned_profiles.count, 2
-    assert_includes returned_profiles.map { |rp| rp['id'] }, profiles(:one).id
-    assert_includes returned_profiles.map { |rp| rp['refId'] },
-                    profiles(:one).ref_id
-    assert_includes returned_profiles.map { |rp| rp['id'] }, profiles(:two).id
-    assert_includes returned_profiles.map { |rp| rp['refId'] },
-                    profiles(:two).ref_id
+      second_profile =
+        returned_profiles.find { |rp| rp['id'] == profiles(:two).id }
+      assert_equal profiles(:two).ref_id, second_profile['refId']
+      assert_equal profiles(:two).name, second_profile['name']
+      assert_equal profiles(:two).description, second_profile['description']
+    end
+
+    should 'query profile with a policy profiles using any policy profile' \
+           ' owned by the user' do
+      query = <<-GRAPHQL
+        query Profile($id: String!){
+            profile(id: $id) {
+                id
+                name
+                description
+                refId
+                policy {
+                  profiles {
+                    id
+                    refId
+                    name
+                    description
+                  }
+                }
+            }
+        }
+      GRAPHQL
+
+      result = Schema.execute(
+        query,
+        variables: { id: profiles(:two).id },
+        context: { current_user: users(:test) }
+      )
+
+      assert_equal profiles(:two).name, result['data']['profile']['name']
+      assert_equal profiles(:two).ref_id, result['data']['profile']['refId']
+
+      returned_profiles = result['data']['profile']['policy']['profiles']
+      assert_equal returned_profiles.count, 2
+
+      policy_profile =
+        returned_profiles.find { |rp| rp['id'] == profiles(:one).id }
+      assert_equal profiles(:one).ref_id, policy_profile['refId']
+      assert_equal policies(:one).name, policy_profile['name']
+      assert_equal policies(:one).description, policy_profile['description']
+
+      second_profile =
+        returned_profiles.find { |rp| rp['id'] == profiles(:two).id }
+      assert_equal profiles(:two).ref_id, second_profile['refId']
+      assert_equal profiles(:two).name, second_profile['name']
+      assert_equal profiles(:two).description, second_profile['description']
+    end
   end
 
   test 'query all profiles' do


### PR DESCRIPTION
Initial (main) policy profile should return name and the description
from the policy on GraphQL, which are user defined.
Profile and pseudo policy (profile) would return same name and the
description on GraphQL, if they are the same objects.

This will fix the problem of caching on UI, where the same GQL objects
(identified by id) had a different values depending on context.
It should also improve and fix filtering and displaying in UI.