### PR TITLE
fix(Profile): wrap associate gql mutations into transactions

### DIFF
--- a/app/graphql/mutations/profile/associate_rules.rb
+++ b/app/graphql/mutations/profile/associate_rules.rb
@@ -13,14 +13,16 @@ module Mutations
       field :profile, Types::Profile, null: true
 
       def resolve(args = {})
-        profile = find_profile(args[:id])
-        if profile
-          rules_added, rules_removed = profile.update_rules(
-            ids: args[:rule_ids]
-          )
-          audit_mutation(profile, rules_added, rules_removed)
+        ::Profile.transaction do
+          profile = find_profile(args[:id])
+          if profile
+            rules_added, rules_removed = profile.update_rules(
+              ids: args[:rule_ids]
+            )
+            audit_mutation(profile, rules_added, rules_removed)
+          end
+          { profile: profile }
         end
-        { profile: profile }
       end
 
       private

--- a/app/graphql/mutations/profile/associate_systems.rb
+++ b/app/graphql/mutations/profile/associate_systems.rb
@@ -11,12 +11,14 @@ module Mutations
       field :profile, Types::Profile, null: true
 
       def resolve(args = {})
-        profile = find_profile(args[:id])
-        if profile&.policy
-          profile.policy.update_hosts(args[:system_ids])
-          audit_mutation(profile)
+        ::Profile.transaction do
+          profile = find_profile(args[:id])
+          if profile&.policy
+            profile.policy.update_hosts(args[:system_ids])
+            audit_mutation(profile)
+          end
+          { profile: profile }
         end
-        { profile: profile }
       end
 
       include HostHelper


### PR DESCRIPTION
Wrapped the `AssociateSystems` and `AssociateRules` mutations with AR transactions. 

Followup on https://github.com/RedHatInsights/compliance-backend/pull/768#discussion_r590632135