### PR TITLE
fix(parse): RHICOMPL-1508 never update existing profile rules

### DIFF
--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -13,18 +13,6 @@ module Xccdf
     end
     alias save_host_profile host_profile
 
-    def associate_rules_from_rule_results
-      ::ProfileRule.import!(
-        ::Rule.where(
-          ref_id: selected_op_rule_results.map(&:id),
-          benchmark_id: @benchmark.id
-        ).pluck(:id).map do |rule_id|
-          ::ProfileRule.new(profile_id: @host_profile.id,
-                            rule_id: rule_id)
-        end, ignore: true
-      )
-    end
-
     def external_report?
       Policy.with_hosts(@host).with_ref_ids(test_result_profile.ref_id)
             .find_by(account: @account).nil?

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -33,7 +33,6 @@ module Xccdf
         save_host_profile
         save_test_result
         save_rule_results
-        associate_rules_from_rule_results
         invalidate_cache
       end
 

--- a/test/services/concerns/xccdf/hosts_test.rb
+++ b/test/services/concerns/xccdf/hosts_test.rb
@@ -27,20 +27,5 @@ module Xccdf
         account: accounts(:one)
       )
     end
-
-    test 'associate_rules_from_rule_results' do
-      @parser.save_all_benchmark_info
-      @parser.save_host_profile
-      @parser.save_test_result
-      @parser.save_rule_results
-
-      assert_difference('ProfileRule.count', 5) do
-        @parser.associate_rules_from_rule_results
-      end
-
-      assert_difference('ProfileRule.count', 0) do
-        @parser.associate_rules_from_rule_results
-      end
-    end
   end
 end


### PR DESCRIPTION
We should never be updating the rule set or any other aspect of a
policy's profile on report upload. This doesn't seem to affect anything
in the reports page, even if the report rule set differs from its
profile rule set.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices