### PR TITLE
refactor: platform_basic_auth to be settable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Prerequisites:
   - or, `host_inventory_url` configured in [settings](config/settings/development.yml)
 * Basic authethication credentials set by
   [option `platform_basic_auth`](config/settings/development.yml)
+  - or, environment variables `SETTINGS__PLATFORM_BASIC_AUTH_USERNAME` and `SETTINGS__PLATFORM_BASIC_AUTH_PASSWORD`
 * Generated minio credentials (for Ingress)
   - environment variables: `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`
 

--- a/app/services/platform.rb
+++ b/app/services/platform.rb
@@ -4,7 +4,8 @@ require 'faraday'
 
 # Methods related to connecting to other platform services
 module Platform
-  BASIC_AUTH = Settings.platform_basic_auth
+  BASIC_AUTH = [Settings.platform_basic_auth_username,
+                Settings.platform_basic_auth_password].freeze
   RETRY_OPTIONS = {
     max: 3,
     interval: 0.05,
@@ -22,7 +23,7 @@ module Platform
       f.request :retry, RETRY_OPTIONS
       f.adapter Faraday.default_adapter # this must be the last middleware
       f.ssl[:verify] = Rails.env.production?
-      f.basic_auth(*BASIC_AUTH) if BASIC_AUTH
+      f.basic_auth(*BASIC_AUTH) if BASIC_AUTH[0].present?
     end
     faraday
   end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,9 +2,8 @@ host_inventory_url: http://inventory-web:8081
 remediations_url: https://ci.cloud.redhat.com
 rbac_url: https://ci.cloud.redhat.com
 # disable_rbac: true
-# platform_basic_auth:
-#   - username
-#   - password
+# platform_basic_auth_username: myusername
+# platform_basic_auth_password: secret
 prometheus_exporter_host: prometheus
 prometheus_exporter_port: 9394
 redis_url: localhost:6379

--- a/test/services/platform_test.rb
+++ b/test/services/platform_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PlatformServiceTest < ActiveSupport::TestCase
+  test 'basic auth' do
+    basic_auth = %w[username pass]
+    ::Platform.stubs(:BASIC_AUTH).returns(basic_auth) do
+      Faraday.any_instance.expects(:basic_auth).with(*basic_auth).at_least_once
+      Platform.connection
+    end
+  end
+end


### PR DESCRIPTION
Changes platform_basic_auth config option to a Hash (from an array) to
be able to be settable via env variables.
Note, that this option is only being used in dev env.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
