### PR TITLE
fix(parsing): RHICOMPL-933 Identify policies with changing ref_ids

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -31,4 +31,8 @@ class Host < ApplicationRecord
               os_major_version: i_host['os_major_version'],
               os_minor_version: i_host['os_minor_version'] }.compact)
   end
+
+  def os_version
+    "#{os_major_version}.#{os_minor_version}"
+  end
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -34,6 +34,12 @@ class Policy < ApplicationRecord
     joins(:profiles).where(profiles: { ref_id: ref_ids }).distinct
   }
 
+  scope :with_ssgs, lambda { |ssgs|
+    joins(profiles: :benchmark).where(
+      profiles: { benchmarks: {version: ssgs }}
+    ).distinct
+  }
+
   def self.attrs_from(profile:)
     profile.attributes.slice(*PROFILE_ATTRS)
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,6 +9,8 @@ class Profile < ApplicationRecord
   include ProfileHosts
   include ProfileRules
 
+  REF_ID_PREFIX = 'xccdf_org.ssgproject.content_profile_'
+
   belongs_to :account, optional: true
   belongs_to :benchmark, class_name: 'Xccdf::Benchmark'
   belongs_to :parent_profile, class_name: 'Profile', optional: true
@@ -57,6 +59,12 @@ class Profile < ApplicationRecord
 
   def policy_type
     (parent_profile || self).name
+  end
+
+  def equivalent_ref_ids
+    SupportedSsg.equivalent_ref_ids(ref_id: ref_id,
+                                    os_major_version: os_major_version,
+                                    ssg_version: ssg_version)
   end
 
   def fill_from_parent

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -11,7 +11,9 @@ module Xccdf
 
     def host_profile
       @host_profile ||= test_result_profile.clone_to(
-        policy: Policy.with_hosts(@host).find_by(account: @account),
+        policy: Policy.with_hosts(@host)
+                      .with_ref_ids(test_result_profile.ref_id)
+                      .find_by(account: @account),
         account: @account
       )
     end

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -11,9 +11,7 @@ module Xccdf
 
     def host_profile
       @host_profile ||= test_result_profile.clone_to(
-        policy: Policy.with_hosts(@host)
-                      .with_ref_ids(test_result_profile.ref_id)
-                      .find_by(account: @account),
+        policy: find_policy,
         account: @account
       )
     end
@@ -37,6 +35,23 @@ module Xccdf
     end
 
     private
+
+    def find_policy
+      Policy.with_hosts(@host).where(account: @account)
+            .with_ref_ids(test_result_profile.ref_id)
+            .first
+
+      # SupportedSsg.equivalent_ref_ids(
+      #   ref_id: test_result_profile.ref_id,
+      #   os_major_version: benchmark.os_major_version,
+      #   ssg_version: benchmark.version
+      # ).map do |profile_info|
+      #   policies.with_ssgs(profile_info[:ssg_version])
+      #           .with_ref_ids(profile_info[:ref_ids])
+      # end.inject(Policy.none) do |rel, policies|
+      #   rel.or(Policy.where(id: policies))
+      # end.or(Policy.with_ref_ids(test_result_profile.ref_id)).first
+    end
 
     def test_result_profile
       @test_result_profile ||= ::Profile.canonical.create_with(


### PR DESCRIPTION
Submitting as a draft for transparency, but the work is still in a rough state at the moment and does not function. :)

Between certain versions of RHEL and SSG, profile ref_ids change. This
prevents identifying a policy by the existing profile ref_ids. Instead,
we must find equivalent ref_ids to search by on the policy. Note that
new ref_ids may be renamed to allow a new profile to take the old
ref_id, so it's important we lookup profiles by ref_id, SSG version, and
benchmark (i.e. OS major version).