### PR TITLE
chore: update db setup on dev to use db:setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ First, let's install all dependencies and initialize the database.
 
 ```shell
 bundle install
-bundle exec rake db:create db:migrate
+bundle exec rake db:setup # invoke only on first setup!
 bundle exec rake db:test:prepare # for test DB setup
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,11 @@ services:
     image: compliance-backend-rails
     entrypoint: ''
     command: sh -c '
-      bundle exec rake db:create db:migrate;
+      if bundle exec rake db:version 2> /dev/null; then
+        bundle exec rake db:migrate;
+      else
+        bundle exec rake db:setup;
+      fi;
       bundle exec rake db:test:prepare;
       bundle exec rails db < db/cyndi_setup.sql;
       RAILS_ENV=test bundle exec rails db < db/cyndi_setup.sql;


### PR DESCRIPTION
When using the docker-compose, it would first check the db version and
run db:migrate or db:setup.  The check needs to be in place, because the
db:setup (precisely db:schema:load) would drop the data.