### PR TITLE
devel(compose): use ingress:stable image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - MINIO_ACCESS_KEY
       - MINIO_SECRET_KEY
   ingress:
-    image: quay.io/cloudservices/insights-ingress:latest
+    image: quay.io/cloudservices/insights-ingress:stable
     environment:
       - AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY
       - AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY


### PR DESCRIPTION
The ingress:latest image doesn't accept local uploads at the moment. I think most of us are keeping this change stashed right now, so it makes sense to commit it until ingress is patched.

Signed-off-by: Andrew Kofink <akofink@redhat.com>