### PR TITLE
feat(Hosts): RHICOMPL-1397 with_policy scope / has_policy search

### DIFF
--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -13,6 +13,24 @@ class HostTest < ActiveSupport::TestCase
   should validate_presence_of :name
   should validate_presence_of :account
 
+  test 'with_policy scope / has_policy filter' do
+    assert_equal 0, PolicyHost.count
+
+    PolicyHost.create!(policy: policies(:one), host: hosts(:one))
+
+    assert_includes Host.with_policy, hosts(:one)
+    assert_includes Host.search_for('has_policy=true'), hosts(:one)
+
+    assert_not_includes Host.with_policy(false), hosts(:one)
+    assert_not_includes Host.search_for('has_policy=false'), hosts(:one)
+
+    assert_includes Host.with_policy(false), hosts(:two)
+    assert_includes Host.search_for('has_policy=false'), hosts(:two)
+
+    assert_not_includes Host.with_policy, hosts(:two)
+    assert_not_includes Host.search_for('has_policy=true'), hosts(:two)
+  end
+
   test 'host provides all profiles, assigned and from test results' do
     host = hosts(:one)
     policies(:one).update!(account: host.account)


### PR DESCRIPTION
Similar to the scope and search term within the profiles API, this scope and search provide a way to show only hosts that are a member of some compliance policy. This is necessary to filter hosts after Cyndi, in which all inventory hosts are visible in our APIs.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
