### PR TITLE
fix(ApplicationController): RHICOMPL-1129 handle validation errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,15 @@ class ApplicationController < ActionController::API
                  status: :not_found
   end
 
+  rescue_from ActiveRecord::RecordInvalid do |error|
+    logger.info "#{error.message} (#{error.class})"
+    if error.record
+      render_model_errors(error.record)
+    else
+      render_error(error.message)
+    end
+  end
+
   rescue_from ActionController::ParameterMissing do |error|
     logger.info "#{error.message} (#{error.class})"
     render_error "Parameter missing: #{error.message}",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,31 +22,30 @@ class ApplicationController < ActionController::API
   end
 
   rescue_from ActiveRecord::RecordNotUnique do |error|
-    render json: {
-      errors: "Duplicate record: #{error.message[/Key \(.+\).+\./]}"
-    }, status: :conflict
+    render_error "Duplicate record: #{error.message[/Key \(.+\).+\./]}",
+                 status: :conflict
   end
 
   rescue_from Pundit::NotAuthorizedError do
-    render json: { errors: 'You are not authorized to access this action.' },
-           status: :forbidden
+    render_error 'You are not authorized to access this action.',
+                 status: :forbidden
   end
 
   rescue_from ActiveRecord::RecordNotFound do |error|
     logger.info "#{error.message} (#{error.class})"
-    render json: { errors: "#{error.model} not found with ID #{error.id}" },
-           status: :not_found
+    render_error "#{error.model} not found with ID #{error.id}",
+                 status: :not_found
   end
 
   rescue_from ActionController::ParameterMissing do |error|
     logger.info "#{error.message} (#{error.class})"
-    render json: { errors: "Parameter missing: #{error.message}" },
-           status: :unprocessable_entity
+    render_error "Parameter missing: #{error.message}",
+                 status: :unprocessable_entity
   end
 
   rescue_from StrongerParameters::InvalidParameter do |error|
     logger.info "#{error.message} (#{error.class})"
-    render json: { errors: error.message },
-           status: :unprocessable_entity
+    render_error error.message,
+                 status: :unprocessable_entity
   end
 end

--- a/app/controllers/concerns/rendering.rb
+++ b/app/controllers/concerns/rendering.rb
@@ -11,10 +11,16 @@ module Rendering
       render({ json: serializer.new(model, opts) }.merge(args))
     end
 
-    def render_error(models, **args)
+    def render_error(messages, status: :not_acceptable, **opts)
+      messages = [messages].flatten
       render({ json: {
-        errors: model_errors(models)
-      }, status: :not_acceptable }.merge(args))
+        errors: messages
+      }, status: status }.merge(opts))
+    end
+
+    def render_model_errors(models, status: :not_acceptable, **opts)
+      messages = model_errors(models)
+      render_error(messages, status: status, **opts)
     end
 
     private

--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -35,7 +35,7 @@ module V1
           update_relationships
           render_json new_profile, status: :created
         else
-          render_error [new_profile, new_policy]
+          render_model_errors [new_profile, new_policy]
           raise ActiveRecord::Rollback
         end
       end
@@ -47,7 +47,7 @@ module V1
           update_relationships
           render_json profile
         else
-          render_error profile
+          render_model_errors profile
         end
       end
     end

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -203,7 +203,9 @@
             "description": "benchmark not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Xccdf::Benchmark not found with ID invalid"
+                "errors": [
+                  "Xccdf::Benchmark not found with ID invalid"
+                ]
               }
             },
             "content": {}
@@ -478,7 +480,9 @@
             "description": "business_objective not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "BusinessObjective not found with ID invalid"
+                "errors": [
+                  "BusinessObjective not found with ID invalid"
+                ]
               }
             },
             "content": {}
@@ -990,7 +994,9 @@
             "description": "profile not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Profile not found with ID invalid"
+                "errors": [
+                  "Profile not found with ID invalid"
+                ]
               }
             },
             "content": {}
@@ -1190,7 +1196,9 @@
             "description": "profile not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Profile not found with ID invalid"
+                "errors": [
+                  "Profile not found with ID invalid"
+                ]
               }
             },
             "content": {}
@@ -1413,7 +1421,9 @@
             "description": "profile not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Profile not found with ID invalid"
+                "errors": [
+                  "Profile not found with ID invalid"
+                ]
               }
             },
             "content": {}
@@ -1848,7 +1858,9 @@
             "description": "rule not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Rule not found with ID 37f7eeff-831b-5c41-984a-254965f58c0f"
+                "errors": [
+                  "Rule not found with ID 37f7eeff-831b-5c41-984a-254965f58c0f"
+                ]
               }
             },
             "content": {}
@@ -2574,7 +2586,9 @@
             "description": "system not found",
             "examples": {
               "application/vnd.api+json": {
-                "errors": "Host not found with ID invalid"
+                "errors": [
+                  "Host not found with ID invalid"
+                ]
               }
             },
             "content": {}

--- a/test/controllers/concerns/rendering_test.rb
+++ b/test/controllers/concerns/rendering_test.rb
@@ -17,6 +17,22 @@ class RenderingTest < ActionDispatch::IntegrationTest
 
   context '#render_error' do
     setup do
+      @controller = DummyController.new
+    end
+
+    should 'accept a single message' do
+      @controller.expects(:render)
+      @controller.render_error('Error message')
+    end
+
+    should 'accept multiple messages' do
+      @controller.expects(:render)
+      @controller.render_error(%w[one two])
+    end
+  end
+
+  context '#render_model_errors' do
+    setup do
       @model = OpenStruct.new(
         errors: OpenStruct.new(full_messages: [:foo.to_s, :bar.to_s])
       )

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -349,6 +349,21 @@ module V1
                      parsed_data.dig('relationships', 'account', 'data', 'id')
       end
 
+      test 'create with an exisiting profile type for a major OS' do
+        (parent = profiles(:one).dup).update!(account: nil, policy_id: nil)
+        profiles(:one).update!(policy_id: policies(:one).id,
+                               parent_profile: parent)
+
+        assert_difference('Profile.count' => 0, 'Policy.count' => 0) do
+          post profiles_path, params: params(
+            attributes: {
+              parent_profile_id: parent.id
+            }
+          )
+        end
+        assert_response :not_acceptable
+      end
+
       test 'create with a business objective' do
         assert_difference('Profile.count' => 1, 'Policy.count' => 1) do
           post profiles_path, params: params(

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -278,7 +278,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: data',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'create with invalid data' do
@@ -287,7 +287,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'data must be a hash',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'create with empty attributes' do
@@ -296,7 +296,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: data',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'create with invalid attributes' do
@@ -305,7 +305,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'attributes must be a hash',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'create with empty parent_profile_id' do
@@ -317,7 +317,7 @@ module V1
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: '\
                      'parent_profile_id',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'create with an unfound parent_profile_id' do
@@ -592,21 +592,21 @@ module V1
         patch v1_profile_path(@profile.id), params: params({})
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: data',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'update with invalid data' do
         patch profile_path(@profile.id), params: params('foo')
         assert_response :unprocessable_entity
         assert_match 'data must be a hash',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'update with invalid attributes' do
         patch profile_path(@profile.id), params: params(attributes: 'foo')
         assert_response :unprocessable_entity
         assert_match 'attributes must be a hash',
-                     JSON.parse(response.body).dig('errors')
+                     JSON.parse(response.body).dig('errors', 0)
       end
 
       test 'update with a single attribute' do


### PR DESCRIPTION
Errors from validation coming from `ActiveRecord::RecordInvalid` are now rendered on all controller endpoints.

Example:
```
{"errors":["Profile policy type must be unique. Another policy with this policy type already exists."]}
```

This also fixes error `Unexpected token < in JSON at position 0` in the frontend happening if a user tried to create the same type of a policy as an existing policy for a major OS version (e.g. when the latest benchmark changed).

Here is the result in frontend with this change:
![Screenshot_2020-11-23 Compliance](https://user-images.githubusercontent.com/7695766/99997800-f789bc80-2dbd-11eb-98d9-10e5ced9862d.png)

`render_error` refactored to accept string messages.
Error messages in the response JSON are now always an array.