### PR TITLE
chore(tests): stub stdout in DuplicateCanonicalProfileResolverTest

### DIFF
--- a/test/services/duplicate_canonical_profile_resolver_test.rb
+++ b/test/services/duplicate_canonical_profile_resolver_test.rb
@@ -21,6 +21,7 @@ class DuplicateCanonicalProfileResolverTest < ActiveSupport::TestCase
   end
 
   test 'removes duplicate entities' do
+    STDOUT.stubs(:puts)
     assert_difference('Profile.count' => -4) do
       ActiveRecord::Migration.suppress_messages do
         DeduplicateCanonicalProfiles.new.up


### PR DESCRIPTION
Another annoying and useless output spamming our test results, unfortunately `capture_io` wasn't working here so I had to stub `STDOUT` explicitly.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
