### PR TITLE
fix(init): RHICOMPL-1438 audit log initializer configuration

### DIFF
--- a/config/initializers/audit_logging.rb
+++ b/config/initializers/audit_logging.rb
@@ -7,13 +7,15 @@ require 'audit_log/audit_log'
 # It can be configured with `config.audit_logger`.
 def init_audit_logging
   logsetup = Insights::API::Common::AuditLog
-  config = Rails.application.config
-  audit_logger = if defined?(config.audit_logger)
-                   config.audit_logger
-                 else
-                   logsetup.new_file_logger('log/audit.log')
-                 end
+  audit_logger =
+    configured_audit_logger || logsetup.new_file_logger('log/audit.log')
   Rails.logger = logsetup.new(Rails.logger, audit_logger)
+end
+
+def configured_audit_logger
+  Rails.application.config.audit_logger
+rescue NoMethodError
+  nil
 end
 
 init_audit_logging


### PR DESCRIPTION
For some reason the `defined?` call responded differently on Ruby 2.6
when checking whether the Rail custom config variable existence.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
