### PR TITLE
fix(smoke): RHICOMPL-1379 grant compliance_user permissions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ def runStages() {
         gitUtils.stageWithContext("Prepare-db", shortenURL = false) {
             migrateStatus = sh(script: "bundle exec rake db:migrate --trace", returnStatus: true)
             sh "bundle exec rake db:test:prepare"
+            sh "POSTGRESQL_USER=postgres bundle exec rails db < db/grant_db_user.sql"
         }
 
         if (migrateStatus != 0) {

--- a/db/grant_db_user.sql
+++ b/db/grant_db_user.sql
@@ -1,0 +1,1 @@
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO compliance_user;


### PR DESCRIPTION
This is required after running migrations because migrations run as the
db super user, but the application runs with compliance_user.

Signed-off-by: Andrew Kofink <akofink@redhat.com>