### PR TITLE
refactor(Policy): RHICOMPL-1057 with_hosts scope 

### DIFF
--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -39,16 +39,6 @@ module ProfilePolicyAssociation
       errors.add(:policy_type, error_msg) if profile
     end
 
-    # Lookup up internal profile that has the host(s)
-    # assinged to a policy an which matches the ref_id
-    # and ref_id of a benchmark (to ensure major OS version)
-    def find_policy(hosts: test_result_hosts, account: account_id)
-      Profile.includes(:benchmark, :policy_hosts)
-             .where(policy_hosts: { host_id: hosts })
-             .find_by(account: account, external: false, ref_id: ref_id,
-                      benchmarks: { ref_id: benchmark.ref_id })
-    end
-
     def compliance_threshold
       policy_object&.compliance_threshold ||
         Policy::DEFAULT_COMPLIANCE_THRESHOLD

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -27,6 +27,10 @@ class Policy < ApplicationRecord
   after_update :destroy_orphaned_business_objective
   after_rollback :destroy_orphaned_business_objective
 
+  scope :with_hosts, lambda { |hosts|
+    joins(:hosts).where(hosts: { id: hosts }).distinct
+  }
+
   def self.attrs_from(profile:)
     profile.attributes.slice(*PROFILE_ATTRS)
   end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -31,6 +31,10 @@ class Policy < ApplicationRecord
     joins(:hosts).where(hosts: { id: hosts }).distinct
   }
 
+  scope :with_ref_ids, lambda { |ref_ids|
+    joins(:profiles).where(profiles: { ref_id: ref_ids }).distinct
+  }
+
   def self.attrs_from(profile:)
     profile.attributes.slice(*PROFILE_ATTRS)
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -72,14 +72,12 @@ class Profile < ApplicationRecord
     parent_profile_id.blank?
   end
 
-  def clone_to(account:, host: nil, external: true, policy: nil)
-    policy ||= Policy.with_hosts(host).find_by(account: account)
-
+  def clone_to(account:, policy:)
     new_profile = in_account(account, policy)
     if new_profile.nil?
       (new_profile = dup).update!(account: account,
                                   parent_profile: self,
-                                  external: external,
+                                  external: true,
                                   policy_object: policy)
       new_profile.update_rules(ref_ids: rules.pluck(:ref_id))
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -72,8 +72,8 @@ class Profile < ApplicationRecord
     parent_profile_id.blank?
   end
 
-  def clone_to(account: nil, host: nil, external: true, policy: nil)
-    policy ||= find_policy(hosts: [host], account: account)&.policy_object
+  def clone_to(account:, host: nil, external: true, policy: nil)
+    policy ||= Policy.with_hosts(host).find_by(account: account)
 
     new_profile = in_account(account, policy)
     if new_profile.nil?
@@ -87,12 +87,6 @@ class Profile < ApplicationRecord
     new_profile
   end
 
-  def in_account(account, policy)
-    Profile.find_by(account: account, ref_id: ref_id,
-                    policy_object: policy,
-                    benchmark_id: benchmark_id)
-  end
-
   def major_os_version
     benchmark ? benchmark.inferred_os_major_version : 'N/A'
   end
@@ -102,5 +96,13 @@ class Profile < ApplicationRecord
     ref_id.downcase.split(
       'xccdf_org.ssgproject.content_profile_'
     )[1] || ref_id
+  end
+
+  private
+
+  def in_account(account, policy)
+    Profile.find_by(account: account, ref_id: ref_id,
+                    policy_object: policy,
+                    benchmark_id: benchmark_id)
   end
 end

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -29,7 +29,8 @@ module Xccdf
     end
 
     def external_report?
-      test_result_profile.find_policy(account: @account, hosts: [@host]).nil?
+      Policy.with_hosts(@host).with_ref_ids(test_result_profile.ref_id)
+            .find_by(account: @account).nil?
     end
 
     private

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -14,7 +14,7 @@ module Xccdf
         account: @account, host: @host
       )
     end
