### PR TITLE
fix(report parse): RHICOMPL-1295 Find Policy by test_result_profile ref_id

### DIFF
--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -11,7 +11,9 @@ module Xccdf
 
     def host_profile
       @host_profile ||= test_result_profile.clone_to(
-        policy: Policy.with_hosts(@host).find_by(account: @account),
+        policy: Policy.with_hosts(@host)
+                      .with_ref_ids(test_result_profile.ref_id)
+                      .find_by(account: @account),
         account: @account
       )
     end


### PR DESCRIPTION
This fixes an oversight where policies are found only by account and
host association while never checking ref_id. This changes it so
policies are matched on exact ref_id of the uploaded test result
profile.

Signed-off-by: Andrew Kofink <akofink@redhat.com>