### PR TITLE
chore: Bump mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
See https://github.com/rails/rails/issues/41750

tl;dr: mimemagic pulled the 0.3.5 release because they updated the license from MIT to GPL. [Our repo is already licensed under GPL](https://github.com/RedHatInsights/compliance-backend/blob/master/LICENSE), so we shouldn't be affected by this change legally. Any gem licensed as GPL must be used/modified under GPL. Anyone using rails (licensed as MIT) right now with an MIT license cannot update this gem, but we already use GPL.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices