### PR TITLE
devel(rake): RHICOMPL-1482 set the default rake task to test:validate

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,6 @@ task :log => :environment do
   ActiveRecord::Base.logger = Logger.new(STDOUT)
 end
 
+task :default => [:'test:validate']
+
 Rails.application.load_tasks


### PR DESCRIPTION
By default minitest sets the `test` task as the default, so when running `bin/rake` it only runs the minitest tests, but not the others. This change makes the `test:validate` to be default, i.e. making the `bin/rake` and `bin/rake test:validate` commands identical.

There might be a reason why we didn't have this before, feel free to close this if that's the case :see_no_evil: 