### PR TITLE
revert: RHICOMPL-1301 remove incorrect profiles from policies

### DIFF
--- a/db/migrate/20210107151954_remove_incorrect_profiles_from_policies.rb
+++ b/db/migrate/20210107151954_remove_incorrect_profiles_from_policies.rb
@@ -1,5 +1,5 @@
 class RemoveIncorrectProfilesFromPolicies < ActiveRecord::Migration[5.2]
   def change
-    IncorrectProfileRemover.run!
+    # IncorrectProfileRemover.run!
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_161848) do
+ActiveRecord::Schema.define(version: 2021_01_12_221033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
We will need to create a new migration when we fix this. This migration
is now just a no-op but must stay in place to keep deployed schemas
versions consistent.

Signed-off-by: Andrew Kofink <akofink@redhat.com>