### PR TITLE
fix(graphql): RHICOMPL-1096 Systems -> profiles returns policies

### DIFF
--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -30,7 +30,7 @@ module Types
 
     def profiles(policy_id: nil)
       context_parent
-      all_profiles = object.all_profiles
+      all_profiles = object.policy_profiles
       all_profiles = all_profiles.in_policy(policy_id) if policy_id
       all_profiles
     end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -34,6 +34,12 @@ class Host < ApplicationRecord
            .distinct
   end
 
+  def policy_profiles
+    Profile.where(id: assigned_profiles.external(false))
+           .or(Profile.where(id: test_result_profiles.external(true)
+                      .where(policy_id: nil))).distinct
+  end
+
   class << self
     def filter_by_policy(_filter, _operator, policy_or_profile_id)
       with_policy = with_policy_lookup(policy_or_profile_id).select('id')

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -189,9 +189,9 @@ class SystemQueryTest < ActiveSupport::TestCase
       result_profiles = result.first['node']['profiles']
 
       result_profile_ids = result_profiles.map { |p| p['id'] }
-      assert_includes result_profile_ids, other_profile.id
+      assert_not_includes result_profile_ids, other_profile.id
       assert_includes result_profile_ids, profiles(:one).id
-      assert_equal 2, result_profile_ids.length
+      assert_equal 1, result_profile_ids.length
     end
 
     should 'return external profile using an external profile id' \
@@ -216,7 +216,7 @@ class SystemQueryTest < ActiveSupport::TestCase
       }
       GRAPHQL
 
-      profiles(:one).update!(policy_id: nil)
+      profiles(:one).update!(policy_id: nil, external: true)
 
       result = Schema.execute(
         query,
@@ -278,7 +278,7 @@ class SystemQueryTest < ActiveSupport::TestCase
     end
   end
 
-  test 'system returns profiles from test results' do
+  test 'system returns profiles from external policy test results' do
     query = <<-GRAPHQL
     query System($systemId: String!){
         system(id: $systemId) {
@@ -292,7 +292,7 @@ class SystemQueryTest < ActiveSupport::TestCase
     }
     GRAPHQL
 
-    profiles(:one).update!(policy_object: nil)
+    profiles(:one).update!(policy_object: nil, external: true)
     profiles(:one).rules << rules(:one)
     rule_results(:one).update(
       host: hosts(:one), rule: rules(:one), test_result: test_results(:one)


### PR DESCRIPTION
When querying GraphQL for systems { profiles { ... } }, we used to
return all profiles, including test_result_profiles and
assigned_profiles. Now, we return only initial profiles of any assigned
policies and any external policy test result profiles; this is
essentially the complete policy list, internal and external.

Signed-off-by: Andrew Kofink <akofink@redhat.com>