### PR TITLE
feat(EditPolicy): RHICOMPL-1542 return all associated profiles

### DIFF
--- a/app/graphql/mutations/profile/associate_systems.rb
+++ b/app/graphql/mutations/profile/associate_systems.rb
@@ -9,6 +9,7 @@ module Mutations
       argument :id, ID, required: true
       argument :system_ids, [ID], required: true
       field :profile, Types::Profile, null: true
+      field :profiles, [Types::Profile], null: true
 
       def resolve(args = {})
         ::Profile.transaction do
@@ -17,7 +18,7 @@ module Mutations
             profile.policy.update_hosts(args[:system_ids])
             audit_mutation(profile)
           end
-          { profile: profile }
+          { profile: profile, profiles: profile.policy.profiles }
         end
       end
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -596,6 +596,7 @@ type associateSystemsPayload {
   """
   clientMutationId: String
   profile: Profile
+  profiles: [Profile!]
 }
 
 """

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -16,20 +16,33 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
              profile {
                  id
              }
+             profiles {
+                 id
+             }
           }
        }
     GRAPHQL
 
     assert_empty profiles(:one).assigned_hosts
 
-    Schema.execute(
+    result = Schema.execute(
       query,
       variables: { input: {
         id: profiles(:one).id,
         systemIds: [hosts(:one).id]
       } },
       context: { current_user: users(:test) }
-    )['data']['associateSystems']['profile']
+    )
+
+    assert_equal(
+      result['data']['associateSystems']['profile']['id'],
+      profiles(:one).id
+    )
+
+    assert_equal(
+      result['data']['associateSystems']['profiles'],
+      [{ 'id' => profiles(:one).id }]
+    )
 
     assert_equal Set.new(profiles(:one).policy.reload.hosts),
                  Set.new([hosts(:one)])
@@ -42,20 +55,33 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
              profile {
                  id
              }
+             profiles {
+                 id
+             }
           }
        }
     GRAPHQL
 
     assert_not_empty profiles(:one).hosts
 
-    Schema.execute(
+    result = Schema.execute(
       query,
       variables: { input: {
         id: profiles(:one).id,
         systemIds: []
       } },
       context: { current_user: users(:test) }
-    )['data']['associateSystems']['profile']
+    )
+
+    assert_equal(
+      result['data']['associateSystems']['profile']['id'],
+      profiles(:one).id
+    )
+
+    assert_equal(
+      result['data']['associateSystems']['profiles'],
+      [{ 'id' => profiles(:one).id }]
+    )
 
     assert_empty profiles(:one).policy.reload.hosts
     assert_audited 'Updated system associaton of policy'


### PR DESCRIPTION
Adjusted the `associateSystems` mutation to also be able to return with all the profiles under the parent policy.

Request:
```graphql
mutation associateSystems($input: associateSystemsInput!) {
    associateSystems(input: $input) {
        profiles {
            id,
            osMajorVersion,
            osMinorVersion,
            ssgVersion,
            benchmarkId,
        }
    }
}
```

Response:
```json
{
  "data": {
    "associateSystems": {
      "profiles": [
        {
          "id": "829735bc-cf80-41bc-a502-9a49fb54567a",
          "osMajorVersion": "7",
          "osMinorVersion": "7",
          "ssgVersion": "0.1.43",
          "benchmarkId": "dd10a20c-2527-4d82-983b-d4a9e512df1a",
          "__typename": "Profile"
        },
        {
          "id": "665881a9-997b-47de-950c-a9260d52d135",
          "osMajorVersion": "7",
          "osMinorVersion": "9",
          "ssgVersion": "0.1.52",
          "benchmarkId": "0df89dd7-8f4a-4520-b06f-371047d7cf40",
          "__typename": "Profile"
        }
      ],
      "__typename": "associateSystemsPayload"
    }
  }
}
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
