### PR TITLE
fix(Profile): RHICOMPL-1140 policy name and description on GQL

### DIFF
--- a/app/graphql/types/concerns/profile_pseudo_policy.rb
+++ b/app/graphql/types/concerns/profile_pseudo_policy.rb
@@ -6,11 +6,11 @@ module Types
     extend ActiveSupport::Concern
 
     def name
-      object == policy ? object.policy_object.name : object.name
+      object.policy_object&.name || object.name
     end
 
     def description
-      object == policy ? object.policy_object.description : object.description
+      object.policy_object&.description || object.description
     end
 
     # Pseudo policy with a Profile type

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -138,7 +138,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
         context: { current_user: users(:test) }
       )
 
-      assert_equal profiles(:two).name, result['data']['profile']['name']
+      assert_equal policies(:one).name, result['data']['profile']['name']
       assert_equal profiles(:two).ref_id, result['data']['profile']['refId']
 
       assert_equal profiles(:one).id,
@@ -193,8 +193,8 @@ class ProfileQueryTest < ActiveSupport::TestCase
       second_profile =
         returned_profiles.find { |rp| rp['id'] == profiles(:two).id }
       assert_equal profiles(:two).ref_id, second_profile['refId']
-      assert_equal profiles(:two).name, second_profile['name']
-      assert_equal profiles(:two).description, second_profile['description']
+      assert_equal policies(:one).name, second_profile['name']
+      assert_equal policies(:one).description, second_profile['description']
     end
 
     should 'query profile with a policy profiles using any policy profile' \
@@ -224,7 +224,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
         context: { current_user: users(:test) }
       )
 
-      assert_equal profiles(:two).name, result['data']['profile']['name']
+      assert_equal policies(:one).name, result['data']['profile']['name']
       assert_equal profiles(:two).ref_id, result['data']['profile']['refId']
 
       returned_profiles = result['data']['profile']['policy']['profiles']
@@ -239,8 +239,8 @@ class ProfileQueryTest < ActiveSupport::TestCase
       second_profile =
         returned_profiles.find { |rp| rp['id'] == profiles(:two).id }
       assert_equal profiles(:two).ref_id, second_profile['refId']
-      assert_equal profiles(:two).name, second_profile['name']
-      assert_equal profiles(:two).description, second_profile['description']
+      assert_equal policies(:one).name, second_profile['name']
+      assert_equal policies(:one).description, second_profile['description']
     end
   end
 
@@ -282,8 +282,9 @@ class ProfileQueryTest < ActiveSupport::TestCase
     )
 
     profile1_result = result['data']['allProfiles'].find do |h|
-      h['name'] == 'profile1'
+      h['id'] == profiles(:one).id
     end
+    assert_equal policies(:one).name, profile1_result['name']
     assert_equal 3, profile1_result['totalHostCount']
     assert_equal 2, profile1_result['testResultHostCount']
     assert_equal 1, profile1_result['compliantHostCount']

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -269,11 +269,13 @@ class SystemQueryTest < ActiveSupport::TestCase
     hosts.each do |graphql_host|
       host = Host.find(graphql_host['node']['id'])
       graphql_host['node']['profiles'].each do |graphql_profile|
-        assert_includes host.assigned_profiles.map(&:name),
-                        graphql_profile['name']
+        assert_includes host.assigned_profiles.map(&:id),
+                        graphql_profile['id']
         profile = Profile.find(graphql_profile['id'])
         assert_equal host.rules_passed(profile), graphql_profile['rulesPassed']
         assert_equal host.rules_failed(profile), graphql_profile['rulesFailed']
+        assert_includes host.policies.pluck(:name),
+                        graphql_profile['name']
       end
     end
   end


### PR DESCRIPTION
Aligns GraphQL with REST API in regards to returning name and
description of profiles that are under a policy.  Both now take the
fields from its policy.

This fixes frontend Systems table and details, where reported
profiles and rules are listed.  On System details cards will
list correct user-defined name, and the rules table will show
correct value on the Policy column.

To get the original profile name consumer can request `policyType`
(or retrieve it from a corresponding canonical profile).