### PR TITLE
feat(cert-auth): RHICOMPL-1080 Validate cert-auth

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -68,7 +68,7 @@ module Authentication
 
   def valid_cert_auth?
     valid_cert_endpoint? && HostInventoryAPI.new(
-      nil, Settings.host_inventory_url, raw_identity_header
+      b64_identity: raw_identity_header
     ).hosts.dig('results').present?
   rescue Faraday::Error => e
     Rails.logger.error(e.full_message)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -67,7 +67,7 @@ module Authentication
   end
 
   def valid_cert_auth?
-    valid_cert_endpoint? && HostInventoryAPI.new(
+    valid_cert_endpoint? && HostInventoryApi.new(
       b64_identity: raw_identity_header
     ).hosts.dig('results').present?
   rescue Faraday::Error => e

--- a/app/controllers/concerns/inventory_service_helper.rb
+++ b/app/controllers/concerns/inventory_service_helper.rb
@@ -30,7 +30,7 @@ module InventoryServiceHelper
     end
 
     def inventory_host(id)
-      ::HostInventoryAPI.new(account: current_user.account).inventory_host(id)
+      ::HostInventoryApi.new(account: current_user.account).inventory_host(id)
     end
   end
 end

--- a/app/controllers/concerns/inventory_service_helper.rb
+++ b/app/controllers/concerns/inventory_service_helper.rb
@@ -30,11 +30,7 @@ module InventoryServiceHelper
     end
 
     def inventory_host(id)
-      ::HostInventoryAPI.new(
-        current_user.account,
-        ::Settings.host_inventory_url,
-        nil # infer identity from account
-      ).inventory_host(id)
+      ::HostInventoryAPI.new(account: current_user.account).inventory_host(id)
     end
   end
 end

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -33,7 +33,7 @@ class ParseReportJob
     parser.save_all
     notify_remediation
     notify_payload_tracker(:success, "Job #{jid} has completed successfully")
-  rescue *XccdfReportParser::ERRORS, *HostInventoryAPI::ERRORS => e
+  rescue *XccdfReportParser::ERRORS, *HostInventoryApi::ERRORS => e
     error_message = "Cannot parse report: #{e} - #{@msg_value.to_json}"
     notify_payload_tracker(:error, error_message)
     Sidekiq.logger.error(error_message)

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -49,9 +49,7 @@ module Xccdf
 
     def inventory_host
       @inventory_host ||= ::HostInventoryAPI.new(
-        @account,
-        ::Settings.host_inventory_url,
-        @b64_identity
+        account: @account, b64_identity: @b64_identity
       ).inventory_host(@host_inventory_id)
     end
   end

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -48,7 +48,7 @@ module Xccdf
     end
 
     def inventory_host
-      @inventory_host ||= ::HostInventoryAPI.new(
+      @inventory_host ||= ::HostInventoryApi.new(
         account: @account, b64_identity: @b64_identity
       ).inventory_host(@host_inventory_id)
     end

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -50,6 +50,12 @@ class HostInventoryAPI
     end
   end
 
+  def hosts
+    JSON.parse(Platform.connection.get(
+      @url, {}, X_RH_IDENTITY: @b64_identity
+    ).body)
+  end
+
   private
 
   def find_os_release(system_profile)

--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -5,7 +5,7 @@ require 'json'
 
 # Interact with the Insights Host Inventory. Usually HTTP calls
 # are all that's needed.
-class HostInventoryAPI
+class HostInventoryApi
   # Error to raise if the inventory host could not be found
   class InventoryHostNotFound < StandardError; end
 

--- a/lib/tasks/import_host_os_releases.rake
+++ b/lib/tasks/import_host_os_releases.rake
@@ -14,7 +14,7 @@ task import_host_os_releases: :environment do
     start_time = Time.now.utc
     puts "Starting import_host_os_releases job at #{start_time}"
     ::Account.includes(:hosts).find_each do |account|
-      inventory_api = HostInventoryAPI.new(account: account)
+      inventory_api = HostInventoryApi.new(account: account)
       ::Host.find_in_batches(batch_size: 50) do |hosts|
         begin
           os_releases = inventory_api.system_profile(hosts.pluck(:id))

--- a/lib/tasks/import_host_os_releases.rake
+++ b/lib/tasks/import_host_os_releases.rake
@@ -14,9 +14,7 @@ task import_host_os_releases: :environment do
     start_time = Time.now.utc
     puts "Starting import_host_os_releases job at #{start_time}"
     ::Account.includes(:hosts).find_each do |account|
-      inventory_api = HostInventoryAPI.new(
-        account, ::Settings.host_inventory_url, account.b64_identity
-      )
+      inventory_api = HostInventoryAPI.new(account: account)
       ::Host.find_in_batches(batch_size: 50) do |hosts|
         begin
           os_releases = inventory_api.system_profile(hosts.pluck(:id))

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -9,9 +9,7 @@ task sync_with_inventory: [:environment] do
     account.hosts.each do |host|
       begin
         host.update_from_inventory_host!(
-          ::HostInventoryAPI.new(
-            account, ::Settings.host_inventory_url, account.b64_identity
-          ).inventory_host(host.id)
+          ::HostInventoryAPI.new(account: account).inventory_host(host.id)
         )
       rescue Faraday::Error => e
         puts 'Inventory API error while syncing account '\

--- a/lib/tasks/sync_with_inventory.rake
+++ b/lib/tasks/sync_with_inventory.rake
@@ -9,13 +9,13 @@ task sync_with_inventory: [:environment] do
     account.hosts.each do |host|
       begin
         host.update_from_inventory_host!(
-          ::HostInventoryAPI.new(account: account).inventory_host(host.id)
+          ::HostInventoryApi.new(account: account).inventory_host(host.id)
         )
       rescue Faraday::Error => e
         puts 'Inventory API error while syncing account '\
           "#{account.account_number}: System #{host.id} - #{host.name}. "
         puts e.full_message
-      rescue HostInventoryAPI::InventoryHostNotFound
+      rescue HostInventoryApi::InventoryHostNotFound
         print "Account #{account.account_number}: "\
           "System #{host.id} - #{host.name} not found in the inventory. "\
           'Removing it from DB...'

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -223,7 +223,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
           }
         }.to_json
       )
