### PR TITLE
fix(Profile): RHICOMPL-1543 prefer profile with exact OS minor ver.

### DIFF
--- a/app/models/concerns/profile_searching.rb
+++ b/app/models/concerns/profile_searching.rb
@@ -90,6 +90,12 @@ module ProfileSearching
 
   # class methods for profile searching
   module ClassMethods
+    def first_by_os_minor_version_preferred(os_minor_version)
+      where(os_minor_version: ['', os_minor_version])
+        .order(:os_minor_version)
+        .last
+    end
+
     def policy_search(_filter, _operator, value)
       profiles = ::Profile.with_policy(
         ::ActiveModel::Type::Boolean.new.cast(value)
@@ -137,9 +143,15 @@ module ProfileSearching
 
   private
 
-  def in_account(account, policy)
-    Profile.find_by(account: account, ref_id: ref_id,
-                    policy: policy,
-                    benchmark_id: benchmark_id)
+  def in_account(account, policy, os_minor_version = nil)
+    search = Profile.where(account: account, ref_id: ref_id,
+                           policy: policy,
+                           benchmark_id: benchmark_id)
+
+    if os_minor_version
+      search.first_by_os_minor_version_preferred(os_minor_version)
+    else
+      search.first
+    end
   end
 end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -58,13 +58,15 @@ class Policy < ApplicationRecord
 
   def update_os_minor_versions
     unassigned_minor_versions.each do |os_minor_version|
-      Profile.canonical_for_os(
+      policy_profile = Profile.canonical_for_os(
         initial_profile.os_major_version, os_minor_version
       ).find_by(ref_id: initial_profile.ref_id)&.clone_to(
         account: account,
-        os_minor_version: os_minor_version,
         policy: self
       )
+      next unless policy_profile
+
+      policy_profile.update_os_minor_version(os_minor_version)
     end
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -84,12 +84,8 @@ class Profile < ApplicationRecord
   end
 
   def clone_to(account:, policy:, os_minor_version: nil)
-    new_profile = in_account(account, policy)
+    new_profile = in_account(account, policy, os_minor_version)
     new_profile ||= create_child_profile(account, policy)
-
-    # Update the os minor version if not already set
-    new_profile.update_os_minor_version(os_minor_version)
-
     new_profile
   end
 

--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -8,7 +8,8 @@ module Xccdf
         policy: Policy.with_hosts(@host)
                       .with_ref_ids(test_result_profile.ref_id)
                       .find_by(account: @account),
-        account: @account
+        account: @account,
+        os_minor_version: @host.os_minor_version.to_s
       )
     end
     alias save_host_profile host_profile

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -302,6 +302,25 @@ class ProfileTest < ActiveSupport::TestCase
     end
   end
 
+  context 'first_by_os_minor_version_preferred' do
+    setup do
+      @os_minor_version = '1'
+      profiles(:one).update!(os_minor_version: @os_minor_version)
+    end
+
+    should 'prefer profile with exact OS minor' do
+      scoped = Profile.where(id: [profiles(:one), profiles(:two)])
+      assert_equal profiles(:one),
+                   scoped.first_by_os_minor_version_preferred(@os_minor_version)
+    end
+
+    should 'fallbacks to empty OS minor version' do
+      scoped = Profile.where(id: [profiles(:two)])
+      assert_equal profiles(:two),
+                   scoped.first_by_os_minor_version_preferred(@os_minor_version)
+    end
+  end
+
   test 'has_test_results filters by test results available' do
     test_results(:one).update profile: profiles(:one), host: hosts(:one)
     profiles(:two).test_results.destroy_all

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -288,7 +288,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       end
     end
 
-    should 'find a policy by hosts, account, and ref_id' do
+    should 'find a policy profile by hosts, account, and ref_id' do
       @report_parser.stubs(:external_report?)
       profiles(:one).update!(
         ref_id: 'xccdf_org.ssgproject.content_profile_standard', hosts: []
@@ -296,13 +296,15 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       policies(:one).hosts = [@report_parser.host]
       policies(:two).hosts = [@report_parser.host]
       Profile.any_instance.expects(:clone_to).with(policy: nil,
-                                                   account: accounts(:test))
+                                                   account: accounts(:test),
+                                                   os_minor_version: '3')
       @report_parser.save_host_profile
 
       profiles(:one).update!(policy: policies(:one),
                              account: accounts(:test))
       Profile.any_instance.expects(:clone_to).with(policy: policies(:one),
-                                                   account: accounts(:test))
+                                                   account: accounts(:test),
+                                                   os_minor_version: '3')
       @report_parser.save_host_profile
     end
   end


### PR DESCRIPTION
When a report is being parsed, its result should be placed to the
profile with matching OS minor version of same benchmark, if such exist.

This tries to fix the case of a multiple OS versions sharing the same
benchmark/SSG version.  For example within RHEL 6.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
