### PR TITLE
fix(Host): RHICOMPL-1415 loose filter search

### DIFF
--- a/app/models/concerns/host_searching.rb
+++ b/app/models/concerns/host_searching.rb
@@ -5,7 +5,7 @@ module HostSearching
   extend ActiveSupport::Concern
 
   included do
-    scoped_search on: %i[display_name os_major_version os_minor_version]
+    scoped_search on: %i[id display_name]
     scoped_search on: :display_name, rename: :name
     scoped_search on: :compliant, ext_method: 'filter_by_compliance',
                   only_explicit: true

--- a/app/models/concerns/system_like.rb
+++ b/app/models/concerns/system_like.rb
@@ -6,7 +6,6 @@ module SystemLike
   extend ActiveSupport::Concern
 
   included do
-    scoped_search on: %i[id name]
     has_many :rule_results, dependent: :destroy
     has_many :rules, through: :rule_results, source: :rule
     belongs_to :account_object, optional: true, foreign_key: :account,

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -17,6 +17,11 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  test 'loose filter search' do
+    host = hosts(:one)
+    assert_includes Host.search_for(host.display_name), host
+  end
+
   test 'with_policy scope / has_policy filter' do
     assert_equal 0, PolicyHost.count
 


### PR DESCRIPTION
Search/filter value without field specified is searching through all
available search fields.  There were some search search fields set that
no longer have a db field representative.  Those would need an external
method lookup.

/cc @Victoremepunto 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
