### PR TITLE
chore(supported_ssg): RHICOMPL-1309 SSG 0.1.52 supported for RHEL 7.9

### DIFF
--- a/config/supported_ssg.yaml
+++ b/config/supported_ssg.yaml
@@ -1,5 +1,5 @@
 ---
-revision: '2020-09-24'
+revision: '2021-01-18'
 supported:
   RHEL-6.6:
     - package: scap-security-guide-0.1.18-3.el6
@@ -212,6 +212,28 @@ supported:
       # RHEL 7 with CIS backported to 0.1.49 in downstream
       version: 0.1.49
       upstream_version: 0.1.50
+      profiles:
+        anssi_nt28_enhanced:
+        anssi_nt28_high:
+        anssi_nt28_intermediary:
+        anssi_nt28_minimal:
+        C2S:
+        cis:
+        cjis:
+        cui:
+        e8:
+        hipaa:
+        ncp:
+        ospp:
+        pci-dss_centric:
+        pci-dss:
+        rhelh-stig:
+        rhelh-vpp:
+        rht-ccp:
+        standard:
+        stig:
+    - package: scap-security-guide-0.1.52-2.el7_9
+      version: 0.1.52
       profiles:
         anssi_nt28_enhanced:
         anssi_nt28_high:


### PR DESCRIPTION
RHEL 7.9 would get two SSG versions (branches) supported.