### PR TITLE
feat(logging): RHICOMPL-1217 introduce audit logging 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'uuid'
 # Prometheus exporter
 gem 'prometheus_exporter', '>= 0.5'
 
+# Logging, incl. CloudWatch
+gem 'manageiq-loggers', '~> 0.6.0'
+
 # Parsing OpenSCAP reports library
 gem 'openscap_parser', '~> 1.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,10 @@ GEM
       systemu (~> 2.6.5)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    manageiq-loggers (0.6.0)
+      activesupport (>= 5.0)
+      manageiq-password (~> 0.1)
+    manageiq-password (0.3.0)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
@@ -357,6 +361,7 @@ DEPENDENCIES
   graphql-batch
   irb (>= 1.2)
   listen (>= 3.0.5, < 3.2)
+  manageiq-loggers (~> 0.6.0)
   minitest-reporters
   mocha
   oj

--- a/lib/audit_log/audit_log.rb
+++ b/lib/audit_log/audit_log.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative 'audit_log/formatter'
+require_relative 'audit_log/middleware'
+
+# Common space for Insights API stuff
+module Insights
+  module API
+    module Common
+      # Audit Logger into selected logger, but primarily to CloudWatch
+      class AuditLog
+        class << self
+          def logger
+            @logger ||= init_logger
+          end
+
+          def logger=(logger)
+            @logger = init_logger(logger)
+          end
+
+          def setup(logger = nil)
+            self.logger = logger
+            self
+          end
+
+          def with_account(account_number)
+            original = Thread.current[:audit_account_number]
+            Thread.current[:audit_account_number] = account_number
+            return unless block_given?
+
+            begin
+              yield
+            ensure
+              Thread.current[:audit_account_number] = original
+            end
+          end
+
+          private
+
+          def init_logger(logger = nil)
+            logger ||= Logger.new($stdout)
+            logger.level = Logger::INFO
+            logger.formatter = Formatter.new
+            logger
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/audit_log/audit_log/formatter.rb
+++ b/lib/audit_log/audit_log/formatter.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'manageiq/loggers'
+
+# Common space for Insights API stuff
+module Insights
+  module API
+    module Common
+      class AuditLog
+        # Audit Log formatter with evidence capture
+        class Formatter < ManageIQ::Loggers::Container::Formatter
+          ALLOWED_PAYLOAD_KEYS = %i[message account_number controller remote_ip
+                                    transaction_id].freeze
+
+          def call(severity, time, progname, msg)
+            payload = {
+              '@timestamp': format_datetime(time),
+              hostname: hostname,
+              pid: $PROCESS_ID,
+              thread_id: thread_id,
+              service: progname,
+              level: translate_error(severity),
+              account_number: account_number
+            }
+            JSON.generate(merge_message(payload, msg).compact) << "\n"
+          end
+
+          def merge_message(payload, msg)
+            if msg.is_a?(Hash)
+              payload.merge!(msg.slice(*ALLOWED_PAYLOAD_KEYS))
+            else
+              payload[:message] = msg2str(msg)
+            end
+            if payload[:transaction_id].blank?
+              payload[:transaction_id] = transaction_id
+            end
+            payload
+          end
+
+          private
+
+          def format_datetime(time)
+            time.utc.strftime('%Y-%m-%dT%H:%M:%S.%6NZ')
+          end
+
+          def account_number
+            Thread.current[:audit_account_number]
+          end
+
+          def transaction_id
+            ActiveSupport::Notifications.instrumenter.id
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/audit_log/audit_log/middleware.rb
+++ b/lib/audit_log/audit_log/middleware.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# Common space for Insights API stuff
+module Insights
+  module API
+    module Common
+      class AuditLog
+        # Request events listener, capturing for evidence
+        class Middleware
+          attr_reader :logger, :evidence, :request, :status
+
+          def initialize(app)
+            @app = app
+            @logger = AuditLog.logger
+            @subscribers = []
+            @evidence = {}
+          end
+
+          def call(env)
+            subscribe
+            @request = ActionDispatch::Request.new(env)
+            @app.call(env).tap do |status, _headers, _body|
+              @status = status
+              response_finished
+            end
+          ensure
+            unsubscribe
+          end
+
+          private
+
+          def response_finished
+            payload = {
+              controller: evidence[:controller],
+              remote_ip: request.remote_ip,
+              message: generate_message
+            }
+            log(payload)
+          end
+
+          def generate_message
+            status_label = Rack::Utils::HTTP_STATUS_CODES[status]
+            parts = [
+              "#{request.method} #{request.original_fullpath}" \
+              " -> #{status} #{status_label}",
+              unpermitted_params_msg,
+              halted_cb_msg
+            ]
+            parts.compact.join('; ')
+          end
+
+          def unpermitted_params_msg
+            params = evidence[:unpermitted_parameters]
+            return if params.blank?
+
+            "unpermitted params #{fmt_params(params)}"
+          end
+
+          def halted_cb_msg
+            return if evidence[:halted_callback].blank?
+
+            "filter chain halted by :#{evidence[:halted_callback]}"
+          end
+
+          def log(payload)
+            if status < 400
+              logger.info(payload)
+            elsif status < 500
+              logger.warn(payload)
+            else
+              logger.error(payload)
+            end
+          end
+
+          def subscribe
+            @subscribers << subscribe_conroller
+          end
+
+          # rubocop:disable Metrics/MethodLength
+          def subscribe_conroller
+            ActiveSupport::Notifications.subscribe(/\.action_controller$/) do
+              |name, _started, _finished, _unique_id, payload|
+              # https://guides.rubyonrails.org/active_support_instrumentation.html#action-controller
+              case name.split('.')[0]
+              when 'process_action'
+                @evidence[:controller] = fmt_controller(payload)
+              when 'halted_callback'
+                @evidence[:halted_callback] = payload[:filter]
+              when 'unpermitted_parameters'
+                @evidence[:unpermitted_parameters] = payload[:keys]
+              end
+            end
+          end
+          # rubocop:enable Metrics/MethodLength
+
+          def unsubscribe
+            @subscribers.each do |sub|
+              ActiveSupport::Notifications.unsubscribe(sub)
+            end
+            @subscribers.clear
+          end
+
+          def fmt_controller(payload)
+            return if payload[:controller].blank?
+
+            [payload[:controller], payload[:action]].compact.join('#')
+          end
+
+          def fmt_params(params)
+            params.map { |e| ":#{e}" }.join(', ')
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/audit_log/audit_log_test.rb
+++ b/test/lib/audit_log/audit_log_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'audit_log/audit_log'
+
+class AuditLogTest < ActiveSupport::TestCase
+  setup do
+    @output = StringIO.new
+    @logger = Logger.new(@output)
+    @audit = Insights::API::Common::AuditLog.setup(@logger)
+  end
+
+  def capture_log(msg)
+    @audit.logger.info(msg)
+    @output.rewind # logger seems to read what it's writing?
+    JSON.parse @output.readlines[-1]
+  end
+
+  test 'logs a general message formatted into JSON' do
+    log_msg = capture_log('Audit message')
+    assert_equal 'Audit message', log_msg['message']
+  end
+
+  test 'logs include general evidence' do
+    @audit.logger.info('Audit message')
+    line = @output.string
+    assert line
+
+    log_msg = JSON.parse(line).compact
+    assert_equal log_msg.keys.sort, %w[
+      @timestamp
+      hostname
+      pid
+      thread_id
+      level
+      transaction_id
+      message
+    ].sort
+  end
+
+  test 'setting account number' do
+    begin
+      @audit.with_account('1')
+      log_msg = capture_log('Audit message')
+      assert_equal '1', log_msg['account_number']
+
+      @audit.with_account('2') do
+        log_msg = capture_log('Audit message')
+        assert_equal '2', log_msg['account_number']
+      end
+
+      log_msg = capture_log('Audit message')
+      assert_equal '1', log_msg['account_number']
+
+      @audit.with_account(nil)
+      log_msg = capture_log('Audit message')
+      assert_not log_msg['account_number']
+    ensure
+      @audit.with_account(nil)
+    end
+  end
+end

--- a/test/lib/audit_log/formatter_test.rb
+++ b/test/lib/audit_log/formatter_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'audit_log/audit_log'
+
+class AuditLogFormatterTest < ActiveSupport::TestCase
+  setup do
+    @formatter = Insights::API::Common::AuditLog::Formatter.new
+  end
+
+  test 'formats message string into JSON' do
+    line = @formatter.call('info', Time.zone.now, 'prog', 'Audit message')
+
+    log_msg = JSON.parse(line)
+    assert_equal 'Audit message', log_msg['message']
+  end
+
+  test 'formats message with additional evidence into JSON' do
+    msg = {
+      message: 'Audit message',
+      account_number: '12345',
+      remote_ip: '172.1.2.3'
+    }
+    line = @formatter.call('info', Time.zone.now, 'prog', msg)
+
+    log_msg = JSON.parse(line)
+    assert_equal 'Audit message', log_msg['message']
+    assert_equal '12345', log_msg['account_number']
+    assert_equal '172.1.2.3', log_msg['remote_ip']
+  end
+end

--- a/test/lib/audit_log/formatter_test.rb
+++ b/test/lib/audit_log/formatter_test.rb
@@ -28,4 +28,50 @@ class AuditLogFormatterTest < ActiveSupport::TestCase
     assert_equal '12345', log_msg['account_number']
     assert_equal '172.1.2.3', log_msg['remote_ip']
   end
+
+  context 'sidekiq' do
+    setup do
+      @test_sidekiq = !Module.const_defined?(:Sidekiq)
+      @sidekiq_module = if @test_sidekiq
+                          Object.const_set('Sidekiq', Module.new)
+                        else
+                          @sidekiq_module = Sidekiq
+                        end
+    end
+
+    teardown do
+      Object.send(:remove_const, :Sidekiq) if @test_sidekiq
+    end
+
+    should 'log sidekiq job id from Sidekiq::Context' do
+      orig_ctx_module = @sidekiq_module.const_defined?(:Context) \
+                         && @sidekiq_module::Context
+      ctx_module = Module.new
+      @sidekiq_module.const_set('Context', ctx_module)
+
+      begin
+        ctx_module.stubs(:current).returns(jid: '123')
+        assert Sidekiq::Context.current
+
+        line = @formatter.call('info', Time.zone.now, 'prog', 'Audit message')
+        log_msg = JSON.parse(line)
+        assert_equal '123', log_msg['transaction_id']
+      ensure
+        @sidekiq_module.send(:remove_const, :Context)
+        @sidekiq_module.const_set('Context', orig_ctx_module) if orig_ctx_module
+      end
+    end
+
+    should 'log sidekiq job id from thread local context' do
+      begin
+        Thread.current[:sidekiq_context] = { jid: '123' }
+
+        line = @formatter.call('info', Time.zone.now, 'prog', 'Audit message')
+        log_msg = JSON.parse(line)
+        assert_equal '123', log_msg['transaction_id']
+      ensure
+        Thread.current[:sidekiq_context] = nil
+      end
+    end
+  end
 end

--- a/test/lib/audit_log/middleware_test.rb
+++ b/test/lib/audit_log/middleware_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'audit_log/audit_log'
+
+class AuditLogMiddlewareTest < ActiveSupport::TestCase
+  class MockRackApp
+    attr_reader :request_body
+
+    def initialize(response = nil, instrumentation = nil)
+      @request_headers = {}
+      @response = response || [200, {}, ['OK']]
+      @instrumentation = instrumentation
+    end
+
+    def call(env)
+      @env = env
+      @request_body = env['rack.input'].read
+      if @instrumentation
+        ActiveSupport::Notifications.instrument(*@instrumentation)
+      end
+      @response
+    end
+
+    def [](key)
+      @env[key]
+    end
+  end
+
+  setup do
+    @output = StringIO.new
+    @logger = Logger.new(@output)
+    @audit = Insights::API::Common::AuditLog.setup(@logger)
+  end
+
+  def capture_log
+    @output.rewind # logger seems to read what it's writing?
+    JSON.parse @output.readlines[-1]
+  end
+
+  test 'log successful request' do
+    app = MockRackApp.new
+    mw = Insights::API::Common::AuditLog::Middleware.new(app)
+    request = Rack::MockRequest.new(mw)
+
+    request.get('/', 'HTTP_X_FORWARDED_FOR' => '172.1.2.3')
+
+    log_msg = capture_log
+    assert_equal 'GET / -> 200 OK', log_msg['message']
+    assert_equal '172.1.2.3', log_msg['remote_ip']
+    assert_equal 'info', log_msg['level']
+  end
+
+  test 'log forbidden request' do
+    app = MockRackApp.new([403, {}, ['Forbidden Access']])
+    mw = Insights::API::Common::AuditLog::Middleware.new(app)
+    request = Rack::MockRequest.new(mw)
+
+    request.get('/', 'HTTP_X_FORWARDED_FOR' => '172.1.2.3')
+
+    log_msg = capture_log
+    assert_equal 'GET / -> 403 Forbidden', log_msg['message']
+    assert_equal '172.1.2.3', log_msg['remote_ip']
+    assert_equal 'warning', log_msg['level']
+  end
+
+  test 'log error request' do
+    app = MockRackApp.new([500, {}, ['some Server Error']])
+    mw = Insights::API::Common::AuditLog::Middleware.new(app)
+    request = Rack::MockRequest.new(mw)
+
+    request.get('/', 'HTTP_X_FORWARDED_FOR' => '172.1.2.3')
+
+    log_msg = capture_log
+    assert_equal 'GET / -> 500 Internal Server Error', log_msg['message']
+    assert_equal '172.1.2.3', log_msg['remote_ip']
+    assert_equal 'err', log_msg['level']
+  end
+
+  test 'capture process_action' do
+    app = MockRackApp.new(
+      [200, {}, ['OK']],
+      ['process_action.action_controller', { controller: 'MyController',
+                                             action: 'index' }]
+    )
+    mw = Insights::API::Common::AuditLog::Middleware.new(app)
+    request = Rack::MockRequest.new(mw)
+
+    request.get('/', 'HTTP_X_FORWARDED_FOR' => '172.1.2.3')
+
+    log_msg = capture_log
+    assert_equal 'GET / -> 200 OK', log_msg['message']
+    assert_equal 'MyController#index', log_msg['controller']
+    assert_equal '172.1.2.3', log_msg['remote_ip']
+    assert_equal 'info', log_msg['level']
+  end
+
+  test 'capture halted_callback' do
+    app = MockRackApp.new(
+      [400, {}, ['Bad Request']],
+      ['halted_callback.action_controller', { filter: 'halting_filter' }]
+    )
+    mw = Insights::API::Common::AuditLog::Middleware.new(app)
+    request = Rack::MockRequest.new(mw)
+
+    request.get('/', 'HTTP_X_FORWARDED_FOR' => '172.1.2.3')
+
+    log_msg = capture_log
+    assert_includes log_msg['message'], 'GET / -> 400 Bad Request'
+    assert_includes log_msg['message'], 'filter chain halted by :halting_filter'
+    assert_equal '172.1.2.3', log_msg['remote_ip']
+    assert_equal 'warning', log_msg['level']
+  end
+
+  test 'capture unpermitted_parameters' do
+    app = MockRackApp.new(
+      [400, {}, ['Bad Request']],
+      ['unpermitted_parameters.action_controller', { keys: ['paramname'] }]
+    )
+    mw = Insights::API::Common::AuditLog::Middleware.new(app)
+    request = Rack::MockRequest.new(mw)
+
+    request.get('/', 'HTTP_X_FORWARDED_FOR' => '172.1.2.3')
+
+    log_msg = capture_log
+    assert_includes log_msg['message'], 'GET / -> 400 Bad Request'
+    assert_includes log_msg['message'], 'unpermitted params :paramname'
+    assert_equal '172.1.2.3', log_msg['remote_ip']
+    assert_equal 'warning', log_msg['level']
+  end
+end


### PR DESCRIPTION
Introduction of a middleware and utility to add entries to an audit log.  By default it logs them to STDOUT, but eventually it can be tied into CloudWatch. Log entries are formatted into JSON, split by a new-line.

Originally posted at https://github.com/RedHatInsights/insights-api-common-rails/pull/217

TODO:
- [X] Capture Rails requests
- [x] Add tests
- [ ] Find a way to have a shortcut to the logger
- [x] Support within a Sidekiq

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
