### PR TITLE
fix(test): RHICOMPL-1482 make disable_rbac: false when testing

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,3 +2,4 @@ host_inventory_url: http://test-host-inventory:8000
 rbac_url: http://test-rbac-url:9002
 # Disable Prometheus
 prometheus_exporter_host:
+disable_rbac: false


### PR DESCRIPTION
As now we [consume the .env file in the rails container](https://github.com/RedHatInsights/compliance-backend/pull/762), the `SETTINGS__DISABLE_RBAC` env var can override the default `nil`
value of `Settings.disable_rbac` which causes issues when running the tests.

In order to prevent this from happening, I'm changing its value to `true` when testing.