### PR TITLE
fix(ssg:import_rhel_supported): RHICOMPL-1142 RHEL-6 SSG imports

### DIFF
--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -29,7 +29,7 @@ namespace :ssg do
     # DATASTREAM_FILENAMES from openscap_parser's ssg:sync
     ENV['DATASTREAMS'] = ::SupportedSsg.available_upstream.map do |ssg|
       "v#{ssg.upstream_version || ssg.version}:rhel#{ssg.os_major_version}"
-    end.join(',')
+    end.uniq.join(',')
     Rake::Task['ssg:sync'].invoke
     DATASTREAM_FILENAMES.flatten.each do |filename|
       ENV['DATASTREAM_FILE'] = filename


### PR DESCRIPTION
Fixes unzipping error/warning:
```
  Archive:  scap-security-guide-0.1.28.zip
    inflating: scap-security-guide-0.1.28/ssg-rhel6-ds.xml
  caution: filename not matched:  scap-security-guide-0.1.28/ssg-rhel6-ds.xml
  caution: filename not matched:  scap-security-guide-0.1.28/ssg-rhel6-ds.xml
```

unzip returned non-zero exit code, which resulted in skipped datastream file for import.

The reason is this command that is being issued:
```
unzip -o scap-security-guide-0.1.28.zip scap-security-guide-0.1.28/ssg-rhel6-ds.xml scap-security-guide-0.1.28/ssg-rhel6-ds.xml scap-security-guide-0.1.28/ssg-rhel6-ds.xml
```