### PR TITLE
fix(data): RHICOMPL-1301 remove incorrect profiles from policies

### DIFF
--- a/app/services/incorrect_profile_remover.rb
+++ b/app/services/incorrect_profile_remover.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# A class to remove profiles on policies that do not have a matching ref_id
+class IncorrectProfileRemover
+  def self.run!
+    counts = Policy.includes(:profiles).find_each.flat_map do |policy|
+      next unless policy.profiles.length > 1
+
+      find_incorrect_profiles(policy).destroy_all.count
+    end.compact
+
+    Logger.new(STDOUT).info "#{counts.sum} profiles removed from policies with"\
+                            ' mismatched ref_ids'
+  end
+
+  def self.find_incorrect_profiles(policy)
+    Profile.where(policy_object: policy)
+           .where.not(ref_id: policy.initial_profile.ref_id)
+  end
+end

--- a/db/migrate/20210107151954_remove_incorrect_profiles_from_policies.rb
+++ b/db/migrate/20210107151954_remove_incorrect_profiles_from_policies.rb
@@ -1,0 +1,5 @@
+class RemoveIncorrectProfilesFromPolicies < ActiveRecord::Migration[5.2]
+  def change
+    IncorrectProfileRemover.run!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_134736) do
+ActiveRecord::Schema.define(version: 2021_01_07_151954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/test/services/incorrect_profile_remover_test.rb
+++ b/test/services/incorrect_profile_remover_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class IncorrectProfileRemoverTest < ActiveSupport::TestCase
+  setup do
+    profiles(:one).update!(policy_object: policies(:one),
+                           account: accounts(:test))
+    profiles(:two).update!(policy_object: policies(:two),
+                           account: accounts(:test))
+  end
+
+  test 'removes profiles with a mismatched ref_id' do
+    profiles(:one).dup.update!(ref_id: 'foo', external: true)
+    assert_equal 2, policies(:one).profiles.count
+    assert_difference('Profile.count' => -1) do
+      IncorrectProfileRemover.run!
+    end
+  end
+
+  test 'does nothing to new policies with only an initial profile' do
+    assert_difference('Profile.count' => 0) do
+      IncorrectProfileRemover.run!
+    end
+  end
+
+  test 'does nothing to policies with no mismatched profiles' do
+    (bm2 = benchmarks(:one).dup).update!(version: '0.1.23')
+    profiles(:one).dup.update!(benchmark: bm2, external: true)
+    assert_equal 2, policies(:one).profiles.count
+    assert_difference('Profile.count' => 0) do
+      IncorrectProfileRemover.run!
+    end
+  end
+end


### PR DESCRIPTION
A bug introduced in RHICOMPL-1295 caused some profiles to be incorrectly
associated to policies. The initial profile on a policy essentially
determines the policy's policy type. If any profile ref_id does not
match this initial profile's ref_id, it does not belong on the policy
and will be removed along with any test results.

Signed-off-by: Andrew Kofink <akofink@redhat.com>