### PR TITLE
feat(parsing): RHICOMPL-722 Stop parsing unknown benchmarks

### DIFF
--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -28,6 +28,10 @@ SupportedSsg = Struct.new(:id, :package, :version, :upstream_version, :profiles,
       )
     end
 
+    def versions
+      all.map(&:version).uniq
+    end
+
     def all
       raw_supported['supported'].map do |rhel, values|
         major, minor = os_version(rhel)

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -35,12 +35,12 @@ module Xccdf
     private
 
     def test_result_profile
-      @test_result_profile ||= ::Profile.canonical.find_or_initialize_by(
+      @test_result_profile ||= ::Profile.canonical.create_with(
+        name: @test_result_file.test_result.profile_id
+      ).find_or_initialize_by(
         ref_id: @test_result_file.test_result.profile_id,
         benchmark: benchmark
-      ).tap do |profile|
-        profile.name ||= @test_result_file.test_result.profile_id
-      end
+      )
     end
 
     def inventory_host

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -35,14 +35,12 @@ module Xccdf
     private
 
     def test_result_profile
-      ::Profile.canonical
-               .where(ref_id: @test_result_file.test_result.profile_id,
-                      benchmark: benchmark).first ||
-        ::Profile.find_or_initialize_by(
-          ref_id: @test_result_file.test_result.profile_id,
-          name: @test_result_file.test_result.profile_id,
-          benchmark_id: benchmark.id
-        )
+      @test_result_profile ||= ::Profile.canonical.find_or_initialize_by(
+        ref_id: @test_result_file.test_result.profile_id,
+        benchmark: benchmark
+      ).tap do |profile|
+        profile.name ||= @test_result_file.test_result.profile_id
+      end
     end
 
     def inventory_host

--- a/app/services/concerns/xccdf/rule_results.rb
+++ b/app/services/concerns/xccdf/rule_results.rb
@@ -33,11 +33,15 @@ module Xccdf
       end
     end
 
+    def test_result_rules_unknown
+      selected_op_rule_results.map(&:id) - rule_ids.keys
+    end
+
     private
 
     def rule_ids
       @rule_ids ||= Rule.where(
-        benchmark: @benchmark, ref_id: selected_op_rule_results.map(&:id)
+        benchmark: benchmark, ref_id: selected_op_rule_results.map(&:id)
       ).pluck(:ref_id, :id).to_h
     end
   end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -64,6 +64,10 @@ class XccdfReportParser
     # rubocop:enable Style/GuardClause
   end
 
+  def save_missing_supported_benchmark
+    save_all_benchmark_info if SupportedSsg.versions.include?(benchmark.version)
+  end
+
   def check_for_missing_benchmark
     # rubocop:disable Style/GuardClause
     unless benchmark.persisted?
@@ -108,6 +112,7 @@ class XccdfReportParser
       save_host
       check_os_version
       check_for_external_reports unless Settings.features.parse_external_reports
+      save_missing_supported_benchmark
       check_for_missing_benchmark_info
       save_all_test_result_info
     end


### PR DESCRIPTION
This changes the xccdf report parser to not save unknown benchmarks (those that are either not yet imported or have an SSG version that matches no supported SSG version). If a benchmark does not already exist, the report will fail to parse with an appropriate message logged. The only way to import benchmarks into Compliance after this change will be to run the SSG import job.

Signed-off-by: Andrew Kofink <akofink@redhat.com>