### PR TITLE
feat(System): RHICOMPL-1139 test result profiles and policies on APIs 

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -387,6 +387,12 @@ type System implements Node {
     """
     profileId: String
   ): Int!
+  testResultProfiles(
+    """
+    Filter results tested against a policy or profile ID
+    """
+    policyId: ID
+  ): [Profile!]
 }
 
 """

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -369,6 +369,12 @@ type System implements Node {
   name: String!
   osMajorVersion: Int
   osMinorVersion: Int
+  policies(
+    """
+    Filter results by policy or profile ID
+    """
+    policyId: ID
+  ): [Profile!]
   profiles(
     """
     Filter results by policy or profile ID

--- a/app/graphql/types/concerns/system_profiles.rb
+++ b/app/graphql/types/concerns/system_profiles.rb
@@ -15,6 +15,12 @@ module Types
       scope_profiles(object.test_result_profiles, policy_id)
     end
 
+    def policies(policy_id: nil)
+      context_parent
+      policy_profiles = object.assigned_profiles.external(false)
+      scope_profiles(policy_profiles, policy_id)
+    end
+
     private
 
     def scope_profiles(profiles, policy_id)

--- a/app/graphql/types/concerns/system_profiles.rb
+++ b/app/graphql/types/concerns/system_profiles.rb
@@ -7,9 +7,18 @@ module Types
 
     def profiles(policy_id: nil)
       context_parent
-      all_profiles = object.all_profiles
-      all_profiles = all_profiles.in_policy(policy_id) if policy_id
-      all_profiles
+      scope_profiles(object.all_profiles, policy_id)
+    end
+
+    def test_result_profiles(policy_id: nil)
+      context_parent
+      scope_profiles(object.test_result_profiles, policy_id)
+    end
+
+    private
+
+    def scope_profiles(profiles, policy_id)
+      policy_id ? profiles.in_policy(policy_id) : profiles
     end
   end
 end

--- a/app/graphql/types/concerns/system_profiles.rb
+++ b/app/graphql/types/concerns/system_profiles.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  # Methods related to system profiles and policies
+  module SystemProfiles
+    extend ActiveSupport::Concern
+
+    def profiles(policy_id: nil)
+      context_parent
+      all_profiles = object.all_profiles
+      all_profiles = all_profiles.in_policy(policy_id) if policy_id
+      all_profiles
+    end
+  end
+end

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative 'concerns/system_profiles'
+
 module Types
   # Definition of the System GraphQL type
   class System < Types::BaseObject
+    include SystemProfiles
+
     model_class ::Host
     graphql_name 'System'
     description 'A System registered in Insights Compliance'
@@ -26,13 +30,6 @@ module Types
     field :last_scanned, String, null: true do
       argument :profile_id, String, 'Filter results by profile ID',
                required: false
-    end
-
-    def profiles(policy_id: nil)
-      context_parent
-      all_profiles = object.all_profiles
-      all_profiles = all_profiles.in_policy(policy_id) if policy_id
-      all_profiles
     end
 
     def rules_passed(args = {})

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -19,6 +19,11 @@ module Types
       argument :policy_id, ID, 'Filter results by policy or profile ID',
                required: false
     end
+    field :test_result_profiles, [::Types::Profile], null: true do
+      argument :policy_id, ID,
+               'Filter results tested against a policy or profile ID',
+               required: false
+    end
     field :rules_passed, Int, null: false do
       argument :profile_id, String, 'Filter results by profile ID',
                required: false

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -24,6 +24,10 @@ module Types
                'Filter results tested against a policy or profile ID',
                required: false
     end
+    field :policies, [::Types::Profile], null: true do
+      argument :policy_id, ID, 'Filter results by policy or profile ID',
+               required: false
+    end
     field :rules_passed, Int, null: false do
       argument :profile_id, String, 'Filter results by profile ID',
                required: false


### PR DESCRIPTION
Extends System GraphQL type:
* `testResultProfiles` 
* `policies` (initial policy profiles out of assigned profiles, where `external=false`)

The GraphQL fields have the option to filter by `policyId` argument, which filters by any policy profile ID. On `testResultProfiles` the `policyId` filter works even if the host/system is disassociated from its policy.

Note that there is an original `profiles` on both APIs, that returns combined result of test result profiles and associated result. It is kept for compatibility. ~~Changing it into `testResultProfiles` might be up for a question.~~ (Edit: having only test result profiles on `profiles` field would break the API, as it won't include assigned profiles if the host system have not had a report).

Rationale:
The consumer can pick any type of context with regards to profiles. For reports the interest is focused on test result profiles, regardless of (dis)association to a policy. For the context of describing system's policies the focus is only on associated policies. There are two field so both contexts can be requested in the same query.

Absence of external policies is deliberate, as their support is soon to be deprecated.