### PR TITLE
fix(HostInventoryApi): RHICOMPL-1383 handles nil b64_identity

### DIFF
--- a/app/services/host_inventory_api.rb
+++ b/app/services/host_inventory_api.rb
@@ -12,10 +12,10 @@ class HostInventoryApi
   ERRORS = [InventoryHostNotFound].freeze
 
   def initialize(account: nil, url: Settings.host_inventory_url,
-                 b64_identity: account&.b64_identity)
+                 b64_identity: nil)
     @url = "#{URI.parse(url)}#{Settings.path_prefix}/inventory/v1/hosts"
     @account = account
-    @b64_identity = b64_identity
+    @b64_identity = b64_identity || account&.b64_identity
   end
 
   def host_already_in_inventory(host_id)

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -27,6 +27,12 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     assert_nil @api.host_already_in_inventory(@host.id)
   end
 
+  test 'works with nil b64_identity' do
+    api = HostInventoryApi.new(account: @account, b64_identity: nil)
+    assert_equal @account.b64_identity,
+                 api.instance_variable_get(:@b64_identity)
+  end
+
   test 'host_already_in_inventory host exists' do
     response = OpenStruct.new(body: { results: [@inventory_host] }.to_json)
     @connection.expects(:get).returns(response)


### PR DESCRIPTION
This is a regression introduced with RHICOMPL-1080. The HostInventoryApi
gets a nil b64_identity during report parse and must use the
fake_identity from the account.

See https://github.com/RedHatInsights/compliance-backend/pull/719/files#r566446351

Signed-off-by: Andrew Kofink <akofink@redhat.com>