### PR TITLE
fix(Prometheus): RHICOMPL-1559 Scope metrics to compliance hosts

### DIFF
--- a/app/models/concerns/host_searching.rb
+++ b/app/models/concerns/host_searching.rb
@@ -37,6 +37,10 @@ module HostSearching
         where.not(id: ::TestResult.select(:host_id))
     }
 
+    scope :with_policies_or_test_results, lambda {
+      with_policy.or(with_test_results)
+    }
+
     scope :os_major_version, lambda { |version, equal = true|
       condition = ['system_profile @> ?',
                    { operating_system: { major: version.to_i } }.to_json]

--- a/lib/prometheus/business_collector.rb
+++ b/lib/prometheus/business_collector.rb
@@ -51,7 +51,7 @@ class BusinessCollector < PrometheusExporter::Server::TypeCollector
     )
     @client_accounts.observe client_accounts.count
     @client_accounts_with_hosts.observe(
-      Host.where(
+      Host.with_policies_or_test_results.where(
         account: client_accounts.select(:account_number)
       ).select(:account).distinct.count
     )
@@ -59,9 +59,10 @@ class BusinessCollector < PrometheusExporter::Server::TypeCollector
     @client_policies.observe(
       Profile.where(account_id: client_accounts.select(:id)).count
     )
-    @total_systems.observe Host.count
+    @total_systems.observe Host.with_policies_or_test_results.count
     @client_systems.observe(
-      Host.where(account: client_accounts.select(:account_number)).count
+      Host.with_policies_or_test_results
+          .where(account: client_accounts.select(:account_number)).count
     )
   end
 

--- a/test/lib/prometheus/business_collector_test.rb
+++ b/test/lib/prometheus/business_collector_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'prometheus_exporter/server'
+require 'prometheus/business_collector'
+
+class BusinessCollectorTest < ActiveSupport::TestCase
+  setup do
+    @collector = BusinessCollector.new
+  end
+
+  test 'metrics' do
+    assert_nothing_raised do
+      metrics = @collector.metrics.map do |metric|
+        [metric.name, metric.data.values.first]
+      end.to_h
+
+      assert_equal 3, metrics['total_accounts']
+      assert_equal 0, metrics['client_accounts']
+      assert_equal 0, metrics['client_accounts_with_hosts']
+      assert_equal 0, metrics['total_policies']
+      assert_equal 0, metrics['client_policies']
+      assert_equal 2, metrics['total_systems']
+      assert_equal 0, metrics['client_systems']
+    end
+  end
+end

--- a/test/lib/prometheus/engineering_collector_test.rb
+++ b/test/lib/prometheus/engineering_collector_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'prometheus_exporter/server'
+require 'prometheus/engineering_collector'
+
+class EngineeringCollectorTest < ActiveSupport::TestCase
+  setup do
+    @collector = EngineeringCollector.new
+  end
+
+  test 'metrics' do
+    assert_nothing_raised do
+      metrics = @collector.metrics.map do |metric|
+        [metric.name, metric.data.values.first]
+      end.to_h
+
+      assert_equal 1, metrics['dangling_accounts']
+      assert_equal 0, metrics['dangling_test_results']
+      assert_equal 0, metrics['dangling_rule_results']
+      assert_equal 0, metrics['dangling_policy_hosts']
+    end
+  end
+end

--- a/test/lib/prometheus/graphql_collector_test.rb
+++ b/test/lib/prometheus/graphql_collector_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'prometheus_exporter/server'
+require 'graphql/tracing/prometheus_tracing/graphql_collector'
+require 'prometheus/graphql_collector'
+
+class GraphQLCollectorTest < ActiveSupport::TestCase
+  setup do
+    @collector = GraphQLCollector.new
+  end
+
+  test 'metrics' do
+    assert_nothing_raised do
+      assert_not_empty @collector.metrics
+    end
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -161,6 +161,30 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  context 'with_policies_or_test_results' do
+    should 'return hosts either associated to a policy or with test results' do
+      assert_equal [test_results(:one)], hosts(:one).test_results
+      assert_equal [test_results(:two)], hosts(:two).test_results
+      assert_empty hosts(:one).policies
+      assert_empty hosts(:two).policies
+
+      assert_includes Host.with_policies_or_test_results, hosts(:one)
+      assert_includes Host.with_policies_or_test_results, hosts(:two)
+
+      test_results(:two).destroy
+      assert_includes Host.with_policies_or_test_results, hosts(:one)
+      assert_not_includes Host.with_policies_or_test_results, hosts(:two)
+
+      policies(:two).update!(hosts: [hosts(:two)])
+      assert_includes Host.with_policies_or_test_results, hosts(:two)
+      assert_includes Host.with_policies_or_test_results, hosts(:one)
+
+      test_results(:one).destroy
+      assert_not_includes Host.with_policies_or_test_results, hosts(:one)
+      assert_includes Host.with_policies_or_test_results, hosts(:two)
+    end
+  end
+
   context 'scope search by a policy' do
     setup do
       profiles(:one).update!(policy: policies(:one),

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -144,11 +144,15 @@ class HostTest < ActiveSupport::TestCase
       assert hosts(:one).test_results.present?
       assert hosts(:two).test_results.empty?
       assert_includes Host.search_for('has_test_results = true'), hosts(:one)
+      assert_includes Host.with_test_results, hosts(:one)
       assert_not_includes(Host.search_for('has_test_results = true'),
                           hosts(:two))
+      assert_not_includes Host.with_test_results, hosts(:two)
       assert_includes Host.search_for('has_test_results = false'), hosts(:two)
+      assert_includes Host.with_test_results(false), hosts(:two)
       assert_not_includes(Host.search_for('has_test_results = false'),
                           hosts(:one))
+      assert_not_includes(Host.with_test_results(false), hosts(:one))
     end
 
     should 'be able to filter by profile_id from test results' do


### PR DESCRIPTION
Joins across the entire hosts view can get very sluggish. We always want
to only count compliance hosts in our metrics. The sluggishness is caused, in part, by the lack of indices, etc. which will be addressed in future PRs. This PR just aims to limit the scope of our queries to compliance hosts only.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices