### PR TITLE
devel(reload): explicit de-namespacing in all model concerns

### DIFF
--- a/app/models/concerns/host_searching.rb
+++ b/app/models/concerns/host_searching.rb
@@ -28,8 +28,8 @@ module HostSearching
                   only_explicit: true, operators: ['=']
 
     scope :with_policy, lambda { |with_policy = true|
-      with_policy && where(id: PolicyHost.select(:host_id)) ||
-        where.not(id: PolicyHost.select(:host_id))
+      with_policy && where(id: ::PolicyHost.select(:host_id)) ||
+        where.not(id: ::PolicyHost.select(:host_id))
     }
 
     scope :os_major_version, lambda { |version, equal = true|

--- a/app/models/concerns/profile_policy_association.rb
+++ b/app/models/concerns/profile_policy_association.rb
@@ -30,7 +30,7 @@ module ProfilePolicyAssociation
 
       error_msg = 'must be unique. Another policy with '\
                   'this policy type already exists.'
-      profile = Profile.includes(:benchmark).find_by(
+      profile = ::Profile.includes(:benchmark).find_by(
         ref_id: ref_id, account: account, external: false,
         benchmarks: { ref_id: benchmark.ref_id }
       )
@@ -40,7 +40,7 @@ module ProfilePolicyAssociation
 
     def compliance_threshold
       policy&.compliance_threshold ||
-        Policy::DEFAULT_COMPLIANCE_THRESHOLD
+        ::Policy::DEFAULT_COMPLIANCE_THRESHOLD
     end
 
     def destroy_policy_with_internal
@@ -63,12 +63,12 @@ module ProfilePolicyAssociation
       return unless policy
 
       msg = "Autoremoved policy #{policy.id} with the initial/main profile"
-      Rails.logger.audit_success(msg)
+      ::Rails.logger.audit_success(msg)
     end
 
     def audit_empty_policy_autoremove(policy)
       msg = "Autoremoved policy #{policy.id} with the last profile"
-      Rails.logger.audit_success(msg)
+      ::Rails.logger.audit_success(msg)
     end
   end
 end

--- a/app/models/concerns/profile_rules.rb
+++ b/app/models/concerns/profile_rules.rb
@@ -9,13 +9,13 @@ module ProfileRules
     has_many :rules, through: :profile_rules, source: :rule
 
     def update_rules(ids: nil, ref_ids: nil)
-      removed = ProfileRule.where(
+      removed = ::ProfileRule.where(
         rule_id: rule_ids_to_destroy(ids, ref_ids), profile_id: id
       ).destroy_all
 
       ids_to_add = rule_ids_to_add(ids, ref_ids)
-      imported = ProfileRule.import!(ids_to_add.map do |rule_id|
-        ProfileRule.new(profile_id: id, rule_id: rule_id)
+      imported = ::ProfileRule.import!(ids_to_add.map do |rule_id|
+        ::ProfileRule.new(profile_id: id, rule_id: rule_id)
       end)
 
       [imported.ids.count, removed.count]

--- a/app/models/concerns/profile_scoring.rb
+++ b/app/models/concerns/profile_scoring.rb
@@ -6,9 +6,9 @@ module ProfileScoring
 
   def total_host_count
     if policy
-      Host.where(id: assigned_hosts).count
+      ::Host.where(id: assigned_hosts).count
     else
-      Host.where(id: hosts).count
+      ::Host.where(id: hosts).count
     end
   end
 
@@ -21,8 +21,9 @@ module ProfileScoring
   end
 
   def unsupported_host_count
-    Host.where(id: latest_policy_test_results.supported(false).select(:host_id))
-        .count
+    ::Host.where(
+      id: latest_policy_test_results.supported(false).select(:host_id)
+    ).count
   end
 
   def compliance_score(host)
@@ -40,9 +41,9 @@ module ProfileScoring
   # Disabling MethodLength because it measures things wrong
   # for a multi-line string SQL query.
   def results(host)
-    Rails.cache.fetch("#{id}/#{host.id}/results") do
-      rule_results = TestResult.where(profile: self, host: host)
-                               .order('created_at DESC')&.first&.rule_results
+    ::Rails.cache.fetch("#{id}/#{host.id}/results") do
+      rule_results = ::TestResult.where(profile: self, host: host)
+                                 .order('created_at DESC')&.first&.rule_results
       return [] if rule_results.blank?
 
       rule_results.map do |rule_result|
@@ -54,12 +55,12 @@ module ProfileScoring
   private
 
   def latest_supported_policy_test_result_hosts
-    Host.where(id: latest_policy_test_results.supported.select(:host_id))
+    ::Host.where(id: latest_policy_test_results.supported.select(:host_id))
   end
 
   def latest_policy_test_results
-    TestResult.where(id: test_results)
-              .or(TestResult.where(id: policy_test_results))
-              .latest
+    ::TestResult.where(id: test_results)
+                .or(::TestResult.where(id: policy_test_results))
+                .latest
   end
 end

--- a/app/models/concerns/profile_searching.rb
+++ b/app/models/concerns/profile_searching.rb
@@ -25,7 +25,7 @@ module ProfileSearching
                   only_explicit: true, operators: ['=']
     scoped_search on: :os_major_version, ext_method: 'os_major_version_search',
                   only_explicit: true, operators: ['=', '!='],
-                  validator: ScopedSearch::Validators::INTEGER
+                  validator: ::ScopedSearch::Validators::INTEGER
     scoped_search on: :ssg_version, ext_method: 'ssg_version_search',
                   only_explicit: true, operators: ['=', '!=']
 
@@ -44,7 +44,7 @@ module ProfileSearching
       where(external: external)
     }
     scope :has_test_results, lambda { |has_test_results = true|
-      test_results = TestResult.select(:profile_id).distinct
+      test_results = ::TestResult.select(:profile_id).distinct
       has_test_results && where(id: test_results) || where.not(id: test_results)
     }
     scope :has_policy_test_results, lambda { |has_policy_test_results = true|
@@ -63,10 +63,10 @@ module ProfileSearching
       end
     }
     scope :os_major_version, lambda { |major, equals = true|
-      where(benchmark: Xccdf::Benchmark.os_major_version(major, equals))
+      where(benchmark: ::Xccdf::Benchmark.os_major_version(major, equals))
     }
     scope :in_policy, lambda { |policy_or_profile_id|
-      return none unless UUID.validate(policy_or_profile_id)
+      return none unless ::UUID.validate(policy_or_profile_id)
 
       policy_cond = { policy_id: policy_or_profile_id }
       profile_cond = {
@@ -102,20 +102,20 @@ module ProfileSearching
     end
 
     def test_results?(_filter, _operator, value)
-      has_test_results = ActiveModel::Type::Boolean.new.cast(value)
+      has_test_results = ::ActiveModel::Type::Boolean.new.cast(value)
       profiles = ::Profile.has_test_results(has_test_results)
       { conditions: profiles.arel.where_sql.gsub(/^where /i, '') }
     end
 
     def policy_test_results?(_filter, _operator, value)
-      has_test_results = ActiveModel::Type::Boolean.new.cast(value)
+      has_test_results = ::ActiveModel::Type::Boolean.new.cast(value)
       profiles = ::Profile.has_policy_test_results(has_test_results)
       { conditions: profiles.arel.where_sql.gsub(/^where /i, '') }
     end
 
     def os_major_version_search(_filter, operator, value)
       benchmark_id = ::Profile.arel_table[:benchmark_id]
-      benchmarks = Xccdf::Benchmark.os_major_version(value, operator == '=')
+      benchmarks = ::Xccdf::Benchmark.os_major_version(value, operator == '=')
       { conditions: benchmark_id.in(benchmarks.pluck(:id)).to_sql }
     end
 


### PR DESCRIPTION
I still found some problems with reloading after [de-namespacing](https://github.com/RedHatInsights/compliance-backend/pull/780) everything in the `ClassMethods` modules under model concerns. I basically added the `::` for any class called in the concerns. It might be an overkill, but it was necessary under `ClassMethods` as well to use it on stuff coming from external gems and not our codebase.