### PR TITLE
RHICOMPL-1482: make the test output more readable

### DIFF
--- a/app/services/concerns/xccdf/rule_references_rules.rb
+++ b/app/services/concerns/xccdf/rule_references_rules.rb
@@ -5,9 +5,9 @@ module Xccdf
   module RuleReferencesRules
     extend ActiveSupport::Concern
 
-    included do
-      RuleReferencesRuleStruct = Struct.new(:rule_id, :rule_reference_id)
+    RuleReferencesRuleStruct = Struct.new(:rule_id, :rule_reference_id)
 
+    included do
       def save_rule_references_rules
         @rule_references_rules = new_rule_references_rules +
                                  existing_rule_references_rules

--- a/test/consumers/inventory_events_consumer_test.rb
+++ b/test/consumers/inventory_events_consumer_test.rb
@@ -5,7 +5,7 @@ require 'sidekiq/testing'
 
 class InventoryEventsConsumerTest < ActiveSupport::TestCase
   setup do
-    @message = stub(:message)
+    @message = stub(message: nil)
     @consumer = InventoryEventsConsumer.new
     DeleteHost.clear
   end

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -196,6 +196,7 @@ module V1
       test 'policy_profile_id is exposed' do
         profiles(:one).update!(external: false,
                                parent_profile: profiles(:two),
+                               policy: policies(:one),
                                account: accounts(:one))
         get v1_profiles_url
         assert_response :success

--- a/test/fixtures/policies.yml
+++ b/test/fixtures/policies.yml
@@ -3,7 +3,9 @@
 one:
   name: policy1
   account: test
+  description: foo
 
 two:
   name: policy2
   account: test
+  description: bar

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -4,8 +4,10 @@ one:
   name: profile1
   ref_id: xccdf_org.ssgproject.profile1
   benchmark: one
+  description: foo
 
 two:
   name: profile2
   ref_id: xccdf_org.ssgproject.profile2
   benchmark: one
+  description: bar

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -697,12 +697,12 @@ class SystemQueryTest < ActiveSupport::TestCase
 
   private
 
-  # rubocop:disable AbcSize
+  # rubocop:disable Metrics/AbcSize
   def setup_two_hosts
     hosts(:one).policies << policies(:one)
     hosts(:two).policies << policies(:two)
     profiles(:one).rules << rules(:one)
     profiles(:two).rules << rules(:two)
   end
-  # rubocop:enable AbcSize
+  # rubocop:enable Metrics/AbcSize
 end

--- a/test/jobs/delete_host_test.rb
+++ b/test/jobs/delete_host_test.rb
@@ -10,6 +10,11 @@ class DeleteHostTest < ActiveSupport::TestCase
       'type': 'delete'
     }
     DeleteHost.clear
+
+    @logger = mock
+    Sidekiq.stubs(:logger).returns(@logger)
+    @logger.stubs(:info)
+    @logger.stubs(:debug)
   end
 
   test 'deletes a host if the passed ID is found' do

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -9,6 +9,11 @@ class ParseReportJobTest < ActiveSupport::TestCase
     @file = file_fixture('report.tar.gz').read
     @parser = mock('XccdfReportParser')
     @issue_id = 'ssg:rhel7|short_profile_ref_id|rule_ref_id'
+    @logger = mock
+
+    Sidekiq.stubs(:logger).returns(@logger)
+    @logger.stubs(:info)
+    @logger.stubs(:error)
   end
 
   test 'payload tracker is notified about successful processing' do

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -71,6 +71,8 @@ class PolicyTest < ActiveSupport::TestCase
   end
 
   should '#attrs_from(profile:)' do
+    profiles(:one).update!(account: accounts(:one))
+
     Policy::PROFILE_ATTRS.each do |attr|
       assert_equal profiles(:one).send(attr),
                    Policy.attrs_from(profile: profiles(:one))[attr]

--- a/test/producers/application_producer_test.rb
+++ b/test/producers/application_producer_test.rb
@@ -28,4 +28,9 @@ class ApplicationProducerTest < ActiveSupport::TestCase
 
     assert_equal config, MockProducer.send(:kafka_config)
   end
+
+  teardown do
+    # Prevents warnings coming from constant redefinition
+    MockProducer.send(:remove_const, :SECURITY_PROTOCOL)
+  end
 end

--- a/test/services/datastream_importer_test.rb
+++ b/test/services/datastream_importer_test.rb
@@ -5,18 +5,18 @@ require 'test_helper'
 # A class to test importing from a Datastream file
 class DatastreamImporterTest < ActiveSupport::TestCase
   setup do
-    DATASTREAM_FILE = file_fixture('ssg-rhel7-ds.xml')
+    @datastream_file = file_fixture('ssg-rhel7-ds.xml')
   end
 
   test 'datastream import' do
-    importer = DatastreamImporter.new(DATASTREAM_FILE)
+    importer = DatastreamImporter.new(@datastream_file)
     importer.expects(:save_all_benchmark_info)
     ENV['JOBS_ACCOUNT_NUMBER'] ||= Account.first.account_number
     importer.import!
   end
 
   test 'works without any accounts' do
-    importer = DatastreamImporter.new(DATASTREAM_FILE)
+    importer = DatastreamImporter.new(@datastream_file)
     importer.expects(:save_all_benchmark_info)
     ENV['JOBS_ACCOUNT_NUMBER'] ||= nil
     importer.import!

--- a/test/services/duplicate_benchmark_resolver_test.rb
+++ b/test/services/duplicate_benchmark_resolver_test.rb
@@ -8,7 +8,9 @@ class DuplicateBenchmarkResolverTest < ActiveSupport::TestCase
   setup do
     # rubocop:disable Lint/SuppressedException
     begin
-      AddUniqueIndexToBenchmarks.new.down
+      ActiveRecord::Migration.suppress_messages do
+        AddUniqueIndexToBenchmarks.new.down
+      end
     rescue ArgumentError # if index doesn't exist
     end
     # rubocop:enable Lint/SuppressedException

--- a/test/services/duplicate_profile_resolver_test.rb
+++ b/test/services/duplicate_profile_resolver_test.rb
@@ -7,7 +7,9 @@ class DuplicateProfileResolverTest < ActiveSupport::TestCase
   setup do
     # rubocop:disable Lint/SuppressedException
     begin
-      AddUniqueIndexToProfiles.new.down
+      ActiveRecord::Migration.suppress_messages do
+        AddUniqueIndexToProfiles.new.down
+      end
     rescue ArgumentError # if index doesn't exist
     end
     # rubocop:enable Lint/SuppressedException

--- a/test/services/duplicate_rule_reference_resolver_test.rb
+++ b/test/services/duplicate_rule_reference_resolver_test.rb
@@ -8,7 +8,9 @@ class DuplicateRuleReferenceResolverTest < ActiveSupport::TestCase
   setup do
     # rubocop:disable Lint/SuppressedException
     begin
-      AddUniqueIndexToRuleReferences.new.down
+      ActiveRecord::Migration.suppress_messages do
+        AddUniqueIndexToRuleReferences.new.down
+      end
     rescue ArgumentError # if index doesn't exist
     end
     # rubocop:enable Lint/SuppressedException

--- a/test/services/duplicate_rule_resolver_test.rb
+++ b/test/services/duplicate_rule_resolver_test.rb
@@ -7,7 +7,9 @@ class DuplicateRuleResolverTest < ActiveSupport::TestCase
   setup do
     # rubocop:disable Lint/SuppressedException
     begin
-      AddUniqueIndexToRules.new.down
+      ActiveRecord::Migration.suppress_messages do
+        AddUniqueIndexToRules.new.down
+      end
     rescue ArgumentError # if index doesn't exist
     end
     # rubocop:enable Lint/SuppressedException

--- a/test/services/duplicate_rule_result_resolver_test.rb
+++ b/test/services/duplicate_rule_result_resolver_test.rb
@@ -8,7 +8,9 @@ class DuplicateRuleResultResolverTest < ActiveSupport::TestCase
   setup do
     # rubocop:disable Lint/SuppressedException
     begin
