### PR TITLE
feat(conf): RHICOMPL-1238 option to use SSL and auth for Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Prerequisites:
   - environment variables: `POSTGRESQL_DATABASE`, `POSTGRESQL_SERVICE_HOST`, `POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `POSTGRESQL_ADMIN_PASSWORD`, `DATABASE_SERVICE_NAME`
 * URL to Redis
   - `redis_url` and `redis_cache_url` configured in [settings](config/settings/development.yml)
+  - or, environment variables `SETTINGS__REDIS_URL` and `SETTINGS__REDIS_CACHE_URL`
 * URL to [Insights Inventory](https://github.com/RedHatInsights/insights-host-inventory)
   - or, `host_inventory_url` configured in [settings](config/settings/development.yml)
 * Basic authethication credentials set by

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,6 +47,7 @@ Rails.application.configure do
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, {
     url: "redis://#{Settings.redis_cache_url}",
+    password: Settings.redis_cache_password.present? ? Settings.redis_cache_password : nil,
     ssl: Settings.redis_cache_ssl
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,10 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: "redis://#{Settings.redis_cache_url}" }
+  config.cache_store = :redis_cache_store, {
+    url: "redis://#{Settings.redis_cache_url}",
+    ssl: Settings.redis_cache_ssl
+  }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,6 +3,7 @@ Redis.exists_returns_integer = false # remove on sidekiq upgrade
 sidekiq_config = lambda do |config|
   config.redis = {
     url: "redis://#{Settings.redis_url}",
+    password: Settings.redis_password.present? ? Settings.redis_password : nil,
     ssl: Settings.redis_ssl,
     network_timeout: 5
   }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,6 +3,7 @@ Redis.exists_returns_integer = false # remove on sidekiq upgrade
 sidekiq_config = lambda do |config|
   config.redis = {
     url: "redis://#{Settings.redis_url}",
+    ssl: Settings.redis_ssl,
     network_timeout: 5
   }
   Sidekiq::ReliableFetch.setup_reliable_fetch!(config)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,8 +13,10 @@ rbac_url: http://rbac.rbac-ci.svc.cluster.local:9002
 prometheus_exporter_host: compliance-prometheus-exporter.compliance-ci.svc
 prometheus_exporter_port: 9394
 redis_url: compliance-redis.compliance-ci.svc.cluster.local:6379
+redis_password:
 redis_ssl: false
 redis_cache_url:
+redis_cache_password:
 redis_cache_ssl: false
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,7 @@ rbac_url: http://rbac.rbac-ci.svc.cluster.local:9002
 prometheus_exporter_host: compliance-prometheus-exporter.compliance-ci.svc
 prometheus_exporter_port: 9394
 redis_url: compliance-redis.compliance-ci.svc.cluster.local:6379
+redis_cache_url:
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'
 async: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,9 @@ rbac_url: http://rbac.rbac-ci.svc.cluster.local:9002
 prometheus_exporter_host: compliance-prometheus-exporter.compliance-ci.svc
 prometheus_exporter_port: 9394
 redis_url: compliance-redis.compliance-ci.svc.cluster.local:6379
+redis_ssl: false
 redis_cache_url:
+redis_cache_ssl: false
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'
 async: true


### PR DESCRIPTION
Option to use SSL for Redis by using `redis_ssl` and `redis_cache_ssl` setting,
also settable via envs `SETTINGS__REDIS_SSL` and
`SETTINGS__REDIS_CACHE_SSL`.

Option to set password for Redis by using `redis_password` and `redis_cache_password` setting,
also settable via envs `SETTINGS__REDIS_PASSWORD` and
`SETTINGS__REDIS_CACHE_PASSWORD`.

