### PR TITLE
feat(createProfile): RHICOMPL-1607 no longer requires rule ref IDs

### DIFF
--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -14,7 +14,7 @@ module Mutations
       argument :description, String, required: false
       argument :business_objective_id, String, required: false
       argument :compliance_threshold, Float, required: false
-      argument :selected_rule_ref_ids, [String], required: true
+      argument :selected_rule_ref_ids, [String], required: false
       field :profile, Types::Profile, null: false
 
       def resolve(args = {})

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -638,7 +638,7 @@ input createProfileInput {
   description: String
   name: String!
   refId: ID!
-  selectedRuleRefIds: [String!]!
+  selectedRuleRefIds: [String!]
 }
 
 """

--- a/test/graphql/mutations/create_profile_mutation_test.rb
+++ b/test/graphql/mutations/create_profile_mutation_test.rb
@@ -27,6 +27,26 @@ class CreateProfileMutationTest < ActiveSupport::TestCase
         refId: 'xccdf-customized',
         name: 'customized profile',
         description: 'abcdf',
+        complianceThreshold: 90.0
+      } },
+      context: { current_user: users(:test) }
+    )['data']['createProfile']['profile']
+
+    cloned_profile = ::Profile.find(result['id'])
+    assert cloned_profile.ref_id, 'xccdf-customized'
+    assert_equal cloned_profile.rules, @original_profile.rules
+    assert_equal cloned_profile.parent_profile, @original_profile
+  end
+
+  test 'provide all required arguments with selectedRuleRefIds' do
+    result = Schema.execute(
+      @query,
+      variables: { input: {
+        benchmarkId: @original_profile.benchmark_id,
+        cloneFromProfileId: @original_profile.id,
+        refId: 'xccdf-customized',
+        name: 'customized profile',
+        description: 'abcdf',
         complianceThreshold: 90.0,
         selectedRuleRefIds: @original_profile.rules.map(&:ref_id)
       } },


### PR DESCRIPTION
Canonical rules are set if this param is not passed, thanks to the way `update_rules` works when `nil` is passed in.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices