### PR TITLE
performance(DeleteHostJob): RHICOMPL-1785 remove the transaction

### DIFF
--- a/app/jobs/delete_host.rb
+++ b/app/jobs/delete_host.rb
@@ -23,11 +23,9 @@ class DeleteHost
 
   def remove_related(host_id)
     num_removed = 0
-    Host.transaction do
-      Sidekiq.logger.info("Deleting related records for host #{host_id}")
-      MODELS.each do |model|
-        num_removed += model.where(host_id: host_id).delete_all
-      end
+    Sidekiq.logger.info("Deleting related records for host #{host_id}")
+    MODELS.each do |model|
+      num_removed += model.where(host_id: host_id).delete_all
     end
     num_removed
   end


### PR DESCRIPTION
I was trying to run the `DeleteHost` job on 2k hosts with generated `TestResult` and `RuleResult` entities meanwhile firing 10k API requests to edit profiles. The sidekiq job was *maybe* a bit faster, but it's hard to measure properly. 

![Screenshot from 2021-05-10 15-16-28](https://user-images.githubusercontent.com/649130/117665225-e7666d80-b1a2-11eb-869b-949cc217b21f.png)
The first two spikes are the jobs processed without the wrapping transaction and the second set is with the transaction.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