-      AddUniqueIndexToRuleResults.new.down
+      ActiveRecord::Migration.suppress_messages do
+        AddUniqueIndexToRuleResults.new.down
+      end
     rescue ArgumentError # if index doesn't exist
     end
     # rubocop:enable Lint/SuppressedException

--- a/test/services/duplicate_test_result_resolver_test.rb
+++ b/test/services/duplicate_test_result_resolver_test.rb
@@ -8,7 +8,11 @@ class DuplicateTestResultResolverTest < ActiveSupport::TestCase
   setup do
     # rubocop:disable Lint/SuppressedException
     begin
-      AddUniqueIndexToTestResults.new.down
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migration.suppress_messages do
+          AddUniqueIndexToTestResults.new.down
+        end
+      end
     rescue ArgumentError # if index doesn't exist
     end
     # rubocop:enable Lint/SuppressedException

--- a/test/services/external_policy_remover_test.rb
+++ b/test/services/external_policy_remover_test.rb
@@ -4,6 +4,12 @@ require 'test_helper'
 
 # A class to test removal of external policies
 class ExternalPolicyRemoverTest < ActiveSupport::TestCase
+  setup do
+    logger = mock
+    Logger.stubs(:new).returns(logger)
+    logger.stubs(:info)
+  end
+
   test 'does nothing if no external policies exist' do
     assert_empty Profile.external.where(policy_id: nil)
     assert_difference('Profile.count' => 0) do

--- a/test/services/incorrect_profile_remover_test.rb
+++ b/test/services/incorrect_profile_remover_test.rb
@@ -8,6 +8,10 @@ class IncorrectProfileRemoverTest < ActiveSupport::TestCase
                            account: accounts(:test))
     profiles(:two).update!(policy: policies(:two),
                            account: accounts(:test))
+
+    logger = mock
+    Logger.stubs(:new).returns(logger)
+    logger.stubs(:info)
   end
 
   test 'removes profiles with a mismatched ref_id' do

--- a/test/tasks/cleanup_db_test.rb
+++ b/test/tasks/cleanup_db_test.rb
@@ -16,7 +16,9 @@ class CleanupDbTest < ActiveSupport::TestCase
       'TestResult.count' => -1, 'RuleResult.count' => -1,
       'PolicyHost.count' => -1
     ) do
-      Rake::Task['cleanup_db'].execute
+      capture_io do
+        Rake::Task['cleanup_db'].execute
+      end
     end
   end
 
@@ -27,7 +29,9 @@ class CleanupDbTest < ActiveSupport::TestCase
     policies(:one).update!(account: account)
     accounts(:one).dup.update!(account_number: hosts(:one).account_number)
     assert_difference('Account.count' => 0) do
-      Rake::Task['cleanup_db'].execute
+      capture_io do
+        Rake::Task['cleanup_db'].execute
+      end
     end
   end
 end

--- a/test/tasks/import_datastream_test.rb
+++ b/test/tasks/import_datastream_test.rb
@@ -12,7 +12,9 @@ class ImportDatastreamTest < ActiveSupport::TestCase
     DatastreamImporter.any_instance.expects(:import!).raises(StandardError)
 
     assert_raises StandardError do
-      Rake::Task['ssg:import'].execute
+      capture_io do
+        Rake::Task['ssg:import'].execute
+      end
     end
   end
 end

--- a/test/tasks/import_remediations_test.rb
+++ b/test/tasks/import_remediations_test.rb
@@ -11,7 +11,9 @@ class ImportRemediationsTest < ActiveSupport::TestCase
                    .raises(StandardError)
 
     assert_raises StandardError do
-      Rake::Task['import_remediations'].execute
+      capture_io do
+        Rake::Task['import_remediations'].execute
+      end
     end
   end
 end


### PR DESCRIPTION
The test output contained a lot of warnings and puts/logging output. I went through all of these and cleaned them up, see the commit messages for more details. There are still two deprecation warnings coming from GraphQL but they will probably need modifications outside the test folder, so I will try to tackle that in a separate PR.