### PR TITLE
fix(REST): RHICOMPL-1458 show links with includes

### DIFF
--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -62,11 +62,16 @@ module Metadata
 
     private
 
+    def includes_link
+      "&include=#{params[:include]}" if params[:include].present?
+    end
+
     def base_link
       base_url = "#{path_prefix}/#{Settings.app_name}"\
                  "/#{controller_name}"
       base = "#{base_url}?limit=#{pagination_limit}"
       base += "&search=#{params[:search]}" if params[:search].present?
+      base += includes_link.to_s
       base
     end
   end

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -14,6 +14,23 @@ class MetadataTest < ActionDispatch::IntegrationTest
     User.current = users(:test)
   end
 
+  test 'meta adds includes to JSON response' do
+    authenticate
+    3.times do
+      Profile.create(ref_id: "foo#{SecureRandom.uuid}", name: SecureRandom.uuid,
+                     benchmark: benchmarks(:one),
+                     account: accounts(:test))
+    end
+    get profiles_url, params: { include: 'rules', limit: 1, offset: 2,
+                                search: '' }
+    assert_response :success
+    assert_match(/include=rules/, json_body['links']['first'])
+    assert_match(/include=rules/, json_body['links']['last'])
+    assert_match(/include=rules/, json_body['links']['next'])
+    assert_match(/include=rules/, json_body['links']['previous'])
+    assert json_body.dig('included')
+  end
+
   test 'meta adds total and search to JSON response' do
     authenticate
     3.times do


### PR DESCRIPTION
When the include parameter is given, include it in the pagination links

```
GET https://ci.foo.redhat.com:1337/api/compliance/v1/systems?include=profiles

{
  "data": […],
  "included": […],
  "meta": {…},
  "links": {  
    "first": "/api/compliance/systems?limit=10&search=has_test_results=true or has_policy=true&include=profiles&offset=1",
    "last": "/api/compliance/systems?limit=10&search=has_test_results=true or has_policy=true&include=profiles&offset=1"
  }
}
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices