### PR TITLE
fix(compose): ingress port use

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,14 +76,13 @@ services:
       - INGRESS_VALIDTOPICS=testareno,advisor,buckit,compliance #if you test a different topic, add it here
       - INGRESS_INVENTORYURL=inventory-web:8081/api/inventory/v1/hosts
       - OPENSHIFT_BUILD_COMMIT=woopwoop
-      - INGRESS_PORT=8080
       - INGRESS_MINIODEV=true
       - INGRESS_MINIOACCESSKEY=$MINIO_ACCESS_KEY
       - INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY
       - INGRESS_MINIOENDPOINT=minio:9000
       - INGRESS_MAXSIZE=104857600 # 100 MB
     ports:
-      - 8080:8080
+      - 8080:3000
     depends_on:
       - kafka
     links:


### PR DESCRIPTION
Ingress uses port 3000, and second port 8080 as metrics port.
The env variable INGRESS_PORT seems to be undocumented (not read?) and
its value conflicts with the metrics port.

Instead, it maps the port 3000 to be accessible via 8080 from outside.

See also Ingress README:
https://github.com/RedHatInsights/insights-ingress-go/blob/27a929894e645ddae9afb055495e4e823098ab17/README.md

and dev compose:
https://github.com/RedHatInsights/insights-ingress-go/blob/61330931ee5f684f54293be049b05d1648cca7ca/development/local-dev-start.yml