### PR TITLE
feat: RHICOMPL-1149 Stop parsing external reports

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -34,7 +34,8 @@ class ParseReportJob
     notify_remediation
     notify_payload_tracker(:success, "Job #{jid} has completed successfully")
   rescue ::MissingIdError, ::WrongFormatError, ::InventoryHostNotFound,
-         ::OSVersionMismatch, ::ActiveRecord::RecordInvalid => e
+         ::OSVersionMismatch, ::ActiveRecord::RecordInvalid,
+         ::ExternalReportError => e
     error_message = "Cannot parse report: #{e} - #{@msg_value.to_json}"
     notify_payload_tracker(:error, error_message)
     Sidekiq.logger.error(error_message)

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -28,16 +28,20 @@ module Xccdf
       )
     end
 
+    def external_report?
+      test_result_profile.find_policy(account: @account, hosts: [@host]).nil?
+    end
+
     private
 
     def test_result_profile
       ::Profile.canonical
                .where(ref_id: @test_result_file.test_result.profile_id,
-                      benchmark: @benchmark).first ||
+                      benchmark: benchmark).first ||
         ::Profile.find_or_initialize_by(
           ref_id: @test_result_file.test_result.profile_id,
           name: @test_result_file.test_result.profile_id,
-          benchmark_id: @benchmark.id
+          benchmark_id: benchmark.id
         )
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,3 +16,5 @@ redis_url: compliance-redis.compliance-ci.svc.cluster.local:6379
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'
 async: true
+features:
+  parse_external_reports: false

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -194,6 +194,10 @@ class XccdfReportParserTest < ActiveSupport::TestCase
   end
 
   context 'rule results' do
+    setup do
+      @report_parser.stubs(:external_report?)
+    end
+
     should 'save them, associate them with a rule and a host' do
       assert_difference('RuleResult.count', 59) do
         @report_parser.save_all
@@ -374,6 +378,16 @@ class XccdfReportParserTest < ActiveSupport::TestCase
             'display_name' => 'lenovolobato.lobatolan.home'
           }
         )
+      end
+    end
+  end
+
+  context 'missing policy' do
+    should 'raise an error and halt parsing (external report)' do
+      @report_parser.stubs(:external_report?).returns(true)
+      @report_parser.save_host
+      assert_raises(::ExternalReportError) do
+        @report_parser.check_for_external_reports
       end
     end
   end


### PR DESCRIPTION
Like other handled exceptions encountered during parsing, this error will be logged to Sidekiq:

```
2020-12-02T02:32:49.235Z 1 TID-govnpna8l ParseReportJob JID-49dd70ddf6e070a2fa899067 INFO: start
2020-12-02T02:32:49.235Z 1 TID-govnpna8l ParseReportJob JID-49dd70ddf6e070a2fa899067 INFO: Parsing report for account 1212729, system a5258d2d-90cf-4fcd-a7c5-e838ffa8b18b
2020-12-02T02:32:49.966Z 1 TID-govnpna8l ParseReportJob JID-49dd70ddf6e070a2fa899067 ERROR: Cannot parse report: No policy found matching benchmark xccdf_org.ssgproject.content_benchmark_RHEL-7 (RHEL-7) and profile xccdf_org.ssgproject.content_profile_pci-dss with host rhel7-insights-client.virbr0.akofink-laptop assigned for account 1212729. - {"ip_addresses":["192.168.121.24"],"insights_id":"b6bb4df7-9b7a-4f7a-81ec-eb1d9e9603b3","machine_id":"2195a0e9-bb9c-4e76-9c95-405a78cc3bde","subscription_manager_id":"e57aaa5b-936b-47eb-b060-3434a7c04a76","mac_addresses":["52:54:00:3f:95:f1","00:00:00:00:00:00"],"fqdn":"rhel7-insights-client.virbr0.akofink-laptop","bios_uuid":"cf2c3f26-98b6-4b04-a7d3-1aa18717eed2","reporter":"puptoo","stale_timestamp":"2020-12-03T04:32:45.430108+00:00","account":"1212729","id":"a5258d2d-90cf-4fcd-a7c5-e838ffa8b18b"}
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>