### PR TITLE
fix(parsing): RHICOMPL-722 No retry for Missing*Errors

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -6,12 +6,6 @@ require 'xccdf_report_parser'
 class ParseReportJob
   include Sidekiq::Worker
 
-  PARSE_ERRORS = [
-    ::MissingIdError, ::WrongFormatError, ::InventoryHostNotFound,
-    ::OSVersionMismatch, ::ActiveRecord::RecordInvalid, ::ExternalReportError,
-    ::UnknownBenchmarkError, ::UnknownProfileError, ::UnknownRuleError
-  ].freeze
-
   def perform(file, message)
     return if cancelled?
 
@@ -39,7 +33,7 @@ class ParseReportJob
     parser.save_all
     notify_remediation
     notify_payload_tracker(:success, "Job #{jid} has completed successfully")
-  rescue *PARSE_ERRORS => e
+  rescue *XccdfReportParser::ERRORS, *HostInventoryAPI::ERRORS => e
     error_message = "Cannot parse report: #{e} - #{@msg_value.to_json}"
     notify_payload_tracker(:error, error_message)
     Sidekiq.logger.error(error_message)

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -3,15 +3,14 @@
 require 'uri'
 require 'json'
 
-# Error to raise if the OS release contains an invalid major or minor
-class InventoryInvalidOsRelease < StandardError; end
-
-# Error to raise if the inventory host could not be found
-class InventoryHostNotFound < StandardError; end
-
 # Interact with the Insights Host Inventory. Usually HTTP calls
 # are all that's needed.
 class HostInventoryAPI
+  # Error to raise if the inventory host could not be found
+  class InventoryHostNotFound < StandardError; end
+
+  ERRORS = [InventoryHostNotFound].freeze
+
   def initialize(account, url, b64_identity)
     @url = "#{URI.parse(url)}#{Settings.path_prefix}/inventory/v1/hosts"
     @account = account
@@ -29,7 +28,7 @@ class HostInventoryAPI
     return @inventory_host if @inventory_host.present?
 
     @inventory_host = host_already_in_inventory(host_id)
-    raise ::InventoryHostNotFound if @inventory_host.blank?
+    raise InventoryHostNotFound if @inventory_host.blank?
 
     if (os_release = system_profile([host_id]).first)
       @inventory_host['os_major_version'] = os_release['os_major_version']

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -1,29 +1,35 @@
 # frozen_string_literal: true
 
-# Error to raise if id is not available
-class MissingIdError < StandardError; end
-# Error to raise if the format of the report is wrong
-class WrongFormatError < StandardError; end
-# Error to raise if the OS version does not match benchmark's
-class OSVersionMismatch < StandardError; end
-# Error to raise if the incoming report belongs to no known policy
-class ExternalReportError < StandardError; end
-# Error to raise if the incoming report belongs to no known benchmark
-class UnknownBenchmarkError < StandardError; end
-# Error to raise if the incoming report belongs to no known profile
-class UnknownProfileError < StandardError; end
-# Error to raise if the incoming report contains an unknown rule
-class UnknownRuleError < StandardError; end
-
 # Takes in a path to an Xccdf file, returns all kinds of properties about it
 # and saves it in our database
 class XccdfReportParser
+  # Error to raise if id is not available
+  class MissingIdError < StandardError; end
+  # Error to raise if the format of the report is wrong
+  class WrongFormatError < StandardError; end
+  # Error to raise if the OS version does not match benchmark's
+  class OSVersionMismatch < StandardError; end
+  # Error to raise if the incoming report belongs to no known policy
+  class ExternalReportError < StandardError; end
+  # Error to raise if the incoming report belongs to no known benchmark
+  class UnknownBenchmarkError < StandardError; end
+  # Error to raise if the incoming report belongs to no known profile
+  class UnknownProfileError < StandardError; end
+  # Error to raise if the incoming report contains an unknown rule
+  class UnknownRuleError < StandardError; end
+
+  ERRORS = [
+    MissingIdError, WrongFormatError, OSVersionMismatch,
+    ActiveRecord::RecordInvalid, ExternalReportError, UnknownBenchmarkError,
+    UnknownProfileError, UnknownRuleError
+  ].freeze
+
   include ::Xccdf::Util
 
   attr_reader :report_path, :test_result_file
 
   def initialize(report_contents, message)
-    raise ::MissingIdError unless valid_message_format?(message)
+    raise MissingIdError unless valid_message_format?(message)
 
     @b64_identity = message['b64_identity']
     @account = Account.find_or_create_by(account_number: message['account'])

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -17,7 +17,7 @@ task sync_with_inventory: [:environment] do
         puts 'Inventory API error while syncing account '\
           "#{account.account_number}: System #{host.id} - #{host.name}. "
         puts e.full_message
-      rescue ::InventoryHostNotFound
+      rescue HostInventoryAPI::InventoryHostNotFound
         print "Account #{account.account_number}: "\
           "System #{host.id} - #{host.name} not found in the inventory. "\
           'Removing it from DB...'

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -49,7 +49,7 @@ class ParseReportJobTest < ActiveSupport::TestCase
 
   test 'payload tracker is notified about errored processing' do
     XccdfReportParser.stubs(:new).returns(@parser)
-    @parser.stubs(:save_all).raises(WrongFormatError)
+    @parser.stubs(:save_all).raises(XccdfReportParser::WrongFormatError)
     Sidekiq.stubs(:redis).returns(false)
     @parse_report_job.stubs(:jid).returns('1')
     PayloadTracker.expects(:deliver).with(
@@ -61,7 +61,8 @@ class ParseReportJobTest < ActiveSupport::TestCase
     PayloadTracker.expects(:deliver).with(
       account: @msg_value['account'], system_id: @msg_value['id'],
       request_id: @msg_value['request_id'], status: :error,
-      status_msg: "Cannot parse report: WrongFormatError - #{error_msg}"
+      status_msg:
+      "Cannot parse report: XccdfReportParser::WrongFormatError - #{error_msg}"
     )
     @parse_report_job.perform(@file, @msg_value)
   end

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -47,7 +47,7 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   end
 
   test 'inventory_host for host not already in inventory' do
-    assert_raises(::InventoryHostNotFound) do
+    assert_raises(HostInventoryAPI::InventoryHostNotFound) do
       @api.expects(:host_already_in_inventory).returns(nil)
       @api.inventory_host(@host.id)
     end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -72,7 +72,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     should 'never save a new benchmark that is not in the support matrix' do
       @report_parser.op_benchmark.stubs(:version).returns('0.1.15')
       assert_difference('Xccdf::Benchmark.count', 0) do
-        assert_raises(::UnknownBenchmarkError) do
+        assert_raises(XccdfReportParser::UnknownBenchmarkError) do
           @report_parser.save_all
         end
       end
@@ -105,7 +105,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     should 'never save a new canonical profile if it did not exist before' do
       @report_parser.stubs(:save_missing_supported_benchmark)
       assert_difference('Profile.count', 0) do
-        assert_raises(::UnknownProfileError) do
+        assert_raises(XccdfReportParser::UnknownProfileError) do
           @report_parser.save_all
         end
       end
@@ -180,7 +180,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       ).returns(OpenStruct.new(body: system_profile_body.to_json))
 
       @report_parser.save_host
-      assert_raises(::OSVersionMismatch) do
+      assert_raises(XccdfReportParser::OSVersionMismatch) do
         @report_parser.check_os_version
       end
     end
@@ -234,7 +234,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
 
   context 'missing ID' do
     should 'raise error if message ID is not present' do
-      assert_raises(::MissingIdError) do
+      assert_raises(XccdfReportParser::MissingIdError) do
         TestParser.new(
           'fakereport',
           'account' => accounts(:test).account_number,
@@ -282,7 +282,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       ).save(validate: false)
 
       assert_difference('Rule.count', 0) do
-        assert_raises(UnknownRuleError) do
+        assert_raises(XccdfReportParser::UnknownRuleError) do
           @report_parser.save_all
         end
       end
@@ -358,7 +358,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
   context 'datastream-based reports only' do
     should 'raise an error if the report is not coming from a datastream' do
       fake_report = file_fixture('rhel-xccdf-report-wrong.xml').read
-      assert_raises(::WrongFormatError) do
+      assert_raises(XccdfReportParser::WrongFormatError) do
         TestParser.new(
           fake_report,
           'account' => accounts(:test).account_number,
@@ -376,7 +376,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     should 'raise an error and halt parsing (external report)' do
       @report_parser.stubs(:external_report?).returns(true)
       @report_parser.save_host
-      assert_raises(::ExternalReportError) do
+      assert_raises(XccdfReportParser::ExternalReportError) do
         @report_parser.check_for_external_reports
       end
     end


### PR DESCRIPTION
If benchmark, profile, or rules are missing from a test result upload,
we should never retry parsing those uploads.

Signed-off-by: Andrew Kofink <akofink@redhat.com>