### PR TITLE
feat(COMP-E-133): RHICOMPL-1520 add a feature flag

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -51,7 +51,7 @@ class Policy < ApplicationRecord
 
     removed = policy_hosts.where.not(host_id: new_host_ids).destroy_all
     imported = PolicyHost.import_from_policy(id, new_host_ids - host_ids)
-    update_os_minor_versions
+    update_os_minor_versions if Settings.feature_133_os_tailoring
 
     [imported.ids.count, removed.count]
   end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -19,7 +19,8 @@ class ProfileSerializer
   has_many :test_results
   attributes :ref_id, :score, :parent_profile_id,
              :external, :compliance_threshold, :os_major_version,
-             :os_minor_version, :os_version, :policy_profile_id
+             :os_version, :policy_profile_id
+  attribute :os_minor_version, if: proc { Settings.feature_133_os_tailoring }
   attribute :parent_profile_ref_id do |profile|
     profile.parent_profile&.ref_id
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,3 +21,4 @@ redis_cache_ssl: false
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'
 async: true
+feature_133_os_tailoring: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,3 +8,4 @@ prometheus_exporter_host: prometheus
 prometheus_exporter_port: 9394
 redis_url: localhost:6379
 redis_cache_url: localhost:6379
+feature_133_os_tailoring: true

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -88,6 +88,22 @@ class PolicyTest < ActiveSupport::TestCase
   end
 
   context 'update_hosts' do
+    should 'update_os_minor_versions' do
+      Settings.feature_133_os_tailoring = true
+
+      policies(:one).expects(:update_os_minor_versions)
+
+      policies(:one).update_hosts([])
+    end
+
+    should 'not update_os_minor_versions if COMP-E-133 feature is disabled' do
+      Settings.feature_133_os_tailoring = false
+
+      policies(:one).expects(:update_os_minor_versions).never
+
+      policies(:one).update_hosts([])
+    end
+
     should 'add new hosts to an empty host set' do
       policies(:one).update!(hosts: [])
       profiles(:one).update!(account: accounts(:test))


### PR DESCRIPTION
Currently the flag only disables setting the os_minor_version on a
policy, and it also disables the os_minor_version attribute from being
serialized in our REST API.

Please test with https://github.com/RedHatInsights/insights-core/pull/2971

Later, we'll remove this flag, and it should be quite trivial to find the locations necessary by searching by the flag name, feature_comp_e_133 in our code and tests.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices