### PR TITLE
chore: Bump mimemagic to 0.3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y qt5-default libqt5webkit5-dev \
       gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x libopenscap-dev \
-      postgresql-client
+      postgresql-client shared-mime-info
 
 COPY vendor/ ./vendor
 COPY Gemfile* ./

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
0.3.5, 0.3.6, and 0.3.7 have been pulled :/

Starting with 0.3.7, mime detection uses the shared-mime-info native dependency. This PR requires https://github.com/RedHatInsights/s2i-insights-compliance/pull/28.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices