### PR TITLE
fix: RHICOMPL-1335 high volume removal of Policy/Profile

### DIFF
--- a/app/models/concerns/profile_hosts.rb
+++ b/app/models/concerns/profile_hosts.rb
@@ -9,7 +9,7 @@ module ProfileHosts
     has_many :test_result_hosts, -> { distinct },
              through: :test_results, source: :host
     has_many :rule_results, through: :test_results
-    has_many :profile_hosts, dependent: :destroy
+    has_many :profile_hosts, dependent: :delete_all
     has_many :policy_hosts, through: :policy_object
     has_many :assigned_hosts, through: :policy_hosts, source: :host
     has_many :profile_host_hosts, through: :profile_hosts, source: :host
@@ -18,7 +18,7 @@ module ProfileHosts
     def update_hosts(new_host_ids)
       return unless new_host_ids
 
-      profile_hosts.where.not(host_id: new_host_ids).destroy_all
+      profile_hosts.where.not(host_id: new_host_ids).delete_all
       ProfileHost.import((new_host_ids - host_ids).map do |host_id|
         { host_id: host_id, profile_id: id }
       end)

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -11,7 +11,7 @@ class Policy < ApplicationRecord
   has_many :benchmarks, through: :profiles
   has_many :test_results, through: :profiles, dependent: :destroy
 
-  has_many :policy_hosts, dependent: :destroy
+  has_many :policy_hosts, dependent: :delete_all
   has_many :hosts, through: :policy_hosts, source: :host
   has_many :test_result_hosts, through: :test_results, source: :host
 

--- a/app/models/profile_host.rb
+++ b/app/models/profile_host.rb
@@ -8,12 +8,4 @@ class ProfileHost < ApplicationRecord
 
   validates :profile, presence: true
   validates :host, presence: true, uniqueness: { scope: :profile }
-
-  after_destroy :destroy_orphaned_external_profile
-
-  def destroy_orphaned_external_profile
-    return unless profile.external && profile.hosts.empty?
-
-    profile.destroy
-  end
 end

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -16,8 +16,6 @@ class TestResult < ApplicationRecord
   validates :end_time, presence: true,
                        uniqueness: { scope: %i[host_id profile_id] }
 
-  after_destroy :destroy_orphaned_external_profiles
-
   scope :latest, lambda {
     joins("JOIN (#{latest_without_ids.to_sql}) as tr on "\
           'test_results.profile_id = tr.profile_id AND '\
@@ -28,10 +26,6 @@ class TestResult < ApplicationRecord
   scope :supported, lambda { |supported = true|
     where(supported: supported)
   }
-
-  def destroy_orphaned_external_profiles
-    profile.destroy if profile&.policy_id.nil? && profile&.test_results&.empty?
-  end
 
   def self.latest_without_ids
     group(:profile_id, :host_id)

--- a/test/models/test_result_test.rb
+++ b/test/models/test_result_test.rb
@@ -11,28 +11,4 @@ class TestResultTest < ActiveSupport::TestCase
   should validate_presence_of(:profile)
   should validate_presence_of(:end_time)
   should validate_uniqueness_of(:end_time).scoped_to(%i[host_id profile_id])
-
-  test 'destroy associated external profiles if they have no test results' do
-    profiles(:one).update!(hosts: [hosts(:one)], external: true,
-                           account: accounts(:test))
-    assert_equal test_results(:one).host, hosts(:one)
-    assert_equal test_results(:one).profile, profiles(:one)
-    assert profiles(:one).test_results.one?
-    assert_nil profiles(:one).policy_object
-
-    assert_difference('Profile.count', -1) { hosts(:one).destroy }
-  end
-
-  test 'does not destroy external policies if they still have hosts' do
-    test_results(:two).update! host: hosts(:two), profile: profiles(:one)
-    assert_equal test_results(:two).host, hosts(:two)
-    assert_equal test_results(:two).profile, profiles(:one)
-    assert_equal test_results(:one).host, hosts(:one)
-    assert_equal test_results(:one).profile, profiles(:one)
-    assert 2, profiles(:one).test_results.count
-    assert_nil profiles(:one).policy_object
-    assert_nil profiles(:two).policy_object
-
-    assert_difference('Profile.count', 0) { hosts(:one).destroy }
-  end
 end


### PR DESCRIPTION
Intermediate tables and child tables of high volume should be deleted
right away without invoking destroy callbacks.  An examples is a removal
of a Policy that has a few Profiles but has a high volume of hosts
attached.  Note, that the hosts are attached via intermediate tables
(PolicyHost and ProfileHost) and via TestResults.

When there is a high removal of Policies/Profiles the destroy callbacks
are called for each intermediate/connecting record slowing down the
delete operation.  The destroy callbacks should only be run from the
other hand, from hosts side in this case.

Hence the change from `dependent: destroy` to `dependent: delete_all`.
It might be possible to keep the destroy if there is a possibility to
know the direction in the callback.

Drops destroy_orphaned_external_profiles hooks, as external profiles are
(being) removed.