### PR TITLE
fix(Account): RHICOMPL-1342 Add auth_type to fake_identity_header

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -16,6 +16,7 @@ class Account < ApplicationRecord
       'identity': {
         'account_number': account_number,
         'type': 'User',
+        'auth_type': 'basic-auth',
         'user': {
           'username': 'ComplianceSyncJob',
           'email': 'no-reply@redhat.com',


### PR DESCRIPTION
This is a new field within the identity that the Inventory service is
now checking for and fails if it does not exist.

Signed-off-by: Andrew Kofink <akofink@redhat.com>