### PR TITLE
fix(profiles migration): RHICOMPL-1045 policy_id foreign key

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -32,6 +32,7 @@ class Profile < ApplicationRecord
   validates :name, presence: true
   validates :benchmark_id, presence: true
   validates :account, presence: true, if: -> { hosts.any? }
+  validates :policy_object, presence: true, if: -> { policy_id }
 
   class << self
     def from_openscap_parser(op_profile, benchmark_id: nil, account_id: nil)

--- a/db/migrate/20201216190051_add_policy_id_foreign_key_on_profiles.rb
+++ b/db/migrate/20201216190051_add_policy_id_foreign_key_on_profiles.rb
@@ -1,0 +1,5 @@
+class AddPolicyIdForeignKeyOnProfiles < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :profiles, :policies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_160531) do
+ActiveRecord::Schema.define(version: 2020_12_16_190051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -216,5 +216,6 @@ ActiveRecord::Schema.define(version: 2020_11_16_160531) do
   add_foreign_key "policies", "business_objectives"
   add_foreign_key "policy_hosts", "hosts"
   add_foreign_key "policy_hosts", "policies"
+  add_foreign_key "profiles", "policies"
   add_foreign_key "profiles", "profiles", column: "parent_profile_id"
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -68,7 +68,16 @@ class ProfileTest < ActiveSupport::TestCase
 
     p = profiles(:one).dup
     assert_not p.update(policy_id: policies(:two).id, benchmark: bm)
-    assert  p.errors.full_messages.join['Policy type must be unique']
+    assert p.errors.full_messages.join['Policy type must be unique']
+  end
+
+  test 'absence of a policy, but policy_id set' do
+    assert_nothing_raised do
+      profiles(:one).update!(policy_id: policies(:one).id)
+    end
+
+    assert_not profiles(:one).update(policy_id: UUID.generate)
+    assert_includes profiles(:one).errors[:policy_object], "can't be blank"
   end
 
   test 'coexistence of external profiles with and without a policy' do
@@ -186,7 +195,7 @@ class ProfileTest < ActiveSupport::TestCase
     bo = BusinessObjective.new(title: 'abcd')
     bo.save
     policies(:one).update(business_objective: bo)
-    assert profiles(:one).business_objective, bo
+    assert profiles(:one).reload.business_objective, bo
     policies(:one).update(business_objective: nil)
     assert_empty BusinessObjective.where(title: 'abcd')
   end


### PR DESCRIPTION
Add a foreign key to profiles.policy_id. This means that a policy cannot
be removed from the database while some profile references it.

This also adds a validation for the same case so we can detect and
report a nice error for it, if it ever happens.

Signed-off-by: Andrew Kofink <akofink@redhat.com>