### PR TITLE
chore(migrations): RHICOMPL-1301 activate remove incorrect profiles from policies

### DIFF
--- a/db/migrate/20210107151954_remove_incorrect_profiles_from_policies.rb
+++ b/db/migrate/20210107151954_remove_incorrect_profiles_from_policies.rb
@@ -1,5 +1,5 @@
 class RemoveIncorrectProfilesFromPolicies < ActiveRecord::Migration[5.2]
   def change
-    # IncorrectProfileRemover.run!
+    IncorrectProfileRemover.run!
   end
 end


### PR DESCRIPTION
This partially reverts commit 220bea2f7acdac477d7f94ce2ed0fb88dd235467.

This would be used for testing on stage and later on updated
accordingly.