### PR TITLE
feat(GraphQL): RHICOMPL-1609 profiles parentProfileId

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -107,6 +107,7 @@ type Profile implements Node & RulesPreload {
   osMajorVersion: String!
   osMinorVersion: String!
   osVersion: String!
+  parentProfileId: ID
   policy: Profile
   policyType: String!
   profiles: [Profile!]

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -41,6 +41,7 @@ module Types
     field :test_result_host_count, Int, null: false
     field :unsupported_host_count, Int, null: false
     field :external, Boolean, null: false
+    field :parent_profile_id, ID, null: true
 
     field :score, Float, null: false do
       argument :system_id, String,

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -53,6 +53,28 @@ class ProfileQueryTest < ActiveSupport::TestCase
                  result['data']['profile']['policyType']
   end
 
+  test 'query profile parentProfileId' do
+    profiles(:one).update!(parent_profile: profiles(:two))
+
+    query = <<-GRAPHQL
+      query Profile($id: String!){
+          profile(id: $id) {
+              id
+              parentProfileId
+          }
+      }
+    GRAPHQL
+
+    result = Schema.execute(
+      query,
+      variables: { id: profiles(:one).id },
+      context: { current_user: users(:test) }
+    )
+
+    assert_equal profiles(:one).parent_profile_id,
+                 result['data']['profile']['parentProfileId']
+  end
+
   test 'query profile with SSG version' do
     query = <<-GRAPHQL
       query Profile($id: String!){


### PR DESCRIPTION
Expose parentProfileId in GraphQL. This is already exposed in REST.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices