### PR TITLE
devel(compose): Use old ingress port env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - INGRESS_VALIDTOPICS=testareno,advisor,buckit,compliance #if you test a different topic, add it here
       - INGRESS_INVENTORYURL=inventory-web:8081/api/inventory/v1/hosts
       - OPENSHIFT_BUILD_COMMIT=woopwoop
+      - INGRESS_PORT=8080
       - INGRESS_WEBPORT=8080
       - INGRESS_METRICSPORT=3001
       - INGRESS_MINIODEV=true


### PR DESCRIPTION
Missed this on the last change :see_no_evil: 

This only breaks with podman because everything is run in the same
network namespace. Using the old stable image requires this env
variable. I'm keeping the new variables there for when we can use latest
again.

Signed-off-by: Andrew Kofink <akofink@redhat.com>