### PR TITLE
feat(Benchmark): RHICOMPL-1121 latest supported from SSG matrix 

### DIFF
--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -7,6 +7,13 @@ SupportedSsg = Struct.new(:id, :package, :version, :upstream_version, :profiles,
                           :os_major_version, :os_minor_version,
                           keyword_init: true) do
   self::SUPPORTED_FILE = Rails.root.join('config/supported_ssg.yaml')
+  OS_NAME = 'RHEL'
+  self::OS_NAME = OS_NAME
+
+  def ref_id
+    'xccdf_org.ssgproject' \
+    ".content_benchmark_#{OS_NAME}-#{os_major_version}"
+  end
 
   class << self
     def supported?(ssg_version:, os_major_version:, os_minor_version:)
@@ -14,9 +21,11 @@ SupportedSsg = Struct.new(:id, :package, :version, :upstream_version, :profiles,
     end
 
     def ssg_for_os(os_major_version, os_minor_version)
-      raw_supported.dig('supported',
-                        "RHEL-#{os_major_version}.#{os_minor_version}",
-                        'version')
+      raw_supported.dig(
+        'supported',
+        "#{self::OS_NAME}-#{os_major_version}.#{os_minor_version}",
+        'version'
+      )
     end
 
     def all

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -43,6 +43,12 @@ SupportedSsg = Struct.new(:id, :package, :version, :upstream_version, :profiles,
       end
     end
 
+    def latest_per_os_major
+      all.group_by(&:os_major_version).values.map do |ssgs|
+        ssgs.max_by { |ssg| ssg.os_minor_version.to_i }
+      end
+    end
+
     private
 
     def map_attributes(values)

--- a/app/models/xccdf/benchmark.rb
+++ b/app/models/xccdf/benchmark.rb
@@ -91,10 +91,6 @@ module Xccdf
       end
     end
 
-    def latest_ssg
-      LATEST_SUPPORTED_VERSIONS[ref_id.to_sym]
-    end
-
     def inferred_os_major_version
       ref_id[/(?<=RHEL-)\d/]
     end

--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -21,7 +21,6 @@ namespace :ssg do
         data: OpenshiftEnvironment.summary
       )
     end
-    Rails.cache.delete('latest_supported_benchmarks')
   end
 
   desc 'Update compliance DB with the supported SCAP Security Guide versions'
@@ -35,7 +34,6 @@ namespace :ssg do
       ENV['DATASTREAM_FILE'] = filename
       Rake::Task['ssg:import'].execute
     end
-    Rails.cache.delete('latest_supported_benchmarks')
   end
 
   desc 'Update compliance DB with data from an Xccdf datastream file'

--- a/test/graphql/queries/benchmark_query_test.rb
+++ b/test/graphql/queries/benchmark_query_test.rb
@@ -4,9 +4,14 @@ require 'test_helper'
 
 class BenchmarkQueryTest < ActiveSupport::TestCase
   test 'query benchmark owned by the user' do
+    supported_ssg = SupportedSsg.new(version: '0.1.50',
+                                     os_major_version: '7',
+                                     os_minor_version: '3')
+    SupportedSsg.stubs(:latest_per_os_major).returns([supported_ssg])
+
     latest_benchmark = ::Xccdf::Benchmark.create(
-      ref_id: ::Xccdf::Benchmark::LATEST_SUPPORTED_VERSIONS.keys[0],
-      version: ::Xccdf::Benchmark::LATEST_SUPPORTED_VERSIONS.values[0],
+      ref_id: supported_ssg.ref_id,
+      version: supported_ssg.version,
       title: 'sample',
       description: 'sample description'
     )

--- a/test/models/supported_ssg_test.rb
+++ b/test/models/supported_ssg_test.rb
@@ -14,10 +14,14 @@ class SupportedSsgTest < ActiveSupport::TestCase
   context 'loaded supported SSGs' do
     setup do
       loaded = [
-        SupportedSsg.new(version: '0.1.50'),
-        SupportedSsg.new(version: '0.1.24'),
-        SupportedSsg.new(upstream_version: '0.1.25', version: '0.1.22'),
-        SupportedSsg.new(upstream_version: 'N/A', version: '0.1.1')
+        SupportedSsg.new(version: '0.1.50',
+                         os_major_version: '7', os_minor_version: '3'),
+        SupportedSsg.new(version: '0.1.24',
+                         os_major_version: '7', os_minor_version: '2'),
+        SupportedSsg.new(upstream_version: '0.1.25', version: '0.1.22',
+                         os_major_version: '6', os_minor_version: '10'),
+        SupportedSsg.new(upstream_version: 'N/A', version: '0.1.1',
+                         os_major_version: '6', os_minor_version: '9')
       ]
       SupportedSsg.stubs(:all).returns(loaded)
     end
@@ -29,6 +33,14 @@ class SupportedSsgTest < ActiveSupport::TestCase
       assert_includes versions, '0.1.24'
       assert_includes versions, '0.1.22' # upstream version is higher
       assert_equal in_upstream.count, 3
+    end
+
+    should 'provide models by latest in each OS major version' do
+      latest = SupportedSsg.latest_per_os_major
+      versions = latest.map(&:version)
+      assert_includes versions, '0.1.50'
+      assert_includes versions, '0.1.22'
+      assert_equal latest.count, 2
     end
   end
 

--- a/test/models/supported_ssg_test.rb
+++ b/test/models/supported_ssg_test.rb
@@ -26,6 +26,11 @@ class SupportedSsgTest < ActiveSupport::TestCase
       SupportedSsg.stubs(:all).returns(loaded)
     end
 
+    should 'provide models with ref_id' do
+      ref_ids = SupportedSsg.all.map(&:ref_id)
+      assert ref_ids.all?(&:present?)
+    end
+
     should 'provide models available upstream' do
       in_upstream = SupportedSsg.available_upstream
       versions = in_upstream.map(&:version)


### PR DESCRIPTION
Return latest supported benchmarks, one each per OS major version. Benchmarks are matched from the SSG supported matrix, picked by latest minor version.

Drops caching of latest supported benchmarks, as it refactors it into a single SQL query within a scope.

Please note, that due to the use of upstream SSG packages, the benchmarks are being matched with the upstream version.

Review suggestion: go by commits.

RHICOMPL-1121