### PR TITLE
refactor(Profile): RHICOMPL-999 remove BO and threshold columns

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -5,8 +5,7 @@ class Policy < ApplicationRecord
   include ProfilePolicyScoring
 
   DEFAULT_COMPLIANCE_THRESHOLD = 100.0
-  PROFILE_ATTRS = %w[name description account_id compliance_threshold
-                     business_objective_id].freeze
+  PROFILE_ATTRS = %w[name description account_id].freeze
 
   has_many :profiles, dependent: :destroy, inverse_of: :policy_object
   has_many :benchmarks, through: :profiles

--- a/app/services/copy_profiles_to_policies.rb
+++ b/app/services/copy_profiles_to_policies.rb
@@ -22,7 +22,7 @@ class CopyProfilesToPolicies
   def create_policies
     profiles.where(external: false).find_each do |profile|
       policy = Policy.create!(Policy.attrs_from(profile: profile))
-      profile.update!(policy_id: policy.id, business_objective_id: nil)
+      profile.update!(policy_id: policy.id)
 
       host_ids = profile.profile_hosts.distinct.pluck(:host_id)
       PolicyHost.create(

--- a/app/services/external_profile_updater.rb
+++ b/app/services/external_profile_updater.rb
@@ -6,9 +6,7 @@ class ExternalProfileUpdater
     # rubocop:disable Rails/SkipsModelValidations
     def run!(date = DateTime.now)
       Profile.where('created_at < ?', date)
-             .update_all(external: true,
-                         compliance_threshold: 100,
-                         business_objective_id: nil)
+             .update_all(external: true)
     end
     # rubocop:enable Rails/SkipsModelValidations
   end

--- a/db/migrate/20201222134736_remove_threshold_business_objective_from_profiles.rb
+++ b/db/migrate/20201222134736_remove_threshold_business_objective_from_profiles.rb
@@ -1,0 +1,8 @@
+class RemoveThresholdBusinessObjectiveFromProfiles < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :profiles, :business_objective_id
+    remove_column :profiles, :business_objective_id, :uuid
+
+    remove_column :profiles, :compliance_threshold, :float, default: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_190051) do
+ActiveRecord::Schema.define(version: 2020_12_22_134736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -112,14 +112,11 @@ ActiveRecord::Schema.define(version: 2020_12_16_190051) do
     t.datetime "updated_at", null: false
     t.string "description"
     t.uuid "account_id"
-    t.float "compliance_threshold", default: 100.0
-    t.uuid "business_objective_id"
     t.uuid "benchmark_id", null: false
     t.uuid "parent_profile_id"
     t.boolean "external", default: false, null: false
     t.uuid "policy_id"
     t.index ["account_id"], name: "index_profiles_on_account_id"
-    t.index ["business_objective_id"], name: "index_profiles_on_business_objective_id"
     t.index ["external"], name: "index_profiles_on_external"
     t.index ["name"], name: "index_profiles_on_name"
     t.index ["parent_profile_id"], name: "index_profiles_on_parent_profile_id"

--- a/test/graphql/mutations/edit_policy_mutation_test.rb
+++ b/test/graphql/mutations/edit_policy_mutation_test.rb
@@ -19,7 +19,6 @@ class EditPolicyMutationTest < ActiveSupport::TestCase
     users(:test).update account: accounts(:test)
     profiles(:one).update(account: accounts(:test),
                           hosts: [hosts(:one)],
-                          compliance_threshold: 90,
                           policy_object: policies(:one))
     assert_nil policies(:one).business_objective
 

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -208,12 +208,10 @@ class ProfileTest < ActiveSupport::TestCase
     assert_equal business_objectives(:one), profiles(:one).business_objective
   end
 
-  test 'compliance_threshold comes from policy for external profiles' do
+  test 'compliance_threshold comes from policy default for external profiles' do
     (bm = benchmarks(:one).dup).update!(version: '0.1.47')
     (external_profile = profiles(:one).dup).update!(benchmark: bm,
-                                                    compliance_threshold: 100,
                                                     policy_object: nil)
-    profiles(:one).update!(compliance_threshold: 30)
     assert_nil external_profile.policy_object
     assert_equal 100, external_profile.compliance_threshold
   end

--- a/test/services/copy_profiles_to_policies_test.rb
+++ b/test/services/copy_profiles_to_policies_test.rb
@@ -9,9 +9,7 @@ class CopyProfilesToPoliciesTest < ActiveSupport::TestCase
   setup do
     Policy.destroy_all
     profiles(:one).update!(parent_profile: profiles(:two),
-                           account: accounts(:test),
-                           compliance_threshold: 75.0,
-                           business_objective_id: business_objectives(:two).id)
+                           account: accounts(:test))
   end
 
   test 'copies profile attributes to new policies' do

--- a/test/services/external_profile_updater_test.rb
+++ b/test/services/external_profile_updater_test.rb
@@ -3,8 +3,7 @@
 require 'test_helper'
 
 class ExternalProfileUpdaterTest < ActiveSupport::TestCase
-  test 'updates profiles before a certain date to be external with default '\
-       'threshold and business objective' do
+  test 'updates profiles before a certain date to be external' do
     expected_change = Profile.count
     date = DateTime.now
 


### PR DESCRIPTION
Remove business_objective and compliance_threshold columns from the
profiles table.

Signed-off-by: Andrew Kofink <akofink@redhat.com>