### PR TITLE
refactor(external_policies): RHICOMPL-1152 remove code related to external policies

### DIFF
--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -8,11 +8,6 @@ module V1
 
     attr_reader :hosts_added, :hosts_removed, :rules_added, :rules_removed
 
-    before_action only: %i[update] do
-      error = 'Editing an external profile is forbidden.'
-      render json: { errors: error }, status: :forbidden if profile.external?
-    end
-
     before_action only: %i[show update] do
       authorize profile
     end

--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -30,7 +30,7 @@ module V1
 
     def create
       Policy.transaction do
-        if new_policy.save && new_profile.update(policy_object: new_policy)
+        if new_policy.save && new_profile.update(policy: new_policy)
           update_relationships
           render_json new_profile, status: :created
         else
@@ -43,7 +43,7 @@ module V1
 
     def update
       Policy.transaction do
-        if profile.policy_object.update(policy_update_attributes)
+        if profile.policy.update(policy_update_attributes)
           update_relationships
           render_json profile
           audit_update
@@ -77,7 +77,7 @@ module V1
 
     def update_relationships
       @hosts_added, @hosts_removed =
-        profile.policy_object.update_hosts(new_host_ids)
+        profile.policy.update_hosts(new_host_ids)
       @rules_added, @rules_removed =
         profile.update_rules(ids: new_rule_ids)
     end

--- a/app/graphql/mutations/profile/associate_systems.rb
+++ b/app/graphql/mutations/profile/associate_systems.rb
@@ -12,8 +12,8 @@ module Mutations
 
       def resolve(args = {})
         profile = find_profile(args[:id])
-        if profile&.policy_object
-          profile.policy_object.update_hosts(args[:system_ids])
+        if profile&.policy
+          profile.policy.update_hosts(args[:system_ids])
           audit_mutation(profile)
         end
         { profile: profile }

--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -32,7 +32,7 @@ module Mutations
         rule_changes = nil
         Policy.transaction do
           policy.save!
-          profile.update!(policy_object: policy, external: false)
+          profile.update!(policy: policy, external: false)
           rule_changes =
             profile.update_rules(ref_ids: rule_ref_ids)
         end

--- a/app/graphql/mutations/profile/edit.rb
+++ b/app/graphql/mutations/profile/edit.rb
@@ -19,7 +19,7 @@ module Mutations
 
       def resolve(args = {})
         profile = authorized_profile(args)
-        profile.policy_object.update(args.slice(*POLICY_ATTRIBUTES))
+        profile.policy.update(args.slice(*POLICY_ATTRIBUTES))
         audit_mutation(profile)
         { profile: profile }
       end

--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -12,7 +12,7 @@ module Mutations
 
       def resolve(args = {})
         host = Host.find(args[:id])
-        policies = find_profiles(args[:profile_ids]).map(&:policy_object).uniq
+        policies = find_profiles(args[:profile_ids]).map(&:policy).uniq
         policies.map do |policy|
           policy.hosts << host
         end

--- a/app/graphql/mutations/test_result/delete.rb
+++ b/app/graphql/mutations/test_result/delete.rb
@@ -14,7 +14,7 @@ module Mutations
 
       def resolve(args = {})
         profile = scoped_profiles.find(args[:profile_id])
-        profiles = profile.external ? [profile] : profile.policy_object.profiles
+        profiles = profile.external ? [profile] : profile.policy.profiles
 
         test_results = scoped_test_results(profile_id: profiles).destroy_all
         audit_mutation(profile, test_results)

--- a/app/graphql/mutations/test_result/delete.rb
+++ b/app/graphql/mutations/test_result/delete.rb
@@ -14,7 +14,7 @@ module Mutations
 
       def resolve(args = {})
         profile = scoped_profiles.find(args[:profile_id])
-        profiles = profile.external ? [profile] : profile.policy.profiles
+        profiles = profile.policy.profiles
 
         test_results = scoped_test_results(profile_id: profiles).destroy_all
         audit_mutation(profile, test_results)
@@ -34,12 +34,8 @@ module Mutations
       end
 
       def audit_mutation(profile, test_results)
-        msg = "Removed all user scoped test results (#{test_results.count})"
-        msg += if profile.external
-                 " of profile #{profile.id}"
-               else
-                 " of policy #{profile.policy_id}"
-               end
+        msg = "Removed all user scoped test results (#{test_results.count}) "\
+          "of policy #{profile.policy_id}"
         audit_success(msg)
       end
 

--- a/app/graphql/types/concerns/profile_pseudo_policy.rb
+++ b/app/graphql/types/concerns/profile_pseudo_policy.rb
@@ -6,25 +6,25 @@ module Types
     extend ActiveSupport::Concern
 
     def name
-      object.policy_object&.name || object.name
+      object.policy&.name || object.name
     end
 
     def description
-      object.policy_object&.description || object.description
+      object.policy&.description || object.description
     end
 
     # Pseudo policy with a Profile type
     def policy
-      return if object.canonical? || object.policy_object.nil?
+      return if object.canonical? || object.policy.nil?
 
-      object.policy_object.initial_profile
+      object.policy.initial_profile
     end
 
     # policy profiles
     def profiles
       return if object.canonical?
 
-      object.policy_object&.profiles
+      object.policy&.profiles
     end
   end
 end

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -98,7 +98,7 @@ module Types
     private
 
     def policy_or_report
-      object.policy_object || object
+      object.policy || object
     end
 
     def system_id(args)

--- a/app/models/concerns/profile_hosts.rb
+++ b/app/models/concerns/profile_hosts.rb
@@ -9,7 +9,7 @@ module ProfileHosts
     has_many :test_result_hosts, -> { distinct },
              through: :test_results, source: :host
     has_many :rule_results, through: :test_results
-    has_many :policy_hosts, through: :policy_object
+    has_many :policy_hosts, through: :policy
     has_many :assigned_hosts, through: :policy_hosts, source: :host
     has_many :hosts, through: :test_results
   end

--- a/app/models/concerns/profile_scoring.rb
+++ b/app/models/concerns/profile_scoring.rb
@@ -5,7 +5,7 @@ module ProfileScoring
   include ProfilePolicyScoring
 
   def total_host_count
-    if policy_object
+    if policy
       Host.where(id: assigned_hosts).count
     else
       Host.where(id: hosts).count
@@ -32,7 +32,7 @@ module ProfileScoring
   end
 
   def compliant?(host)
-    return policy_object.compliant?(host) if policy_id
+    return policy.compliant?(host) if policy_id
 
     score(host: host) >= compliance_threshold
   end

--- a/app/models/concerns/profile_searching.rb
+++ b/app/models/concerns/profile_searching.rb
@@ -21,7 +21,7 @@ module ProfileSearching
                   only_explicit: true, operators: ['=']
     scoped_search on: :canonical, ext_method: 'canonical?', only_explicit: true,
                   operators: ['=']
-    scoped_search on: :has_policy, ext_method: 'policy_object_search',
+    scoped_search on: :has_policy, ext_method: 'policy_search',
                   only_explicit: true, operators: ['=']
     scoped_search on: :os_major_version, ext_method: 'os_major_version_search',
                   only_explicit: true, operators: ['=', '!='],
@@ -53,7 +53,7 @@ module ProfileSearching
       # that must have a different order in the resulting query
       # of a scoped_search
       with_policy_test_results = default_scoped.joins(
-        policy_object: :test_results
+        policy: :test_results
       )
 
       if has_policy_test_results
@@ -70,14 +70,14 @@ module ProfileSearching
 
       policy_cond = { policy_id: policy_or_profile_id }
       profile_cond = {
-        policy_object: {
+        policy: {
           profiles_policies: {
             id: policy_or_profile_id
           }
         }
       }
 
-      search = left_outer_joins(policy_object: :profiles)
+      search = left_outer_joins(policy: :profiles)
       search.where(id: policy_or_profile_id)
             .or(search.where(policy_cond))
             .or(search.where(profile_cond))
@@ -87,7 +87,7 @@ module ProfileSearching
 
   # class methods for profile searching
   module ClassMethods
-    def policy_object_search(_filter, _operator, value)
+    def policy_search(_filter, _operator, value)
       profiles = Profile.with_policy(ActiveModel::Type::Boolean.new.cast(value))
       { conditions: profiles.arel.where_sql.gsub(/^where /i, '') }
     end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -7,7 +7,7 @@ class Policy < ApplicationRecord
   DEFAULT_COMPLIANCE_THRESHOLD = 100.0
   PROFILE_ATTRS = %w[name description account_id].freeze
 
-  has_many :profiles, dependent: :destroy, inverse_of: :policy_object
+  has_many :profiles, dependent: :destroy, inverse_of: :policy
   has_many :benchmarks, through: :profiles
   has_many :test_results, through: :profiles, dependent: :destroy
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -32,7 +32,7 @@ class Profile < ApplicationRecord
   validates :name, presence: true
   validates :benchmark_id, presence: true
   validates :account, presence: true, if: -> { hosts.any? }
-  validates :policy_object, presence: true, if: -> { policy_id }
+  validates :policy, presence: true, if: -> { policy_id }
 
   delegate :account_number, to: :account, allow_nil: true
 
@@ -80,7 +80,7 @@ class Profile < ApplicationRecord
       (new_profile = dup).update!(account: account,
                                   parent_profile: self,
                                   external: true,
-                                  policy_object: policy)
+                                  policy: policy)
       new_profile.update_rules(ref_ids: rules.pluck(:ref_id))
     end
 
@@ -102,7 +102,7 @@ class Profile < ApplicationRecord
 
   def in_account(account, policy)
     Profile.find_by(account: account, ref_id: ref_id,
-                    policy_object: policy,
+                    policy: policy,
                     benchmark_id: benchmark_id)
   end
 end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -9,8 +9,8 @@ class ProfileSerializer
   belongs_to :parent_profile, record_type: :profile
   has_many :rules
   has_many :hosts do |profile|
