### PR TITLE
 fix(auth): RHICOMPL-1439 ensure current user reset 

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -12,7 +12,7 @@ module Authentication
   ].freeze
 
   included do
-    before_action :authenticate_user
+    around_action :authenticate_user
   end
 
   def authenticate_user
@@ -25,6 +25,9 @@ module Authentication
     return if performed?
 
     User.current = user
+    yield
+  ensure
+    User.current = nil
   end
 
   def current_user

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -16,14 +16,15 @@ module Authentication
   end
 
   def authenticate_user
+    if identity_header.blank?
+      return unauthenticated(error: 'Error parsing the X-RH-IDENTITY header')
+    end
     return unauthenticated unless identity_header.valid?
     return unauthorized unless rbac_allowed?
 
     return if performed?
 
     User.current = user
-  rescue JSON::ParserError, NoMethodError
-    unauthenticated error: 'Error parsing the X-RH-IDENTITY header'
   end
 
   def current_user

--- a/app/models/identity_header.rb
+++ b/app/models/identity_header.rb
@@ -10,14 +10,21 @@ class IdentityHeader
     @b64_identity = b64_identity
   end
 
+  def blank?
+    @b64_identity.blank?
+  end
+
   def valid?
     identity.present? && entitled?
   end
 
   def content
-    return @content if @content.present?
-
-    @content = JSON.parse(Base64.decode64(@b64_identity))
+    @content ||=
+      begin
+        JSON.parse(Base64.decode64(@b64_identity))
+      rescue JSON::ParserError
+        {}
+      end
   end
 
   def identity

--- a/test/controllers/concerns/default_headers_test.rb
+++ b/test/controllers/concerns/default_headers_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class DefaultHeadersTest < ActionDispatch::IntegrationTest
   setup do
-    ApplicationController.any_instance.expects(:authenticate_user)
+    ApplicationController.any_instance.expects(:authenticate_user).yields
     ApplicationController.any_instance.stubs(:index).returns('Response Body')
     Rails.application.routes.draw do
       root 'application#index'

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -9,7 +9,7 @@ require 'securerandom'
 # instead for the time being
 class MetadataTest < ActionDispatch::IntegrationTest
   def authenticate
-    V1::ProfilesController.any_instance.expects(:authenticate_user)
+    V1::ProfilesController.any_instance.expects(:authenticate_user).yields
     users(:test).account = accounts(:test)
     User.current = users(:test)
   end

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class GraphqlControllerTest < ActionDispatch::IntegrationTest
   test 'calls the schema executor with a query, variables, and user' do
-    GraphqlController.any_instance.expects(:authenticate_user)
+    GraphqlController.any_instance.expects(:authenticate_user).yields
     query = 'gqlquery'
     variables = ['samplevar']
     User.current = users(:test)

--- a/test/controllers/v1/benchmarks_controller_test.rb
+++ b/test/controllers/v1/benchmarks_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module V1
   class BenchmarksControllerTest < ActionDispatch::IntegrationTest
     setup do
-      BenchmarksController.any_instance.stubs(:authenticate_user)
+      BenchmarksController.any_instance.stubs(:authenticate_user).yields
       User.current = users(:test)
       users(:test).update! account: accounts(:test)
     end

--- a/test/controllers/v1/business_objectives_controller_test.rb
+++ b/test/controllers/v1/business_objectives_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module V1
   class BusinessObjectivesControllerTest < ActionDispatch::IntegrationTest
     setup do
-      BusinessObjectivesController.any_instance.stubs(:authenticate_user)
+      BusinessObjectivesController.any_instance.stubs(:authenticate_user).yields
       User.current = users(:test)
       users(:test).update! account: accounts(:test)
       policies(:one).update!(account: accounts(:test),

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -148,7 +148,7 @@ module V1
 
   class ProfilesControllerTest < ActionDispatch::IntegrationTest
     setup do
-      ProfilesController.any_instance.stubs(:authenticate_user)
+      ProfilesController.any_instance.stubs(:authenticate_user).yields
       User.current = users(:test)
       users(:test).update! account: accounts(:one)
       profiles(:one).update! account: accounts(:one)

--- a/test/controllers/v1/rule_results_controller_test.rb
+++ b/test/controllers/v1/rule_results_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module V1
   class RuleResultsControllerTest < ActionDispatch::IntegrationTest
     setup do
-      RuleResultsController.any_instance.expects(:authenticate_user)
+      RuleResultsController.any_instance.expects(:authenticate_user).yields
     end
 
     test 'index lists all rule results' do

--- a/test/controllers/v1/rules_controller_test.rb
+++ b/test/controllers/v1/rules_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module V1
   class RulesControllerTest < ActionDispatch::IntegrationTest
     setup do
-      RulesController.any_instance.stubs(:authenticate_user)
+      RulesController.any_instance.stubs(:authenticate_user).yields
       User.current = users(:test)
       users(:test).update account: accounts(:test)
       profiles(:one).update(

--- a/test/controllers/v1/supported_ssgs_controller_test.rb
+++ b/test/controllers/v1/supported_ssgs_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module V1
   class SupportedSsgsControllerTest < ActionDispatch::IntegrationTest
     setup do
-      SupportedSsgsController.any_instance.stubs(:authenticate_user)
+      SupportedSsgsController.any_instance.stubs(:authenticate_user).yields
     end
 
     context 'index' do

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module V1
   class SystemsControllerTest < ActionDispatch::IntegrationTest
     setup do
-      SystemsController.any_instance.expects(:authenticate_user)
+      SystemsController.any_instance.expects(:authenticate_user).yields
     end
 
     context 'index' do

--- a/test/models/identity_header_test.rb
+++ b/test/models/identity_header_test.rb
@@ -31,6 +31,37 @@ class IdentityHeaderTest < ActiveSupport::TestCase
     ).valid?
   end
 
+  test 'is not valid if entitlements are not provided' do
+    @b64_identity.delete(:entitlements)
+    assert_not IdentityHeader.new(
+      Base64.strict_encode64(@b64_identity.to_json)
+    ).valid?
+  end
+
+  test 'is not valid on malformed identity' do
+    assert_not IdentityHeader.new(
+      Base64.strict_encode64('{"identity":""}')
+    ).valid?
+  end
+
+  test 'is not valid on empty JSON object' do
+    assert_not IdentityHeader.new(
+      Base64.strict_encode64('{}')
+    ).valid?
+  end
+
+  test 'is not valid on empty JSON string' do
+    assert_not IdentityHeader.new(
+      Base64.strict_encode64('""')
+    ).valid?
+  end
+
+  test 'is not valid on malformed JSON' do
+    assert_not IdentityHeader.new(
+      Base64.strict_encode64('{')
+    ).valid?
+  end
+
   test 'properly detects cert-based auth from the auth_type' do
     assert_not IdentityHeader.new(
       Base64.strict_encode64(@b64_identity.to_json)


### PR DESCRIPTION
Changes `before_action` to `around_action` for `authenticate_user` to add the ensure block for resetting the current user (thread local).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
