### PR TITLE
feat(REST systems): RHICOMPL-1413 defaults to compliance systems

### DIFF
--- a/app/controllers/v1/systems_controller.rb
+++ b/app/controllers/v1/systems_controller.rb
@@ -4,6 +4,7 @@ module V1
   # API for Systems (only Hosts for the moment)
   class SystemsController < ApplicationController
     def index
+      params[:search] ||= 'has_test_results=true or has_policy=true'
       render_json scope_search
     end
 

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -24,6 +24,25 @@ module V1
 
         assert_response :success
       end
+
+      should 'provide a default search' do
+        SystemsController.any_instance.expects(:policy_scope).with(Host)
+                         .returns(Host.all).at_least_once
+        get v1_systems_url
+
+        assert_response :success
+        assert_equal 'has_test_results=true or has_policy=true',
+                     JSON.parse(response.body).dig('meta', 'search')
+      end
+
+      should 'allow custom search' do
+        SystemsController.any_instance.expects(:policy_scope).with(Host)
+                         .returns(Host.all).at_least_once
+        get v1_systems_url, params: { search: '' }
+
+        assert_response :success
+        assert_empty JSON.parse(response.body).dig('meta', 'search')
+      end
     end
 
     context 'show' do


### PR DESCRIPTION
This adds a default search to only show hosts with test results or those
associated to a policy. The search may be overridden with any other
search or simply left empty to return all inventory hosts.

Similar to https://github.com/RedHatInsights/compliance-backend/pull/496

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