-    if profile.policy_object
-      profile.policy_object.hosts
+    if profile.policy
+      profile.policy.hosts
     else
       # external profile
       profile.test_result_hosts
@@ -25,11 +25,11 @@ class ProfileSerializer
   end
 
   attribute :name do |profile|
-    profile.policy_object&.name || profile.name
+    profile.policy&.name || profile.name
   end
 
   attribute :description do |profile|
-    profile.policy_object&.description || profile.description
+    profile.policy&.description || profile.description
   end
 
   attribute :canonical, &:canonical?
@@ -40,7 +40,7 @@ class ProfileSerializer
   attribute :test_result_host_count
   attribute :unsupported_host_count
   attribute :business_objective do |profile|
-    profile&.policy_object&.business_objective&.title
+    profile&.policy&.business_objective&.title
   end
   attribute :policy_type
 end

--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -19,8 +19,8 @@ module Xccdf
     end
 
     def delete_old_test_results
-      ::TestResult.left_outer_joins(profile: :policy_object)
-                  .where(profiles: { policy_object: @host_profile.policy_id },
+      ::TestResult.left_outer_joins(profile: :policy)
+                  .where(profiles: { policy: @host_profile.policy_id },
                          host: @host)
                   .where.not(id: @test_result.id)
                   .destroy_all

--- a/app/services/incorrect_profile_remover.rb
+++ b/app/services/incorrect_profile_remover.rb
@@ -14,7 +14,7 @@ class IncorrectProfileRemover
   end
 
   def self.find_incorrect_profiles(policy)
-    Profile.where(policy_object: policy)
+    Profile.where(policy: policy)
            .where.not(ref_id: policy.initial_profile.ref_id)
   end
 end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -116,7 +116,7 @@ class XccdfReportParser
   def save_all
     Host.transaction do
       check_os_version
-      check_for_external_reports unless Settings.features.parse_external_reports
+      check_for_external_reports
       save_missing_supported_benchmark
       check_for_missing_benchmark_info
       save_all_test_result_info

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,5 +21,3 @@ redis_cache_ssl: false
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'
 async: true
-features:
-  parse_external_reports: false

--- a/spec/integration/business_objectives_spec.rb
+++ b/spec/integration/business_objectives_spec.rb
@@ -9,11 +9,11 @@ describe 'Business Objectives API' do
     policies(:one).update!(account: accounts(:one),
                            business_objective: business_objectives(:one))
     profiles(:one).update!(account: accounts(:one),
-                           policy_object: policies(:one))
+                           policy: policies(:one))
     policies(:two).update!(account: accounts(:one),
                            business_objective: business_objectives(:two))
     profiles(:two).update!(account: accounts(:one),
-                           policy_object: policies(:two))
+                           policy: policies(:two))
   end
 
   path "#{Settings.path_prefix}/#{Settings.app_name}/business_objectives" do

--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -27,7 +27,7 @@ describe 'Profiles API' do
         before do
           policies(:one).update!(account: accounts(:one))
           profiles(:one).update!(account: accounts(:one),
-                                 policy_object: policies(:one))
+                                 policy: policies(:one))
         end
 
         let(:'X-RH-IDENTITY') { encoded_header(accounts(:one)) }
@@ -342,7 +342,7 @@ describe 'Profiles API' do
         let(:id) do
           new_profile = Profile.new(parent_profile_id: profiles(:two).id,
                                     account_id: accounts(:one).id,
-                                    policy_object: policies(:one))
+                                    policy: policies(:one))
                                .fill_from_parent
           new_profile.save
           new_profile.update_rules

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -65,7 +65,7 @@ class MetadataTest < ActionDispatch::IntegrationTest
         Profile.create(ref_id: SecureRandom.uuid, name: SecureRandom.uuid,
                        benchmark: benchmarks(:one),
                        account: accounts(:test), parent_profile: profiles(:one),
-                       policy_object: policies(:one))
+                       policy: policies(:one))
       end
       get profiles_url, params: { limit: 1, offset: 3 }
       assert_response :success
@@ -104,7 +104,7 @@ class MetadataTest < ActionDispatch::IntegrationTest
                      benchmark: benchmarks(:one),
                      parent_profile: profiles(:one),
                      account: accounts(:test),
-                     policy_object: policies(:one))
+                     policy: policies(:one))
       get profiles_url, params: { limit: 1, offset: 2 }
       assert_response :success
       assert_match(/limit=1/, json_body['links']['first'])
@@ -123,7 +123,7 @@ class MetadataTest < ActionDispatch::IntegrationTest
                        benchmark: benchmarks(:one),
                        parent_profile: profiles(:one),
                        account: accounts(:test),
-                       policy_object: policies(:one))
+                       policy: policies(:one))
       end
       get profiles_url, params: { limit: 2, offset: 1 }
       assert_response :success

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -335,6 +335,20 @@ module V1
       end
     end
 
+    class ShowTest < ProfilesControllerTest
+      test 'a single profile may be requested' do
+        profiles(:one).update!(external: false,
+                               parent_profile: profiles(:two),
+                               account: accounts(:one))
+        get v1_profile_url(profiles(:one).id)
+        assert_response :success
+
+        body = JSON.parse(response.body)
+        assert_equal profiles(:one).policy_profile_id,
+                     body.dig('data', 'attributes', 'policy_profile_id')
+      end
+    end
+
     class DestroyTest < ProfilesControllerTest
       require 'sidekiq/testing'
       Sidekiq::Testing.inline!

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -253,7 +253,7 @@ module V1
           account: accounts(:one), name: 'foo', ref_id: 'foo',
           benchmark: benchmarks(:one),
           parent_profile: profiles(:one),
-          policy_object: policies(:one)
+          policy: policies(:one)
         )
         get v1_profiles_url
         assert_response :success
@@ -268,7 +268,7 @@ module V1
           account: accounts(:one), name: 'foo', ref_id: 'foo',
           benchmark: benchmarks(:one),
           parent_profile: profiles(:one),
-          policy_object: policies(:one)
+          policy: policies(:one)
         )
         external = Profile.create!(
           account: accounts(:one), name: 'bar', ref_id: 'bar',
@@ -293,9 +293,9 @@ module V1
         assert hosts
         host_ids = hosts.map(&:id).sort
 
-        profiles(:one).update!(policy_object: policies(:one))
+        profiles(:one).update!(policy: policies(:one))
         profiles(:two).update!(account: accounts(:one),
-                               policy_object: policies(:one),
+                               policy: policies(:one),
                                external: true)
         policies(:one).update!(account: accounts(:one))
         policies(:one).hosts = hosts
@@ -317,7 +317,7 @@ module V1
 
       test 'returns test result hosts for external profiles' do
         test_results(:one).update(host: hosts(:one), profile: profiles(:one))
-        profiles(:one).update!(policy_object: nil, external: true)
+        profiles(:one).update!(policy: nil, external: true)
 
         get v1_profiles_url, params: { search: 'external = true' }
         assert_response :success
@@ -354,7 +354,7 @@ module V1
       Sidekiq::Testing.inline!
 
       setup do
-        profiles(:one).update!(policy_object: policies(:one))
+        profiles(:one).update!(policy: policies(:one))
       end
 
       test 'destroy an existing, accessible profile' do
@@ -757,7 +757,7 @@ module V1
         @policy = policies(:one)
         @profile = Profile.new(parent_profile_id: profiles(:two).id,
                                account_id: accounts(:one).id,
-                               policy_object: @policy).fill_from_parent
+                               policy: @policy).fill_from_parent
         @profile.save
         @profile.update_rules
       end
@@ -790,7 +790,7 @@ module V1
           )
         end
         assert_response :success
-        assert_equal NAME, @profile.policy_object.reload.name
+        assert_equal NAME, @profile.policy.reload.name
         assert_audited 'Updated profile'
         assert_audited @profile.id
         assert_audited @policy.id
@@ -808,8 +808,8 @@ module V1
           )
         end
         assert_response :success
-        assert_equal NAME, @profile.policy_object.reload.name
-        assert_equal DESCRIPTION, @profile.policy_object.description
+        assert_equal NAME, @profile.policy.reload.name
+        assert_equal DESCRIPTION, @profile.policy.description
         assert_equal COMPLIANCE_THRESHOLD, @profile.compliance_threshold
         assert_equal BUSINESS_OBJECTIVE, @profile.business_objective.title
         assert_audited 'Updated profile'
@@ -876,8 +876,8 @@ module V1
       end
 
       test 'update to update hosts relationships' do
-        @profile.policy_object.update!(hosts: hosts[0...-1])
-        assert_difference('@profile.policy_object.reload.hosts.count' => 0) do
+        @profile.policy.update!(hosts: hosts[0...-1])
+        assert_difference('@profile.policy.reload.hosts.count' => 0) do
           patch profile_path(@profile.id), params: params(
             attributes: {},
             relationships: {
@@ -898,9 +898,9 @@ module V1
       end
 
       test 'update to remove hosts relationships' do
-        @profile.policy_object.update!(hosts: hosts)
+        @profile.policy.update!(hosts: hosts)
         assert_difference(
-          '@profile.policy_object.reload.hosts.count' => -1
+          '@profile.policy.reload.hosts.count' => -1
         ) do
           patch profile_path(@profile.id), params: params(
             attributes: {},

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -317,7 +317,7 @@ module V1
 
       test 'returns test result hosts for external profiles' do
         test_results(:one).update(host: hosts(:one), profile: profiles(:one))
-        profiles(:one).update!(policy: nil, external: true)
+        profiles(:one).update!(external: true)
 
         get v1_profiles_url, params: { search: 'external = true' }
         assert_response :success

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -18,10 +18,10 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     users(:test).update account: accounts(:one)
     policies(:one).update account: accounts(:one)
     profiles(:one).update account: accounts(:one),
-                          policy_object: policies(:one)
+                          policy: policies(:one)
     policies(:two).update account: accounts(:one)
     profiles(:two).update account: accounts(:one),
-                          policy_object: policies(:two)
+                          policy: policies(:two)
 
     assert_empty hosts(:one).policies
 
@@ -52,10 +52,10 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     users(:test).update account: accounts(:one)
     policies(:one).update account: accounts(:one)
     profiles(:one).update account: accounts(:one),
-                          policy_object: policies(:one)
+                          policy: policies(:one)
     policies(:two).update account: accounts(:one)
     profiles(:two).update account: accounts(:one),
-                          policy_object: policies(:two)
+                          policy: policies(:two)
 
     Schema.execute(
       query,

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class AssociateSystemsMutationTest < ActiveSupport::TestCase
   setup do
     profiles(:one).update account: accounts(:one),
-                          policy_object: policies(:one)
+                          policy: policies(:one)
     users(:test).update account: accounts(:one)
   end
 
@@ -31,7 +31,7 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
       context: { current_user: users(:test) }
     )['data']['associateSystems']['profile']
 
-    assert_equal Set.new(profiles(:one).policy_object.reload.hosts),
+    assert_equal Set.new(profiles(:one).policy.reload.hosts),
                  Set.new([hosts(:one)])
   end
 
@@ -57,7 +57,7 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
       context: { current_user: users(:test) }
     )['data']['associateSystems']['profile']
 
-    assert_empty profiles(:one).policy_object.reload.hosts
+    assert_empty profiles(:one).policy.reload.hosts
     assert_audited 'Updated system associaton of policy'
     assert_audited policies(:one).id
   end

--- a/test/graphql/mutations/delete_test_result_mutation_test.rb
+++ b/test/graphql/mutations/delete_test_result_mutation_test.rb
@@ -26,7 +26,7 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
   end
 
   test 'delete a test result keeps the profile if part of a policy' do
-    profiles(:one).update(policy_object: policies(:one), external: true)
+    profiles(:one).update(policy: policies(:one), external: true)
     assert_difference('TestResult.count', -1) do
       assert_difference('Profile.count', 0) do
         result = Schema.execute(
@@ -47,8 +47,8 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
 
   test 'delete test results from initial policy profile deletes all results'\
        'in the policy' do
-    profiles(:one).update!(policy_object: policies(:one), external: false)
-    profiles(:two).update!(policy_object: policies(:one), external: true,
+    profiles(:one).update!(policy: policies(:one), external: false)
+    profiles(:two).update!(policy: policies(:one), external: true,
                            account: accounts(:test))
     test_results(:two).update! host: hosts(:two), profile: profiles(:two)
     assert_difference('TestResult.count', -2) do
@@ -70,7 +70,7 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
   end
 
   test 'deleting results for external policy removes profile and profilehost' do
-    profiles(:one).update(policy_object: nil, external: true)
+    profiles(:one).update(policy: nil, external: true)
     assert_difference('TestResult.count', -1) do
       assert_difference('Profile.count', -1) do
         result = Schema.execute(

--- a/test/graphql/mutations/delete_test_result_mutation_test.rb
+++ b/test/graphql/mutations/delete_test_result_mutation_test.rb
@@ -41,7 +41,7 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
       end
     end
     assert_audited 'Removed all user scoped test results'
-    assert_audited 'of profile'
+    assert_audited 'of policy'
     assert_audited profiles(:one).id
   end
 
@@ -67,25 +67,5 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
     assert_audited 'Removed all user scoped test results'
     assert_audited 'of policy'
     assert_audited policies(:one).id
-  end
-
-  test 'deleting results for external policy removes profile and profilehost' do
-    profiles(:one).update(policy: nil, external: true)
-    assert_difference('TestResult.count', -1) do
-      assert_difference('Profile.count', -1) do
-        result = Schema.execute(
-          QUERY,
-          variables: { input: {
-            profileId: profiles(:one).id
-          } },
-          context: { current_user: users(:test) }
-        ).dig('data', 'deleteTestResults')
-        assert_equal profiles(:one).id, result.dig('profile', 'id')
-        assert_equal test_results(:one).id, result.dig('testResults', 0, 'id')
-      end
-    end
-    assert_audited 'Removed all user scoped test results'
-    assert_audited 'of profile'
-    assert_audited profiles(:one).id
   end
 end

--- a/test/graphql/mutations/edit_policy_mutation_test.rb
+++ b/test/graphql/mutations/edit_policy_mutation_test.rb
@@ -19,7 +19,7 @@ class EditPolicyMutationTest < ActiveSupport::TestCase
     users(:test).update account: accounts(:test)
     profiles(:one).update(account: accounts(:test),
                           hosts: [hosts(:one)],
-                          policy_object: policies(:one))
+                          policy: policies(:one))
     assert_nil policies(:one).business_objective
 
     result = Schema.execute(
@@ -54,7 +54,7 @@ class EditPolicyMutationTest < ActiveSupport::TestCase
     policies(:one).update!(business_objective: business_objectives(:one))
     profiles(:one).update(account: accounts(:test),
                           hosts: [hosts(:one)],
-                          policy_object: policies(:one))
+                          policy: policies(:one))
 
     Schema.execute(
       query,

--- a/test/graphql/queries/business_objective_query_test.rb
+++ b/test/graphql/queries/business_objective_query_test.rb
@@ -15,7 +15,7 @@ class BusinessObjectiveTest < ActiveSupport::TestCase
 
     users(:test).update account: accounts(:test)
     profiles(:one).update(account: accounts(:test), hosts: [hosts(:one)],
-                          policy_object: policies(:one))
+                          policy: policies(:one))
     policies(:one).update(business_objective: business_objectives(:one))
 
     result = Schema.execute(

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -107,13 +107,13 @@ class ProfileQueryTest < ActiveSupport::TestCase
                              hosts: [hosts(:one), hosts(:two)])
 
       (parent = profiles(:one).dup).update!(account: nil, hosts: [])
-      profiles(:one).update!(policy_object: policies(:one),
+      profiles(:one).update!(policy: policies(:one),
                              external: false,
                              parent_profile: parent)
       profiles(:two).update!(account: accounts(:test),
                              external: true,
                              parent_profile: parent,
-                             policy_object: policies(:one))
+                             policy: policies(:one))
     end
 
     should 'query profile with a policy owned by the user' do
@@ -257,6 +257,9 @@ class ProfileQueryTest < ActiveSupport::TestCase
             businessObjective {
                title
             }
+            hosts {
+               id
+            }
         }
     }
     GRAPHQL
@@ -268,9 +271,9 @@ class ProfileQueryTest < ActiveSupport::TestCase
     profiles(:one).rules << rules(:one)
     profiles(:one).rules << rules(:two)
     profiles(:one).update(account: accounts(:test),
-                          policy_object: policies(:one))
+                          policy: policies(:one))
     profiles(:two).update(account: accounts(:test),
-                          policy_object: policies(:one))
+                          policy: policies(:one))
     policies(:one).update(compliance_threshold: 95,
                           account: accounts(:test),
                           hosts: [hosts(:one)])
