### PR TITLE
feat(logging): RHICOMPL-1423 AuditLog wrapper

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,13 @@ Rails.application.configure do
     Bullet.rails_logger = true
     Bullet.add_footer = true
   end
+
+  logger = ActiveSupport::Logger.new('log/development.log')
+  logger.formatter = config.log_formatter
+  logger = ActiveSupport::TaggedLogging.new(logger)
+
+  # Use our custom audit logger
+  require 'audit_log/audit_log'
+  config.logger = Insights::API::Common::AuditLog.new_to_file(logger, 'log/audit.log')
+  config.middleware.use Insights::API::Common::AuditLog::Middleware
 end

--- a/lib/audit_log/audit_log.rb
+++ b/lib/audit_log/audit_log.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'audit_log/wrapped_logger'
 require_relative 'audit_log/formatter'
 require_relative 'audit_log/middleware'
 
@@ -8,40 +9,20 @@ module Insights
   module API
     module Common
       # Audit Logger into selected logger, but primarily to CloudWatch
-      class AuditLog
-        class << self
-          def logger
-            @logger ||= init_logger
-          end
+      module AuditLog
+        def self.new(base_logger, audit_logger = nil)
+          WrappedLogger.new(base_logger, audit_logger)
+        end
 
-          def logger=(logger)
-            @logger = init_logger(logger)
-          end
+        def self.audit_with_account(account_number)
+          original = Thread.current[:audit_account_number]
+          Thread.current[:audit_account_number] = account_number
+          return unless block_given?
 
-          def setup(logger = nil)
-            self.logger = logger
-            self
-          end
-
-          def with_account(account_number)
-            original = Thread.current[:audit_account_number]
-            Thread.current[:audit_account_number] = account_number
-            return unless block_given?
-
-            begin
-              yield
-            ensure
-              Thread.current[:audit_account_number] = original
-            end
-          end
-
-          private
-
-          def init_logger(logger = nil)
-            logger ||= Logger.new($stdout)
-            logger.level = Logger::INFO
-            logger.formatter = Formatter.new
-            logger
+          begin
+            yield
+          ensure
+            Thread.current[:audit_account_number] = original
           end
         end
       end

--- a/lib/audit_log/audit_log.rb
+++ b/lib/audit_log/audit_log.rb
@@ -14,6 +14,15 @@ module Insights
           WrappedLogger.new(base_logger, audit_logger)
         end
 
+        def self.new_to_file(base_logger, filepath, autoflush = true)
+          f = File.open(filepath, 'a')
+          f.binmode
+          f.sync = autoflush
+
+          audit_logger = ::Logger.new(f)
+          new(base_logger, audit_logger)
+        end
+
         def self.audit_with_account(account_number)
           original = Thread.current[:audit_account_number]
           Thread.current[:audit_account_number] = account_number

--- a/lib/audit_log/audit_log/formatter.rb
+++ b/lib/audit_log/audit_log/formatter.rb
@@ -6,7 +6,7 @@ require 'manageiq/loggers'
 module Insights
   module API
     module Common
-      class AuditLog
+      module AuditLog
         # Audit Log formatter with evidence capture
         class Formatter < ManageIQ::Loggers::Container::Formatter
           ALLOWED_PAYLOAD_KEYS = %i[message status account_number controller

--- a/lib/audit_log/audit_log/formatter.rb
+++ b/lib/audit_log/audit_log/formatter.rb
@@ -9,18 +9,18 @@ module Insights
       class AuditLog
         # Audit Log formatter with evidence capture
         class Formatter < ManageIQ::Loggers::Container::Formatter
-          ALLOWED_PAYLOAD_KEYS = %i[message account_number controller remote_ip
-                                    transaction_id].freeze
+          ALLOWED_PAYLOAD_KEYS = %i[message status account_number controller
+                                    remote_ip transaction_id].freeze
 
           # rubocop:disable Metrics/MethodLength
-          def call(severity, time, progname, msg)
+          def call(_, time, progname, msg)
             payload = {
               '@timestamp': format_datetime(time),
               hostname: hostname,
               pid: $PROCESS_ID,
               thread_id: thread_id,
               service: progname,
-              level: translate_error(severity),
+              level: 'audit',
               account_number: account_number
             }
             payload.merge!(framework_evidence)

--- a/lib/audit_log/audit_log/middleware.rb
+++ b/lib/audit_log/audit_log/middleware.rb
@@ -66,7 +66,11 @@ module Insights
           def log(payload)
             payload[:status] = status < 400 ? 'success' : 'fail'
             if logger.respond_to?(:audit)
-              logger.audit(payload)
+              if status < 400
+                logger.audit_success(payload)
+              else
+                logger.audit_fail(payload)
+              end
             else
               # fallback
               logger.info(payload)

--- a/lib/audit_log/audit_log/middleware.rb
+++ b/lib/audit_log/audit_log/middleware.rb
@@ -63,13 +63,8 @@ module Insights
           end
 
           def log(payload)
-            if status < 400
-              logger.info(payload)
-            elsif status < 500
-              logger.warn(payload)
-            else
-              logger.error(payload)
-            end
+            payload[:status] = status < 400 ? 'success' : 'fail'
+            logger.info(payload)
           end
 
           def subscribe

--- a/lib/audit_log/audit_log/middleware.rb
+++ b/lib/audit_log/audit_log/middleware.rb
@@ -4,14 +4,15 @@
 module Insights
   module API
     module Common
-      class AuditLog
+      module AuditLog
         # Request events listener, capturing for evidence
         class Middleware
-          attr_reader :logger, :evidence, :request, :status
+          attr_accessor :logger
+          attr_reader :evidence, :request, :status
 
           def initialize(app)
             @app = app
-            @logger = AuditLog.logger
+            @logger = Rails.logger
             @subscribers = []
             @evidence = {}
           end
@@ -64,7 +65,12 @@ module Insights
 
           def log(payload)
             payload[:status] = status < 400 ? 'success' : 'fail'
-            logger.info(payload)
+            if logger.respond_to?(:audit)
+              logger.audit(payload)
+            else
+              # fallback
+              logger.info(payload)
+            end
           end
 
           def subscribe

--- a/lib/audit_log/audit_log/wrapped_logger.rb
+++ b/lib/audit_log/audit_log/wrapped_logger.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Common space for Insights API stuff
+module Insights
+  module API
+    module Common
+      module AuditLog
+        # Wrapper and combiner of a base and audit logger
+        class WrappedLogger
+          attr_reader :base_logger
+
+          delegate :add, :debug, :info, :warn, :error, :fatal,
+                   :datetime_format, :datetime_format=,
+                   to: :base_logger
+
+          def initialize(base_logger, audit_logger = nil)
+            @base_logger = base_logger
+            @audit_logger = init_logger(audit_logger)
+          end
+
+          def audit(payload)
+            @audit_logger.info(payload)
+          end
+
+          def audit_with_account(account_number, &block)
+            AuditLog.audit_with_account(account_number, &block)
+          end
+
+          def close
+            send_both(:close)
+          end
+
+          def reopen
+            send_both(:reopen)
+          end
+
+          def method_missing(symbol, *args, &block)
+            if respond_to_missing?(symbol)
+              @base_logger.public_send(symbol, *args, &block)
+            else
+              super
+            end
+          end
+
+          def respond_to_missing?(name, include_private = false)
+            @base_logger.respond_to?(name) || super
+          end
+
+          private
+
+          def send_both(symbol, *args)
+            [@base_logger, @audit_logger].each do |logger|
+              logger.public_send(symbol, *args)
+            end
+          end
+
+          def init_logger(logger = nil)
+            logger ||= Logger.new($stdout)
+            logger.level = Logger::INFO
+            logger.formatter = Formatter.new
+            logger
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/audit_log/audit_log/wrapped_logger.rb
+++ b/lib/audit_log/audit_log/wrapped_logger.rb
@@ -7,6 +7,9 @@ module Insights
       module AuditLog
         # Wrapper and combiner of a base and audit logger
         class WrappedLogger
+          AUDIT_SUCCESS = 'success'
+          AUDIT_FAIL = 'fail'
+
           attr_reader :base_logger
 
           delegate :add, :debug, :info, :warn, :error, :fatal,
@@ -20,6 +23,16 @@ module Insights
 
           def audit(payload)
             @audit_logger.info(payload)
+          end
+
+          def audit_success(payload)
+            payload = hash_payload(payload).merge(status: AUDIT_SUCCESS)
+            audit(payload)
+          end
+
+          def audit_fail(payload)
+            payload = hash_payload(payload).merge(status: AUDIT_FAIL)
+            audit(payload)
           end
 
           def audit_with_account(account_number, &block)
@@ -59,6 +72,12 @@ module Insights
             logger.level = Logger::INFO
             logger.formatter = Formatter.new
             logger
+          end
+
+          def hash_payload(payload)
+            return payload if payload.is_a?(Hash)
+
+            { message: payload }
           end
         end
       end

--- a/lib/audit_log/audit_log/wrapped_logger.rb
+++ b/lib/audit_log/audit_log/wrapped_logger.rb
@@ -13,7 +13,7 @@ module Insights
           attr_reader :base_logger
 
           delegate :add, :debug, :info, :warn, :error, :fatal,
-                   :datetime_format, :datetime_format=,
+                   :datetime_format, :datetime_format=, :extend,
                    to: :base_logger
 
           def initialize(base_logger, audit_logger = nil)

--- a/test/lib/audit_log/audit_log_test.rb
+++ b/test/lib/audit_log/audit_log_test.rb
@@ -17,6 +17,20 @@ class AuditLogTest < ActiveSupport::TestCase
     assert wrapped.respond_to?(:audit_fail)
   end
 
+  test 'new to file' do
+    Dir.mktmpdir('audit_log_test') do |dir|
+      base_logger = Logger.new(StringIO.new)
+      filepath = "#{dir}/audit.log"
+      wrapped = Insights::API::Common::AuditLog.new_to_file(
+        base_logger, filepath
+      )
+      wrapped.audit('Test message')
+
+      content = File.read(filepath)
+      assert_includes content, 'Test message'
+    end
+  end
+
   test 'setting account number context' do
     begin
       Insights::API::Common::AuditLog.audit_with_account('1')

--- a/test/lib/audit_log/audit_log_test.rb
+++ b/test/lib/audit_log/audit_log_test.rb
@@ -13,6 +13,8 @@ class AuditLogTest < ActiveSupport::TestCase
     assert wrapped.respond_to?(:error)
     assert wrapped.respond_to?(:fatal)
     assert wrapped.respond_to?(:audit)
+    assert wrapped.respond_to?(:audit_success)
+    assert wrapped.respond_to?(:audit_fail)
   end
 
   test 'setting account number context' do

--- a/test/lib/audit_log/audit_log_test.rb
+++ b/test/lib/audit_log/audit_log_test.rb
@@ -19,6 +19,7 @@ class AuditLogTest < ActiveSupport::TestCase
   test 'logs a general message formatted into JSON' do
     log_msg = capture_log('Audit message')
     assert_equal 'Audit message', log_msg['message']
+    assert_equal 'audit', log_msg['level']
   end
 
   test 'logs include general evidence' do

--- a/test/lib/audit_log/audit_log_test.rb
+++ b/test/lib/audit_log/audit_log_test.rb
@@ -4,60 +4,29 @@ require 'test_helper'
 require 'audit_log/audit_log'
 
 class AuditLogTest < ActiveSupport::TestCase
-  setup do
-    @output = StringIO.new
-    @logger = Logger.new(@output)
-    @audit = Insights::API::Common::AuditLog.setup(@logger)
+  test 'new wraps base logger' do
+    base_logger = Logger.new(StringIO.new)
+    wrapped = Insights::API::Common::AuditLog.new(base_logger)
+    assert wrapped.respond_to?(:debug)
+    assert wrapped.respond_to?(:info)
+    assert wrapped.respond_to?(:warn)
+    assert wrapped.respond_to?(:error)
+    assert wrapped.respond_to?(:fatal)
+    assert wrapped.respond_to?(:audit)
   end
 
-  def capture_log(msg)
-    @audit.logger.info(msg)
-    @output.rewind # logger seems to read what it's writing?
-    JSON.parse @output.readlines[-1]
-  end
-
-  test 'logs a general message formatted into JSON' do
-    log_msg = capture_log('Audit message')
-    assert_equal 'Audit message', log_msg['message']
-    assert_equal 'audit', log_msg['level']
-  end
-
-  test 'logs include general evidence' do
-    @audit.logger.info('Audit message')
-    line = @output.string
-    assert line
-
-    log_msg = JSON.parse(line).compact
-    assert_equal log_msg.keys.sort, %w[
-      @timestamp
-      hostname
-      pid
-      thread_id
-      level
-      transaction_id
-      message
-    ].sort
-  end
-
-  test 'setting account number' do
+  test 'setting account number context' do
     begin
-      @audit.with_account('1')
-      log_msg = capture_log('Audit message')
-      assert_equal '1', log_msg['account_number']
+      Insights::API::Common::AuditLog.audit_with_account('1')
+      assert_equal '1', Thread.current[:audit_account_number]
 
-      @audit.with_account('2') do
-        log_msg = capture_log('Audit message')
-        assert_equal '2', log_msg['account_number']
+      Insights::API::Common::AuditLog.audit_with_account('2') do
+        assert_equal '2', Thread.current[:audit_account_number]
       end
 
-      log_msg = capture_log('Audit message')
-      assert_equal '1', log_msg['account_number']
-
-      @audit.with_account(nil)
-      log_msg = capture_log('Audit message')
-      assert_not log_msg['account_number']
+      assert_equal '1', Thread.current[:audit_account_number]
     ensure
-      @audit.with_account(nil)
+      Thread.current[:audit_account_number] = nil
     end
   end
 end

--- a/test/lib/audit_log/formatter_test.rb
+++ b/test/lib/audit_log/formatter_test.rb
@@ -9,7 +9,7 @@ class AuditLogFormatterTest < ActiveSupport::TestCase
   end
 
   test 'formats message string into JSON' do
-    line = @formatter.call('info', Time.zone.now, 'prog', 'Audit message')
+    line = @formatter.call('INFO', Time.zone.now, 'prog', 'Audit message')
 
     log_msg = JSON.parse(line)
     assert_equal 'Audit message', log_msg['message']
@@ -21,7 +21,7 @@ class AuditLogFormatterTest < ActiveSupport::TestCase
       account_number: '12345',
       remote_ip: '172.1.2.3'
     }
-    line = @formatter.call('info', Time.zone.now, 'prog', msg)
+    line = @formatter.call('INFO', Time.zone.now, 'prog', msg)
 
     log_msg = JSON.parse(line)
     assert_equal 'Audit message', log_msg['message']

--- a/test/lib/audit_log/middleware_test.rb
+++ b/test/lib/audit_log/middleware_test.rb
@@ -47,7 +47,7 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     log_msg = capture_log
     assert_equal 'GET / -> 200 OK', log_msg['message']
     assert_equal '172.1.2.3', log_msg['remote_ip']
-    assert_equal 'info', log_msg['level']
+    assert_equal 'success', log_msg['status']
   end
 
   test 'log forbidden request' do
@@ -60,7 +60,7 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     log_msg = capture_log
     assert_equal 'GET / -> 403 Forbidden', log_msg['message']
     assert_equal '172.1.2.3', log_msg['remote_ip']
-    assert_equal 'warning', log_msg['level']
+    assert_equal 'fail', log_msg['status']
   end
 
   test 'log error request' do
@@ -73,7 +73,7 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     log_msg = capture_log
     assert_equal 'GET / -> 500 Internal Server Error', log_msg['message']
     assert_equal '172.1.2.3', log_msg['remote_ip']
-    assert_equal 'err', log_msg['level']
+    assert_equal 'fail', log_msg['status']
   end
 
   test 'capture process_action' do
@@ -91,7 +91,7 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     assert_equal 'GET / -> 200 OK', log_msg['message']
     assert_equal 'MyController#index', log_msg['controller']
     assert_equal '172.1.2.3', log_msg['remote_ip']
-    assert_equal 'info', log_msg['level']
+    assert_equal 'success', log_msg['status']
   end
 
   test 'capture halted_callback' do
@@ -108,7 +108,7 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     assert_includes log_msg['message'], 'GET / -> 400 Bad Request'
     assert_includes log_msg['message'], 'filter chain halted by :halting_filter'
     assert_equal '172.1.2.3', log_msg['remote_ip']
-    assert_equal 'warning', log_msg['level']
+    assert_equal 'fail', log_msg['status']
   end
 
   test 'capture unpermitted_parameters' do
@@ -125,6 +125,6 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     assert_includes log_msg['message'], 'GET / -> 400 Bad Request'
     assert_includes log_msg['message'], 'unpermitted params :paramname'
     assert_equal '172.1.2.3', log_msg['remote_ip']
-    assert_equal 'warning', log_msg['level']
+    assert_equal 'fail', log_msg['status']
   end
 end

--- a/test/lib/audit_log/wrapped_logger_test.rb
+++ b/test/lib/audit_log/wrapped_logger_test.rb
@@ -100,6 +100,20 @@ class AuditLogWrappedLoggerTest < ActiveSupport::TestCase
     @wrapped.close
   end
 
+  test 'supports Rails broadcasting' do
+    base_logger = ActiveSupport::Logger.new(StringIO.new)
+    wrapped = Insights::API::Common::AuditLog::WrappedLogger.new(
+      base_logger, @audit_logger
+    )
+
+    secondary_output = StringIO.new
+    secondary = ActiveSupport::Logger.new(secondary_output)
+    wrapped.extend(ActiveSupport::Logger.broadcast(secondary))
+
+    wrapped.info('Test broadcast')
+    assert_includes secondary_output.string, 'Test broadcast'
+  end
+
   test 'missing methods passed to base logger' do
     @wrapped << 'RAW MESSAGE'
 

--- a/test/lib/audit_log/wrapped_logger_test.rb
+++ b/test/lib/audit_log/wrapped_logger_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'audit_log/audit_log'
+
+class AuditLogWrappedLoggerTest < ActiveSupport::TestCase
+  setup do
+    @base_logger_output = StringIO.new
+    @base_logger = Logger.new(@base_logger_output)
+    @base_logger.level = Logger::DEBUG
+
+    @output = StringIO.new
+    @audit_logger = Logger.new(@output)
+    @wrapped = Insights::API::Common::AuditLog::WrappedLogger.new(
+      @base_logger, @audit_logger
+    )
+  end
+
+  def capture_log(msg)
+    @wrapped.audit(msg)
+    assert @output.size.positive?, 'No ouput in the log'
+    @output.rewind # logger seems to read what it's writing?
+    JSON.parse @output.readlines[-1]
+  end
+
+  test 'logs a general audit message formatted into JSON' do
+    log_msg = capture_log('Audit message')
+    assert_equal 'Audit message', log_msg['message']
+    assert_equal 'audit', log_msg['level']
+  end
+
+  test 'logs audit with general evidence included' do
+    @wrapped.audit('Audit message')
+    line = @output.string
+    assert line
+
+    log_msg = JSON.parse(line).compact
+    assert_equal log_msg.keys.sort, %w[
+      @timestamp
+      hostname
+      pid
+      thread_id
+      level
+      transaction_id
+      message
+    ].sort
+  end
+
+  test 'other logs passed to base logger' do
+    @wrapped.info('Test info to base logger')
+    @wrapped.info { 'Test block passing to base logger' }
+    @wrapped.debug('Test debug to base logger')
+    @wrapped.warn('Test warn to base logger')
+    @wrapped.error('Test error to base logger')
+    @wrapped.fatal('Test fatal to base logger')
+
+    output = @base_logger_output.string
+    assert_includes output, 'info'
+    assert_includes output, 'block'
+    assert_includes output, 'debug'
+    assert_includes output, 'warn'
+    assert_includes output, 'error'
+    assert_includes output, 'fatal'
+  end
+
+  test 'sends reopen to both loggers' do
+    @base_logger.stubs(:reopen).at_least_once
+    @audit_logger.stubs(:reopen).at_least_once
+    @wrapped.reopen
+  end
+
+  test 'sends close to both loggers' do
+    @base_logger.stubs(:close).at_least_once
+    @audit_logger.stubs(:close).at_least_once
+    @wrapped.close
+  end
+
+  test 'missing methods passed to base logger' do
+    @wrapped << 'RAW MESSAGE'
+
+    output = @base_logger_output.string
+    assert_includes output, 'RAW MESSAGE'
+  end
+
+  test 'raises NameError if missing also on base logger' do
+    assert_raises NameError do
+      @wrapped.non_existent_method
+    end
+  end
+
+  test 'setting account number' do
+    begin
+      @wrapped.audit_with_account('1')
+      log_msg = capture_log('Audit message')
+      assert_equal '1', log_msg['account_number']
+
+      @wrapped.audit_with_account('2') do
+        log_msg = capture_log('Audit message')
+        assert_equal '2', log_msg['account_number']
+      end
+
+      @wrapped.audit_with_account(nil)
+      log_msg = capture_log('Audit message')
+      assert_not log_msg['account_number']
+    ensure
+      @wrapped.audit_with_account(nil)
+    end
+  end
+end


### PR DESCRIPTION
Reworks the AuditLog to provide audit capabilities by wrapping a base
logger.  This allows to configure any logger (e.g. Rails.logger) to have
an audit method.

The AuditLog Middleware requires the `Rails.logger` to be wapped,
otherwise it falls back to an info logging.

Audit logs can be sent through `audit_success` or `audit_fail` depending on the status.

Example Rails configuration:
```
  # Rails config
  # base_logger = ActiveSupport::Logger.new(STDOUT)
  config.logger = Insights::API::Common::AuditLog.new(base_logger, Logger.new('log/myaudit.log'))
  config.middleware.use Insights::API::Common::AuditLog::Middleware
```

Example usage:
```
  Rails.logger.audit('Audit message')
  Rails.logger.audit({ controller: 'MyCtrl', message: 'with evidence' })
  Rails.logger.audit_success('Success!')
  Rails.logger.audit_fail('Fail!')

  # setting account number evience context (with optional block)
  Insights::API::Common::AuditLog.audit_with_account('123')
  # or
  Rails.logger.audit_with_account('123')
```

(Apologies for too many changes.)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