-      HostInventoryAPI.any_instance.expects(:hosts)
+      HostInventoryApi.any_instance.expects(:hosts)
                       .raises(Faraday::Error.new(''))
       RbacApi.expects(:new).never
       get profiles_url, headers: { 'X-RH-IDENTITY': encoded_header }
@@ -245,7 +245,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
           }
         }.to_json
       )
-      HostInventoryAPI.any_instance.expects(:hosts).returns('results' => [:foo])
+      HostInventoryApi.any_instance.expects(:hosts).returns('results' => [:foo])
       RbacApi.expects(:new).never
       get profiles_url, headers: { 'X-RH-IDENTITY': encoded_header }
       assert_response :success
@@ -266,7 +266,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
           }
         }.to_json
       )
-      HostInventoryAPI.any_instance.expects(:hosts).returns('results' => [])
+      HostInventoryApi.any_instance.expects(:hosts).returns('results' => [])
       RbacApi.expects(:new).never
       get profiles_url, headers: { 'X-RH-IDENTITY': encoded_header }
       assert_response :forbidden
@@ -288,7 +288,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
           }
         }.to_json
       )
-      HostInventoryAPI.any_instance.expects(:hosts).returns('results' => [:foo])
+      HostInventoryApi.any_instance.expects(:hosts).returns('results' => [:foo])
       RbacApi.expects(:new).never
       get tailoring_file_profile_url(profiles(:one)),
           headers: { 'X-RH-IDENTITY': encoded_header }
@@ -311,7 +311,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
           }
         }.to_json
       )
-      HostInventoryAPI.any_instance.expects(:hosts).returns('results' => [])
+      HostInventoryApi.any_instance.expects(:hosts).returns('results' => [])
       RbacApi.expects(:new).never
       get tailoring_file_profile_url(profiles(:one)),
           headers: { 'X-RH-IDENTITY': encoded_header }
@@ -319,7 +319,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     end
 
     should 'disallow access to profiles#show' do
