### PR TITLE
feat(GraphQL): RHICOMPL-1721 benchmarks collection

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -15,6 +15,42 @@ type Benchmark implements Node {
 }
 
 """
+The connection type for Benchmark.
+"""
+type BenchmarkConnection {
+  """
+  A list of edges.
+  """
+  edges: [BenchmarkEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Benchmark]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type BenchmarkEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Benchmark
+}
+
+"""
 A Business Objective registered in Insights Compliance
 """
 type BusinessObjective implements Node {
@@ -203,6 +239,42 @@ type Query implements Node {
   """
   allProfiles: [Profile!]
   benchmark(id: String!): Benchmark
+  benchmarks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Pagination limit
+    """
+    limit: Int
+
+    """
+    Pagination offset
+    """
+    offset: Int
+
+    """
+    Search query
+    """
+    search: String
+  ): BenchmarkConnection!
 
   """
   All business objectives visible by the user

--- a/app/graphql/types/benchmark.rb
+++ b/app/graphql/types/benchmark.rb
@@ -3,6 +3,7 @@
 module Types
   # Definition of Benchmark as a GraphQL type
   class Benchmark < Types::BaseObject
+    model_class ::Xccdf::Benchmark
     graphql_name 'Benchmark'
     description 'A representation of a SCAP Security Guide version'
 

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -11,6 +11,7 @@ module Types
     collection_field :systems, Types::System
     collection_field :profiles, Types::Profile
     collection_field :test_results, Types::TestResult
+    collection_field :benchmarks, Types::Benchmark
     record_field :profile, Types::Profile
     record_field :test_result, Types::TestResult
 


### PR DESCRIPTION
This change allows using GraphQL to query all benchmarks with an
optional filter. This type of query is used during the Edit Policy modal
and Create Policy wizard to get the latest_supported_os_minor_versions
to draw the rule tabs.

You can test this with https://github.com/RedHatInsights/compliance-frontend/pull/1151

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices