### PR TITLE
fix(docker-compose): Remove conflicting ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,13 +76,15 @@ services:
       - INGRESS_VALIDTOPICS=testareno,advisor,buckit,compliance #if you test a different topic, add it here
       - INGRESS_INVENTORYURL=inventory-web:8081/api/inventory/v1/hosts
       - OPENSHIFT_BUILD_COMMIT=woopwoop
+      - INGRESS_WEBPORT=8080
+      - INGRESS_METRICSPORT=3001
       - INGRESS_MINIODEV=true
       - INGRESS_MINIOACCESSKEY=$MINIO_ACCESS_KEY
       - INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY
       - INGRESS_MINIOENDPOINT=minio:9000
       - INGRESS_MAXSIZE=104857600 # 100 MB
     ports:
-      - 8080:3000
+      - 8080:8080
     depends_on:
       - kafka
     links:


### PR DESCRIPTION
This essentially reverts #679 but uses the new env variables. I did not
properly test #679 at the time, but it breaks podman-compose, which runs all
containers in the same pod. That means ports cannot conflict internally
or externally because they are mapped from the pod, not each container.

Signed-off-by: Andrew Kofink <akofink@redhat.com>