-      HostInventoryAPI.any_instance.expects(:hosts).never
+      HostInventoryApi.any_instance.expects(:hosts).never
       RbacApi.any_instance.expects(:check_user).never
       profiles(:one).update!(account: accounts(:one))
       encoded_header = Base64.encode64(

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -62,8 +62,8 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     profiles(:two).update account: accounts(:test),
                           policy_object: policies(:two)
 
-    @api = mock('HostInventoryAPI')
-    HostInventoryAPI.expects(:new).returns(@api)
+    @api = mock('HostInventoryApi')
+    HostInventoryApi.expects(:new).returns(@api)
     @api.expects(:inventory_host).returns(
       'id' => NEW_ID,
       'display_name' => 'newhostname'

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -52,8 +52,8 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
 
     assert_empty profiles(:one).assigned_hosts
 
-    @api = mock('HostInventoryAPI')
-    HostInventoryAPI.expects(:new).returns(@api)
+    @api = mock('HostInventoryApi')
+    HostInventoryApi.expects(:new).returns(@api)
     @api.expects(:inventory_host).returns(
       'id' => NEW_ID,
       'display_name' => 'newhostname'

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -12,7 +12,7 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     @host = hosts(:one)
     @url = 'http://localhost'
     @b64_identity = '1234abcd'
-    @api = HostInventoryAPI.new(account: @account, url: @url,
+    @api = HostInventoryApi.new(account: @account, url: @url,
                                 b64_identity: @b64_identity)
     @connection = mock('faraday_connection')
     @system_profile_response = OpenStruct.new(body: {
@@ -48,7 +48,7 @@ class HostInventoryApiTest < ActiveSupport::TestCase
   end
 
   test 'inventory_host for host not already in inventory' do
-    assert_raises(HostInventoryAPI::InventoryHostNotFound) do
+    assert_raises(HostInventoryApi::InventoryHostNotFound) do
       @api.expects(:host_already_in_inventory).returns(nil)
       @api.inventory_host(@host.id)
     end

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -12,7 +12,8 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     @host = hosts(:one)
     @url = 'http://localhost'
     @b64_identity = '1234abcd'
-    @api = HostInventoryAPI.new(@account, @url, @b64_identity)
+    @api = HostInventoryAPI.new(account: @account, url: @url,
+                                b64_identity: @b64_identity)
     @connection = mock('faraday_connection')
     @system_profile_response = OpenStruct.new(body: {
       results: [{ id: @host.id, system_profile: { os_release: '8.2' } }]

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -53,6 +53,13 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     end
   end
 
+  test 'hosts queries inventory hosts endpoint' do
+    response = OpenStruct.new(body: { results: [@inventory_host] }.to_json)
+    @connection.expects(:get).returns(response)
+
+    assert_includes @api.hosts.dig('results').map { |h| h['id'] }, @host.id
+  end
+
   test 'find_results matches on ID' do
     assert_equal(
       @api.send(

--- a/test/tasks/import_datastream_test.rb
+++ b/test/tasks/import_datastream_test.rb
@@ -5,7 +5,7 @@ require 'rake'
 
 class ImportDatastreamTest < ActiveSupport::TestCase
   setup do
-    HostInventoryAPI.any_instance.stubs(:inventory_host).returns(
+    HostInventoryApi.any_instance.stubs(:inventory_host).returns(
       'display_name' => 'foo',
       'os_major_version' => 7,
       'os_minor_version' => 5

--- a/test/tasks/sync_with_inventory_test.rb
+++ b/test/tasks/sync_with_inventory_test.rb
@@ -5,7 +5,7 @@ require 'rake'
 
 class SyncWithInventoryTest < ActiveSupport::TestCase
   setup do
-    HostInventoryAPI.any_instance.stubs(:inventory_host).returns(
+    HostInventoryApi.any_instance.stubs(:inventory_host).returns(
       'display_name' => 'foo',
       'os_major_version' => 7,
       'os_minor_version' => 5
@@ -25,7 +25,7 @@ class SyncWithInventoryTest < ActiveSupport::TestCase
   end
 
   test 'sync_with_inventory handles Inventory API errors' do
-    HostInventoryAPI.any_instance.stubs(:inventory_host)
+    HostInventoryApi.any_instance.stubs(:inventory_host)
                     .raises(Faraday::ServerError.new(500))
 
     assert_nothing_raised do
@@ -34,7 +34,7 @@ class SyncWithInventoryTest < ActiveSupport::TestCase
   end
 
   test 'sync_with_inventory handles Forbidden errors' do
-    HostInventoryAPI.any_instance.stubs(:inventory_host)
+    HostInventoryApi.any_instance.stubs(:inventory_host)
                     .raises(Faraday::ForbiddenError.new(''))
 
     assert_nothing_raised do
@@ -43,7 +43,7 @@ class SyncWithInventoryTest < ActiveSupport::TestCase
   end
 
   test 'sync_with_inventory handles Client errors' do
-    HostInventoryAPI.any_instance.stubs(:inventory_host)
+    HostInventoryApi.any_instance.stubs(:inventory_host)
                     .raises(Faraday::ClientError.new(''))
 
     assert_nothing_raised do
@@ -52,7 +52,7 @@ class SyncWithInventoryTest < ActiveSupport::TestCase
   end
 
   test 'sync_with_inventory handles ConnectionFailed errors' do
-    HostInventoryAPI.any_instance.stubs(:inventory_host)
+    HostInventoryApi.any_instance.stubs(:inventory_host)
                     .raises(Faraday::ConnectionFailed.new(''))
 
     assert_nothing_raised do


### PR DESCRIPTION
For cert-auth, the identity.system.cn must match the system's owner_id
in the system_profile, otherwise the request is unauthorized. In this
implementation, we simply pass cert-auth identity headers through to
inventory, and the response is filtered by identity.system.cn matching
owner_id in the system_profile. If nothing is returned, the identity
header is invalid for that host.

Signed-off-by: Andrew Kofink <akofink@redhat.com>