-    alias save_profile_host host_profile
+    alias save_host_profile host_profile
 
     def associate_rules_from_rule_results
       ::ProfileRule.import!(

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -11,7 +11,8 @@ module Xccdf
 
     def host_profile
       @host_profile ||= test_result_profile.clone_to(
-        account: @account, host: @host
+        policy: Policy.with_hosts(@host).find_by(account: @account),
+        account: @account
       )
     end
     alias save_host_profile host_profile

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -30,7 +30,7 @@ module Xccdf
       end
 
       def save_all_test_result_info
-        save_profile_host
+        save_host_profile
         save_test_result
         save_rule_results
         associate_rules_from_rule_results

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -36,6 +36,38 @@ class PolicyTest < ActiveSupport::TestCase
       assert_includes Policy.with_hosts(hosts(:one)), policies(:one)
       assert_includes Policy.with_hosts(hosts(:two)), policies(:one)
     end
+
+    should '#with_ref_ids accepts multiple ref_ids' do
+      profiles(:one).update!(account: accounts(:test))
+      profiles(:two).update!(account: accounts(:test))
+
+      policies(:one).update!(profiles: [profiles(:one)])
+
+      assert_empty Policy.with_ref_ids([profiles(:two).ref_id])
+      assert_includes Policy.with_ref_ids([profiles(:one).ref_id]),
+                      policies(:one)
+
+      policies(:one).update!(profiles: [profiles(:one), profiles(:two)])
+
+      assert_includes Policy.with_ref_ids([profiles(:one).ref_id,
+                                           profiles(:two).ref_id]),
+                      policies(:one)
+    end
+
+    should '#with_ref_ids accepts single ref_ids' do
+      profiles(:one).update!(account: accounts(:test))
+      profiles(:two).update!(account: accounts(:test))
+
+      policies(:one).update!(profiles: [profiles(:one)])
+
+      assert_empty Policy.with_ref_ids(profiles(:two).ref_id)
+      assert_includes Policy.with_ref_ids(profiles(:one).ref_id), policies(:one)
+
+      policies(:one).update!(profiles: [profiles(:one), profiles(:two)])
+
+      assert_includes Policy.with_ref_ids(profiles(:one).ref_id), policies(:one)
+      assert_includes Policy.with_ref_ids(profiles(:two).ref_id), policies(:one)
+    end
   end
 
   should '#attrs_from(profile:)' do

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -12,6 +12,32 @@ class PolicyTest < ActiveSupport::TestCase
   should belong_to(:business_objective).optional
   should belong_to(:account)
 
+  context 'scopes' do
+    should '#with_hosts accepts multiple hosts' do
+      policies(:one).update!(hosts: [hosts(:one)])
+
+      assert_empty Policy.with_hosts([hosts(:two)])
+      assert_includes Policy.with_hosts([hosts(:one)]), policies(:one)
+
+      policies(:one).update!(hosts: [hosts(:one), hosts(:two)])
+
+      assert_includes Policy.with_hosts([hosts(:one), hosts(:two)]),
+                      policies(:one)
+    end
+
+    should '#with_hosts accepts single hosts' do
+      policies(:one).update!(hosts: [hosts(:one)])
+
+      assert_empty Policy.with_hosts(hosts(:two))
+      assert_includes Policy.with_hosts(hosts(:one)), policies(:one)
+
+      policies(:one).update!(hosts: [hosts(:one), hosts(:two)])
+
+      assert_includes Policy.with_hosts(hosts(:one)), policies(:one)
+      assert_includes Policy.with_hosts(hosts(:two)), policies(:one)
+    end
+  end
+
   should '#attrs_from(profile:)' do
     Policy::PROFILE_ATTRS.each do |attr|
       assert_equal profiles(:one).send(attr),

--- a/test/services/concerns/xccdf/hosts_test.rb
+++ b/test/services/concerns/xccdf/hosts_test.rb
@@ -34,7 +34,7 @@ module Xccdf
     test 'associate_rules_from_rule_results' do
       @parser.save_all_benchmark_info
       @parser.save_host
-      @parser.save_profile_host
+      @parser.save_host_profile
       @parser.save_test_result
       @parser.save_rule_results
 

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -327,7 +327,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
           Profile.find_by(parent_profile: parent_profile)&.rules&.count || 0
         } => parent_profile.rules.count
       ) do
-        @report_parser.save_profile_host
+        @report_parser.save_host_profile
       end
     end
 
@@ -350,7 +350,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         @report_parser.save_rules
         @report_parser.save_profile_rules
         @report_parser.save_host
-        @report_parser.save_profile_host
+        @report_parser.save_host_profile
       end
     end
   end


### PR DESCRIPTION
Introduce `Policy.with_hosts` scope and refactor `profile.clone_to` to use it for policy object lookup.

~`BusinessObjective.in_account` now uses `includes` rather than `joins`+`distinct`, same as `Policy.with_hosts`.~

Remove `Profile#find_policy` altogether by introducing `Policy.with_ref_ids` scope.