### PR TITLE
feat(external policies): RHICOMPL-1151 remove them all

### DIFF
--- a/app/models/concerns/profile_hosts.rb
+++ b/app/models/concerns/profile_hosts.rb
@@ -8,6 +8,7 @@ module ProfileHosts
     has_many :test_results, dependent: :destroy
     has_many :test_result_hosts, -> { distinct },
              through: :test_results, source: :host
+    has_many :rule_results, through: :test_results
     has_many :profile_hosts, dependent: :destroy
     has_many :policy_hosts, through: :policy_object
     has_many :assigned_hosts, through: :policy_hosts, source: :host

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -8,6 +8,7 @@ class RuleResult < ApplicationRecord
   belongs_to :host
   belongs_to :rule
   belongs_to :test_result
+  has_one :profile, through: :test_result
 
   validates :test_result, presence: true,
                           uniqueness: { scope: %i[host_id rule_id] }

--- a/app/services/external_policy_remover.rb
+++ b/app/services/external_policy_remover.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# A service class to remove external policies (i.e. profiles with no policy)
+class ExternalPolicyRemover
+  class << self
+    def run!
+      count = Profile.external(true).where(policy_id: nil).destroy_all.count
+
+      Logger.new(STDOUT).info "Removed #{count} external policies"
+    end
+  end
+end

--- a/db/migrate/20210107161848_remove_external_policies.rb
+++ b/db/migrate/20210107161848_remove_external_policies.rb
@@ -1,0 +1,5 @@
+class RemoveExternalPolicies < ActiveRecord::Migration[5.2]
+  def change
+    ExternalPolicyRemover.run!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_151954) do
+ActiveRecord::Schema.define(version: 2021_01_07_161848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -8,6 +8,8 @@ class ProfileTest < ActiveSupport::TestCase
   should have_many(:profile_host_hosts).through(:profile_hosts)
   should have_many(:assigned_hosts).through(:policy_hosts).source(:host)
   should have_many(:hosts).through(:test_results)
+  should have_many(:test_results).dependent(:destroy)
+  should have_many(:rule_results).through(:test_results)
   should belong_to(:policy_object).optional
   should validate_uniqueness_of(:ref_id)
     .scoped_to(%i[account_id benchmark_id external policy_id])
@@ -238,8 +240,15 @@ class ProfileTest < ActiveSupport::TestCase
     end
 
     should 'also destroys its related test results' do
-      test_results(:one).update profile: profiles(:one), host: hosts(:one)
+      assert_equal 1, profiles(:one).test_results.count
       assert_difference('Profile.count' => -1, 'TestResult.count' => -1) do
+        profiles(:one).destroy
+      end
+    end
+
+    should 'also destroys its related rule results' do
+      assert_equal 1, profiles(:one).rule_results.count
+      assert_difference('Profile.count' => -1, 'RuleResult.count' => -1) do
         profiles(:one).destroy
       end
     end

--- a/test/models/rule_result_test.rb
+++ b/test/models/rule_result_test.rb
@@ -6,4 +6,6 @@ class RuleResultTest < ActiveSupport::TestCase
   should validate_presence_of :rule
   should validate_presence_of :host
   should validate_presence_of :test_result
+
+  should have_one(:profile).through(:test_result)
 end

--- a/test/services/external_policy_remover_test.rb
+++ b/test/services/external_policy_remover_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# A class to test removal of external policies
+class ExternalPolicyRemoverTest < ActiveSupport::TestCase
+  test 'does nothing if no external policies exist' do
+    assert_empty Profile.external.where(policy_id: nil)
+    assert_difference('Profile.count' => 0) do
+      ExternalPolicyRemover.run!
+    end
+  end
+
+  test 'removes all external policies' do
+    profiles(:one).dup.update!(external: true, account: accounts(:test))
+    profiles(:two).dup.update!(external: true, policy_object: policies(:one),
+                               account: accounts(:test))
+    assert_equal 1, Profile.external.where(policy_id: nil).count
+    assert_difference('Profile.count' => -1) do
+      ExternalPolicyRemover.run!
+    end
+  end
+end


### PR DESCRIPTION
Remove all external policies from the perspective of the UI. This means
removing all profiles that are not associated to a policy that have the
external attribute set to true. Note: canonical profiles are marked as
external=false and are not affected by this migration.

Signed-off-by: Andrew Kofink <akofink@redhat.com>