### PR TITLE
feat(graphql): RHICOMPL-1114 RHICOMPL-681 supported and scoring

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -140,8 +140,15 @@ type Profile implements Node & RulesPreload {
     systemId: String
   ): Float!
   ssgVersion: String!
+  supported(
+    """
+    Latest TestResult supported for this system and profile
+    """
+    systemId: String
+  ): Boolean!
   testResultHostCount: Int!
   totalHostCount: Int!
+  unsupportedHostCount: Int!
 }
 
 """
@@ -448,6 +455,7 @@ type TestResult implements Node {
   profile: Profile!
   score: Float!
   startTime: String
+  supported: Boolean!
 }
 
 """

--- a/app/graphql/types/concerns/profile_scoring.rb
+++ b/app/graphql/types/concerns/profile_scoring.rb
@@ -5,6 +5,15 @@ module Types
   module ProfileScoring
     extend ActiveSupport::Concern
 
+    def unsupported_host_count
+      ::CollectionLoader.for(
+        object.class,
+        object.policy_id ? :policy_test_results : :test_results
+      ).load(object).then do |test_results|
+        test_results.latest.supported(false).count
+      end
+    end
+
     def compliant_host_count
       ::CollectionLoader.for(
         object.class,

--- a/app/graphql/types/concerns/test_results.rb
+++ b/app/graphql/types/concerns/test_results.rb
@@ -15,6 +15,16 @@ module Types
       end
     end
 
+    def supported(args = {})
+      latest_test_result_batch(args).then do |latest_test_result|
+        if latest_test_result.blank?
+          false
+        else
+          latest_test_result.supported
+        end
+      end
+    end
+
     def compliant(args = {})
       latest_test_result_batch(args).then do |latest_test_result|
         host_results = latest_test_result&.rule_results

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -41,11 +41,18 @@ module Types
     field :business_objective_id, ID, null: true
     field :total_host_count, Int, null: false
     field :test_result_host_count, Int, null: false
+    field :unsupported_host_count, Int, null: false
     field :external, Boolean, null: false
 
     field :score, Float, null: false do
       argument :system_id, String,
                'Latest TestResult score for this system and profile',
+               required: false
+    end
+
+    field :supported, Boolean, null: false do
+      argument :system_id, String,
+               'Latest TestResult supported for this system and profile',
                required: false
     end
 

--- a/app/graphql/types/test_result.rb
+++ b/app/graphql/types/test_result.rb
@@ -11,6 +11,7 @@ module Types
     field :start_time, String, null: true
     field :end_time, String, null: false
     field :score, Float, null: false
+    field :supported, Boolean, null: false
     field :profile, ::Types::Profile, null: false
     field :host, ::Types::System, null: false
   end

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -25,6 +25,10 @@ class TestResult < ApplicationRecord
           'test_results.end_time = tr.end_time')
   }
 
+  scope :supported, lambda { |supported = true|
+    where(supported: supported)
+  }
+
   def destroy_orphaned_external_profiles
     profile.destroy if profile&.policy_id.nil? && profile&.test_results&.empty?
   end

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -287,7 +287,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
     end
     assert_equal policies(:one).name, profile1_result['name']
     assert_equal 3, profile1_result['totalHostCount']
-    assert_equal 2, profile1_result['testResultHostCount']
+    assert_equal 1, profile1_result['testResultHostCount']
     assert_equal 1, profile1_result['compliantHostCount']
     assert_equal 1, profile1_result['unsupportedHostCount']
     assert_not profile1_result['businessObjective']

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -253,6 +253,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
             totalHostCount
             testResultHostCount
             compliantHostCount
+            unsupportedHostCount
             businessObjective {
                title
             }
@@ -263,7 +264,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
     test_results(:one).update(profile: profiles(:one), host: hosts(:one),
                               score: 100)
     test_results(:two).update(profile: profiles(:two), host: hosts(:two),
-                              score: 90)
+                              score: 90, supported: false)
     profiles(:one).rules << rules(:one)
     profiles(:one).rules << rules(:two)
     profiles(:one).update(account: accounts(:test),
@@ -288,6 +289,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
     assert_equal 3, profile1_result['totalHostCount']
     assert_equal 2, profile1_result['testResultHostCount']
     assert_equal 1, profile1_result['compliantHostCount']
+    assert_equal 1, profile1_result['unsupportedHostCount']
     assert_not profile1_result['businessObjective']
   end
 end


### PR DESCRIPTION
Changes to support https://github.com/RedHatInsights/compliance-frontend/pull/845

RHICOMPL-1114: Expose supported information in GraphQL
RHICOMPL-681: Only score supported reports

Signed-off-by: Andrew Kofink <akofink@redhat.com>