### PR TITLE
feat(Cyndi): RHICOMPL-1374 create cyndi schema in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,34 @@ First, let's install all dependencies and initialize the database.
 ```shell
 bundle install
 bundle exec rake db:create db:migrate
+bundle exec rake db:test:prepare # for test DB setup
 ```
 
 Once you have database initialized, you might want to import SSG policies:
 
 ```shell
 bundle exec rake ssg:import_rhel_supported
+```
+
+#### Project Cyndi
+
+The compliance project integrates with project cyndi. For local development, a database view is created, built from the inventory database which runs alongside the compliance database. The Cyndi hosts view exists within an inventory schema within the compliance database.
+
+```shell
+bundle exec rails db < db/cyndi_setup.sql # syndicated (cyndi) hosts from inventory
+RAILS_ENV=test bundle exec rails db < db/cyndi_setup.sql # cyndi for test DB
+```
+
+You can verify everything worked as expected within psql for compliance_dev and
+compliance_test databases:
+
+```
+compliance_dev=# \dv inventory.
+          List of relations
+  Schema   | Name  | Type |  Owner
+-----------+-------+------+----------
+ inventory | hosts | view | insights
+(1 row)
 ```
 
 #### Kafka Consumers (XCCDF report consumers)

--- a/db/cyndi_setup.sql
+++ b/db/cyndi_setup.sql
@@ -1,0 +1,32 @@
+--
+-- Intializes a Cyndi-like inventory schema and creates a view copied from a
+-- local inventory DB
+--
+
+CREATE SCHEMA IF NOT EXISTS inventory;
+
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- This view should be queried instead
+CREATE OR REPLACE VIEW inventory.hosts AS
+SELECT
+    id,
+    account,
+    display_name,
+    created_on as created,
+    modified_on as updated,
+    stale_timestamp,
+    stale_timestamp + INTERVAL '1' DAY * 7 AS stale_warning_timestamp,
+    stale_timestamp + INTERVAL '1' DAY * 14 AS culled_timestamp,
+    tags,
+    system_profile_facts as system_profile
+FROM dblink('dbname=insights user=insights', 'select id, account, display_name, created_on, modified_on, stale_timestamp, tags, system_profile_facts from hosts') as hosts(
+    id uuid,
+    account character varying(10),
+    display_name character varying(200),
+    created_on timestamp with time zone,
+    modified_on timestamp with time zone,
+    stale_timestamp timestamp with time zone,
+    tags jsonb,
+    system_profile_facts jsonb
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,12 @@ services:
   build-rails-db:
     image: compliance-backend-rails
     entrypoint: ''
-    command: 'bundle exec rake db:create db:migrate'
+    command: sh -c '
+      bundle exec rake db:create db:migrate;
+      bundle exec rake db:test:prepare;
+      bundle exec rails db < db/cyndi_setup.sql;
+      RAILS_ENV=test bundle exec rails db < db/cyndi_setup.sql;
+      '
     volumes:
       - .:/app:z
     depends_on:


### PR DESCRIPTION
This PR just creates the inventory schema for cyndi and creates a view that comes directly from the local inventory database (using [dblink](https://www.postgresql.org/docs/9.3/contrib-dblink-function.html)). We won't need to run any kind of app-connector here to keep it in sync, since it's just a view of the inventory database. Thanks to beav for the help figuring this out :) This shouldn't break any existing devel workflows. 

Signed-off-by: Andrew Kofink <akofink@redhat.com>