### PR TITLE
fix(reports): RHICOMPL-1491 parsing empty and non-archive reports

### DIFF
--- a/app/services/safe_downloader.rb
+++ b/app/services/safe_downloader.rb
@@ -41,7 +41,7 @@ class SafeDownloader
     def report_contents(downloaded_file)
       case downloaded_file
       when StringIO
-        downloaded_file.string
+        [downloaded_file.string]
       else
         ReportsTarReader.new(downloaded_file).reports
       end

--- a/test/services/safe_downloader_test.rb
+++ b/test/services/safe_downloader_test.rb
@@ -8,20 +8,22 @@ class SafeDownloaderTest < ActiveSupport::TestCase
   end
 
   test 'download success with small file' do
-    strio = StringIO.new('a')
+    strio = StringIO.new('report')
     URI::HTTP.any_instance.expects(:open).returns(strio)
     IO.expects(:read).never
-    strio.expects(:string)
+    strio.expects(:string).returns('report')
 
-    SafeDownloader.download(@url)
+    downloaded = SafeDownloader.download(@url)
+    assert_equal 1, downloaded.count
   end
 
   test 'download success with large file' do
     file = File.new(file_fixture('insights-archive.tar.gz'))
     URI::HTTP.any_instance.expects(:open).returns(file)
-    ReportsTarReader.any_instance.expects(:reports)
+    ReportsTarReader.any_instance.expects(:reports).returns(['report'])
 
-    SafeDownloader.download(@url)
+    downloaded = SafeDownloader.download(@url)
+    assert_equal 1, downloaded.count
   end
 
   test 'download with empty file fails' do


### PR DESCRIPTION
This have been failing in kafka consumer when an empty report was
uploaded with:
```
undefined method `map' for #<String:0x000056166eb12788>
```
After this change a report validation is done correctly and error message is printed (for an empty report):
```
Invalid Report: 1:1: FATAL: Start tag expected, '<' not found
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