@@ -293,6 +296,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
     assert_equal 1, profile1_result['testResultHostCount']
     assert_equal 1, profile1_result['compliantHostCount']
     assert_equal 1, profile1_result['unsupportedHostCount']
+    assert_equal 1, profile1_result['hosts'].length
     assert_not profile1_result['businessObjective']
   end
 end

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -4,9 +4,9 @@ require 'test_helper'
 
 class SystemQueryTest < ActiveSupport::TestCase
   setup do
-    profiles(:one).update! policy_object: policies(:one),
+    profiles(:one).update! policy: policies(:one),
                            account: accounts(:one)
-    profiles(:two).update! policy_object: policies(:two),
+    profiles(:two).update! policy: policies(:two),
                            account: accounts(:one)
     users(:test).update account: accounts(:one)
   end
@@ -174,7 +174,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
       (second_benchmark = benchmarks(:one).dup).update!(version: '1.2.3')
       other_profile = profiles(:one).dup
-      other_profile.update!(policy_object: policies(:one),
+      other_profile.update!(policy: policies(:one),
                             external: true,
                             benchmark: second_benchmark,
                             account: accounts(:test))
@@ -265,7 +265,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
       (second_benchmark = benchmarks(:one).dup).update!(version: '1.2.3')
       other_profile = profiles(:one).dup
-      other_profile.update!(policy_object: policies(:one),
+      other_profile.update!(policy: policies(:one),
                             external: true,
                             benchmark: second_benchmark,
                             account: accounts(:test))
@@ -308,7 +308,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
       (second_benchmark = benchmarks(:one).dup).update!(version: '1.2.3')
       other_profile = profiles(:one).dup
-      other_profile.update!(policy_object: policies(:one),
+      other_profile.update!(policy: policies(:one),
                             external: true,
                             benchmark: second_benchmark,
                             account: accounts(:test))
@@ -512,7 +512,7 @@ class SystemQueryTest < ActiveSupport::TestCase
     }
     GRAPHQL
 
-    profiles(:one).update!(policy_object: nil)
+    profiles(:one).update!(policy: nil)
     profiles(:one).rules << rules(:one)
     rule_results(:one).update(
       host: hosts(:one), rule: rules(:one), test_result: test_results(:one)

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -512,7 +512,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     }
     GRAPHQL
 
-    profiles(:one).update!(policy: nil)
     profiles(:one).rules << rules(:one)
     rule_results(:one).update(
       host: hosts(:one), rule: rules(:one), test_result: test_results(:one)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -74,7 +74,7 @@ class HostTest < ActiveSupport::TestCase
     policies(:one).hosts << host
 
     profiles(:one).update!(account: host.account_object,
-                           policy_object: policies(:one))
+                           policy: policies(:one))
     test_results(:two).update!(host: host, profile: profiles(:two))
 
     assert_equal host.all_profiles.count, 2
@@ -159,7 +159,7 @@ class HostTest < ActiveSupport::TestCase
 
   context 'scope search by a policy' do
     setup do
-      profiles(:one).update!(policy_object: policies(:one),
+      profiles(:one).update!(policy: policies(:one),
                              account: accounts(:one))
       policies(:one).hosts << hosts(:one)
     end
@@ -189,7 +189,7 @@ class HostTest < ActiveSupport::TestCase
 
     should 'NOT find host unassigned to the policy even with test results' do
       policies(:one).hosts = []
-      profiles(:two).update!(policy_object: policies(:one),
+      profiles(:two).update!(policy: policies(:one),
                              external: true,
                              account: accounts(:one))
       rules(:one).profiles << profiles(:two)
@@ -207,7 +207,7 @@ class HostTest < ActiveSupport::TestCase
 
   context 'scope search for hosts with policy test results' do
     setup do
-      profiles(:one).update!(policy_object: policies(:one),
+      profiles(:one).update!(policy: policies(:one),
                              account: accounts(:one))
       policies(:one).hosts << hosts(:one)
     end
@@ -235,7 +235,7 @@ class HostTest < ActiveSupport::TestCase
     end
 
     should 'find host using external profile id from its test result' do
-      profiles(:two).update!(policy_object: policies(:one),
+      profiles(:two).update!(policy: policies(:one),
                              account: accounts(:one),
                              external: true)
       test_results(:one).update!(profile: profiles(:two))

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -124,7 +124,7 @@ class PolicyTest < ActiveSupport::TestCase
   end
 
   should 'return an OS major version' do
-    profiles(:one).update!(policy_object: policies(:one),
+    profiles(:one).update!(policy: policies(:one),
                            account: accounts(:test))
     assert_equal '7', policies(:one).os_major_version
   end
@@ -154,7 +154,7 @@ class PolicyTest < ActiveSupport::TestCase
     should 'be compliant if score is above compliance threshold' do
       policies(:one).update!(compliance_threshold: 90)
       policies(:one).stubs(:score).returns(95)
-      profiles(:one).update!(policy_object: policies(:one),
+      profiles(:one).update!(policy: policies(:one),
                              account: accounts(:test))
 
       assert policies(:one).compliant?(hosts(:one))
@@ -167,9 +167,9 @@ class PolicyTest < ActiveSupport::TestCase
 
   context 'score' do
     should 'return the associated profile score' do
-      profiles(:one).update!(policy_object: policies(:one),
+      profiles(:one).update!(policy: policies(:one),
                              account: accounts(:test))
-      profiles(:two).update!(policy_object: policies(:one),
+      profiles(:two).update!(policy: policies(:one),
                              account: accounts(:test))
 
       assert_equal test_results(:one).score,

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -105,11 +105,10 @@ class ProfileTest < ActiveSupport::TestCase
   end
 
   test 'policy_profile finds the initial profile of a policy' do
-    profiles(:two).update!(account: accounts(:test), policy: nil)
-    assert_nil profiles(:two).policy_profile
     profiles(:one).update!(policy: policies(:one), external: false)
     assert_equal profiles(:one), profiles(:one).policy_profile
-    profiles(:two).update!(policy: policies(:one), external: true)
+    profiles(:two).update!(policy: policies(:one), external: true,
+                           account: accounts(:test))
     assert_equal profiles(:one), profiles(:one).policy_profile
     assert_equal profiles(:one), profiles(:two).policy_profile
   end
@@ -203,18 +202,8 @@ class ProfileTest < ActiveSupport::TestCase
 
   test 'business_objective comes from policy' do
     policies(:one).update!(business_objective: business_objectives(:one))
-    profiles(:one).update!(policy: nil)
-    assert_nil profiles(:one).business_objective
     profiles(:one).update!(policy: policies(:one))
     assert_equal business_objectives(:one), profiles(:one).business_objective
-  end
-
-  test 'compliance_threshold comes from policy default for external profiles' do
-    (bm = benchmarks(:one).dup).update!(version: '0.1.47')
-    (external_profile = profiles(:one).dup).update!(benchmark: bm,
-                                                    policy: nil)
-    assert_nil external_profile.policy
-    assert_equal 100, external_profile.compliance_threshold
   end
 
   context 'destroying' do
@@ -282,8 +271,7 @@ class ProfileTest < ActiveSupport::TestCase
     end
 
     should 'find by exact profile id' do
-      profiles(:two).update!(policy: nil,
-                             account: accounts(:one))
+      profiles(:two).update!(account: accounts(:one))
       assert_includes Profile.in_policy(profiles(:two).id),
                       profiles(:two)
       assert_equal 1, Profile.in_policy(profiles(:two).id).length
@@ -439,8 +427,7 @@ class ProfileTest < ActiveSupport::TestCase
   end
 
   test 'external is searchable' do
-    profiles(:one).update!(policy: nil, external: true)
-    assert_nil profiles(:one).policy
+    profiles(:one).update!(external: true)
     assert_includes Profile.search_for('external = true'), profiles(:one)
     assert_includes Profile.external, profiles(:one)
     assert_not_includes Profile.search_for('external = false'), profiles(:one)

--- a/test/policies/profile_policy_test.rb
+++ b/test/policies/profile_policy_test.rb
@@ -12,7 +12,7 @@ class ProfilePolicyTest < ActiveSupport::TestCase
     users(:test).account = accounts(:test)
     policies(:one).update!(account: accounts(:test))
     profiles(:one).update!(account: accounts(:test),
-                           policy_object: policies(:one))
+                           policy: policies(:one))
     policies(:one).hosts = [hosts(:one)]
     assert_includes Pundit.policy_scope(users(:test), Profile), profiles(:one)
     assert Pundit.authorize(users(:test), profiles(:one), :index?)

--- a/test/services/concerns/xccdf/test_result_test.rb
+++ b/test/services/concerns/xccdf/test_result_test.rb
@@ -61,27 +61,6 @@ class TestResultTest < ActiveSupport::TestCase
     assert_equal TestResult.find_by(host: hosts(:one)), @mock.test_result
   end
 
-  test 'old external test results are replaced by the new test result' do
-    profiles(:two).update!(policy: nil, account: accounts(:test))
-    profiles(:one).update!(policy: nil, account: accounts(:test))
-    TestResult.where(host: hosts(:one), profile: profiles(:one)).destroy_all
-
-    assert_difference('TestResult.count' => 2) do
-      TestResult.create!(host: hosts(:one),
-                         profile: profiles(:one),
-                         end_time: @end_time - 3.minutes)
-
-      TestResult.create!(host: hosts(:one),
-                         profile: profiles(:two),
-                         end_time: @end_time - 8.minutes)
-    end
-
-    assert_difference('TestResult.count' => -1) do
-      @mock.save_test_result
-    end
-    assert_equal TestResult.find_by(host: hosts(:one)), @mock.test_result
-  end
-
   context 'supportability' do
     should 'default to supported' do
       assert test_results(:one).supported

--- a/test/services/concerns/xccdf/test_result_test.rb
+++ b/test/services/concerns/xccdf/test_result_test.rb
@@ -39,9 +39,9 @@ class TestResultTest < ActiveSupport::TestCase
   end
 
   test 'old test results within a policy replaced by the new test result' do
-    profiles(:two).update!(policy_object: policies(:one),
+    profiles(:two).update!(policy: policies(:one),
                            account: accounts(:test))
-    profiles(:one).update!(policy_object: policies(:one),
+    profiles(:one).update!(policy: policies(:one),
                            account: accounts(:test))
     TestResult.where(host: hosts(:one), profile: profiles(:one)).destroy_all
 
@@ -62,8 +62,8 @@ class TestResultTest < ActiveSupport::TestCase
   end
 
   test 'old external test results are replaced by the new test result' do
-    profiles(:two).update!(policy_object: nil, account: accounts(:test))
-    profiles(:one).update!(policy_object: nil, account: accounts(:test))
+    profiles(:two).update!(policy: nil, account: accounts(:test))
+    profiles(:one).update!(policy: nil, account: accounts(:test))
     TestResult.where(host: hosts(:one), profile: profiles(:one)).destroy_all
 
     assert_difference('TestResult.count' => 2) do

--- a/test/services/external_policy_remover_test.rb
+++ b/test/services/external_policy_remover_test.rb
@@ -13,7 +13,7 @@ class ExternalPolicyRemoverTest < ActiveSupport::TestCase
 
   test 'removes all external policies' do
     profiles(:one).dup.update!(external: true, account: accounts(:test))
-    profiles(:two).dup.update!(external: true, policy_object: policies(:one),
+    profiles(:two).dup.update!(external: true, policy: policies(:one),
                                account: accounts(:test))
     assert_equal 1, Profile.external.where(policy_id: nil).count
     assert_difference('Profile.count' => -1) do

--- a/test/services/incorrect_profile_remover_test.rb
+++ b/test/services/incorrect_profile_remover_test.rb
@@ -4,9 +4,9 @@ require 'test_helper'
 
 class IncorrectProfileRemoverTest < ActiveSupport::TestCase
   setup do
-    profiles(:one).update!(policy_object: policies(:one),
+    profiles(:one).update!(policy: policies(:one),
                            account: accounts(:test))
-    profiles(:two).update!(policy_object: policies(:two),
+    profiles(:two).update!(policy: policies(:two),
                            account: accounts(:test))
   end
 

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -299,7 +299,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
                                                    account: accounts(:test))
       @report_parser.save_host_profile
 
-      profiles(:one).update!(policy_object: policies(:one),
+      profiles(:one).update!(policy: policies(:one),
                              account: accounts(:test))
       Profile.any_instance.expects(:clone_to).with(policy: policies(:one),
                                                    account: accounts(:test))


### PR DESCRIPTION
This PR is intended to remove all remaining external policy support code and any tests which cover that path, either intentionally or unintentionally (lots of `policy: nil` in tests that didn't need to be there). I recommend to review each commit. In some places, I've added a couple tests due to codecov complaining about patch coverage.

Please merge after approval (if approved), since I won't be around to do it myself.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices