### PR TITLE
feat(logging): RHICOMPL-1438 enable audit logging on all envs

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rbac_api'
-require 'audit_log/audit_log'
 
 # Authentication logic for all controllers
 module Authentication

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rbac_api'
+require 'audit_log/audit_log'
 
 # Authentication logic for all controllers
 module Authentication
@@ -24,7 +25,7 @@ module Authentication
 
     return if performed?
 
-    User.current = user
+    set_authenticated_user
     yield
   ensure
     User.current = nil
@@ -63,6 +64,13 @@ module Authentication
   end
 
   private
+
+  def set_authenticated_user
+    User.current = user
+    Insights::API::Common::AuditLog.audit_with_account(
+      current_user.account_number
+    )
+  end
 
   def valid_cert_endpoint?
     ALLOWED_CERT_BASED_RBAC_ACTIONS.include?(

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,10 @@ module ComplianceBackend
     config.api_only = true
     config.active_job.queue_adapter = :sidekiq
 
+    # Attach audit logging for requests
+    require 'audit_log/audit_log'
+    config.middleware.use Insights::API::Common::AuditLog::Middleware
+
     # GraphiQL
     if Rails.env.development?
       config.middleware.use Rack::MethodOverride

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,13 +60,4 @@ Rails.application.configure do
     Bullet.rails_logger = true
     Bullet.add_footer = true
   end
-
-  logger = ActiveSupport::Logger.new('log/development.log')
-  logger.formatter = config.log_formatter
-  logger = ActiveSupport::TaggedLogging.new(logger)
-
-  # Use our custom audit logger
-  require 'audit_log/audit_log'
-  config.logger = Insights::API::Common::AuditLog.new_to_file(logger, 'log/audit.log')
-  config.middleware.use Insights::API::Common::AuditLog::Middleware
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,9 +76,10 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    logger              = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter    = config.log_formatter
+    config.logger       = ActiveSupport::TaggedLogging.new(logger)
+    config.audit_logger = Logger.new(STDOUT)
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.audit_logger = Logger.new(File::NULL)
 end

--- a/config/initializers/audit_logging.rb
+++ b/config/initializers/audit_logging.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'audit_log/audit_log'
+
+# Wraps base Rails logger to add audit capabilities.
+# The default is set to log into 'log/audit.log`.
+# It can be configured with `config.audit_logger`.
+def init_audit_logging
+  logsetup = Insights::API::Common::AuditLog
+  config = Rails.application.config
+  audit_logger = if defined?(config.audit_logger)
+                   config.audit_logger
+                 else
+                   logsetup.new_file_logger('log/audit.log')
+                 end
+  Rails.logger = logsetup.new(Rails.logger, audit_logger)
+end
+
+init_audit_logging

--- a/lib/audit_log/audit_log.rb
+++ b/lib/audit_log/audit_log.rb
@@ -14,13 +14,12 @@ module Insights
           WrappedLogger.new(base_logger, audit_logger)
         end
 
-        def self.new_to_file(base_logger, filepath, autoflush = true)
+        def self.new_file_logger(filepath, autoflush = true)
           f = File.open(filepath, 'a')
           f.binmode
           f.sync = autoflush
 
-          audit_logger = ::Logger.new(f)
-          new(base_logger, audit_logger)
+          ::Logger.new(f)
         end
 
         def self.audit_with_account(account_number)

--- a/lib/audit_log/audit_log/middleware.rb
+++ b/lib/audit_log/audit_log/middleware.rb
@@ -26,6 +26,7 @@ module Insights
             end
           ensure
             unsubscribe
+            reset_context
           end
 
           private
@@ -103,6 +104,10 @@ module Insights
               ActiveSupport::Notifications.unsubscribe(sub)
             end
             @subscribers.clear
+          end
+
+          def reset_context
+            AuditLog.audit_with_account(nil)
           end
 
           def fmt_controller(payload)

--- a/lib/audit_log/audit_log/middleware.rb
+++ b/lib/audit_log/audit_log/middleware.rb
@@ -21,7 +21,7 @@ module Insights
             subscribe
             @request = ActionDispatch::Request.new(env)
             @app.call(env).tap do |status, _headers, _body|
-              @status = status
+              @status = status.to_i
               response_finished
             end
           ensure

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -215,6 +215,28 @@ class AuthenticationTest < ActionController::TestCase
       assert_not User.current, 'current user must be reset after request'
     end
 
+    should 'successful authentication sets audit account context' do
+      encoded_header = Base64.encode64(
+        {
+          'identity':
+          {
+            'account_number': '1234',
+            'user': { 'username': 'username' }
+          },
+          'entitlements':
+          {
+            'insights': {
+              'is_entitled': true
+            }
+          }
+        }.to_json
+      )
+      Insights::API::Common::AuditLog.expects(:audit_with_account).with('1234')
+      process_test(headers: { 'X-RH-IDENTITY': encoded_header })
+      assert_response :success
+      assert_not User.current, 'current user must be reset after request'
+    end
+
     should 'reset current user after an exeption' do
       encoded_header = Base64.encode64(
         {

--- a/test/lib/audit_log/audit_log_test.rb
+++ b/test/lib/audit_log/audit_log_test.rb
@@ -17,12 +17,13 @@ class AuditLogTest < ActiveSupport::TestCase
     assert wrapped.respond_to?(:audit_fail)
   end
 
-  test 'new to file' do
+  test 'new to a file' do
     Dir.mktmpdir('audit_log_test') do |dir|
       base_logger = Logger.new(StringIO.new)
       filepath = "#{dir}/audit.log"
-      wrapped = Insights::API::Common::AuditLog.new_to_file(
-        base_logger, filepath
+      audit_logger = Insights::API::Common::AuditLog.new_file_logger(filepath)
+      wrapped = Insights::API::Common::AuditLog.new(
+        base_logger, audit_logger
       )
       wrapped.audit('Test message')
 


### PR DESCRIPTION
Fixes AuditLog middleware to reset the audit log context (currently only account number) after the request. This ensures that it will not leak to another request.

Sets account number context in the Authentication layer, once a user is authenticated.

Reworks AuditLog's `new_to_file` into `new_file_logger` utility for greater control.

And finally it audit logging initializer that sets up the AuditLog wrapper and the middleware on all envs.
The audit logger is configured via `config.audit_logger`.  By default it
puts audit logs to "log/audit.log".  If the base (non-audit) logger
isn't explicitly configured, it would use the default Rails one.

Audit logging configured:
* development: `log/audit.log` (default)
* test: NULL (devnull)
* production: STDOUT if``RAILS_LOG_TO_STDOUT` env var is set

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
