### PR TITLE
feat(Kafka Producers): RHICOMPL-1242 now with SSL

### DIFF
--- a/app/producers/application_producer.rb
+++ b/app/producers/application_producer.rb
@@ -4,6 +4,8 @@
 # https://www.rubydoc.info/gems/ruby-kafka/Kafka/Producer
 class ApplicationProducer < Kafka::Client
   BROKERS = [ENV['KAFKAMQ']].compact.freeze
+  SSL_CA_LOCATION = ENV['RACECAR_SSL_CA_LOCATION']
+  SECURITY_PROTOCOL = ENV['RACECAR_SECURITY_PROTOCOL']
   CLIENT_ID = 'compliance-backend'
   SERVICE = 'compliance'
   # Define TOPIC in the inherited class.
@@ -26,8 +28,19 @@ class ApplicationProducer < Kafka::Client
       Rails.logger
     end
 
+    def kafka_ca_cert
+      File.read(self::SSL_CA_LOCATION) if self::SECURITY_PROTOCOL == 'ssl'
+    end
+
+    def kafka_config
+      {}.tap do |config|
+        config[:client_id] = self::CLIENT_ID
+        config[:ssl_ca_cert] = kafka_ca_cert if kafka_ca_cert
+      end
+    end
+
     def kafka
-      @kafka ||= Kafka.new(BROKERS, client_id: CLIENT_ID) if BROKERS.any?
+      @kafka ||= Kafka.new(self::BROKERS, **kafka_config) if self::BROKERS.any?
     end
   end
 end

--- a/test/fixtures/files/test_ca.crt
+++ b/test/fixtures/files/test_ca.crt
@@ -1,0 +1,1 @@
+very secure

--- a/test/producers/application_producer_test.rb
+++ b/test/producers/application_producer_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationProducerTest < ActiveSupport::TestCase
+  class MockProducer < ApplicationProducer
+    BROKERS = ['broker1'].freeze
+  end
+
+  test 'handles SSL settings' do
+    MockProducer::SECURITY_PROTOCOL = 'ssl'
+    MockProducer::SSL_CA_LOCATION = 'test/fixtures/files/test_ca.crt'
+
+    config = {
+      client_id: ApplicationProducer::CLIENT_ID,
+      ssl_ca_cert: "very secure\n"
+    }
+
+    assert_equal config, MockProducer.send(:kafka_config)
+  end
+
+  test 'handles plaintext settings' do
+    MockProducer::SECURITY_PROTOCOL = 'plaintext'
+
+    config = {
+      client_id: ApplicationProducer::CLIENT_ID
+    }
+
+    assert_equal config, MockProducer.send(:kafka_config)
+  end
+end


### PR DESCRIPTION
Our kafka producers will now allow SSL with the same config the
consumers use to connect to kafka. This is fairly difficult to test
in devel without setting up kafka with SSL, but I intend to test this
thoroughly in stage. In any case, it should be able to use plaintext
mode with the change of the racecar environment variables if anything
goes amiss.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices