### PR TITLE
feat(REST): RHICOMPL-1563 status API endpoint

### DIFF
--- a/app/controllers/v1/statuses_controller.rb
+++ b/app/controllers/v1/statuses_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module V1
+  # API for Compliance Status
+  class StatusesController < ApplicationController
+    skip_around_action :authenticate_user
+
+    ARB = ActiveRecord::Base
+
+    def show
+      render json: { data: all_statuses }, status: status_return_code
+    end
+
+    private
+
+    def all_statuses
+      @all_statuses ||= {
+        api: api_status
+      }
+    end
+
+    def status_return_code
+      all_statuses.values.all? ? :ok : :internal_server_error
+    end
+
+    def api_status
+      ensure_db_connection
+      ARB.connection.active?
+    rescue PG::Error
+      false
+    end
+
+    def ensure_db_connection
+      ARB.establish_connection unless ARB.connection.active?
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     scope "#{prefix}/#{Settings.app_name}" do
       concern :rest_api_v1 do
         scope module: 'v1' do
+          resource 'status', only: :show
           resources :benchmarks, only: [:index, :show]
           resources :business_objectives, only: [:index, :show]
           resources :profiles do

--- a/spec/api/v1/schemas.rb
+++ b/spec/api/v1/schemas.rb
@@ -9,6 +9,7 @@ require './spec/api/v1/schemas/business_objectives'
 require './spec/api/v1/schemas/profiles'
 require './spec/api/v1/schemas/rule_results'
 require './spec/api/v1/schemas/rules'
+require './spec/api/v1/schemas/status'
 require './spec/api/v1/schemas/supported_ssgs'
 
 module Api
@@ -23,6 +24,7 @@ module Api
       include Profiles
       include RuleResults
       include Rules
+      include Status
       include SupportedSggs
 
       SCHEMAS = {
@@ -44,6 +46,7 @@ module Api
         rule_result_relationships: RULE_RESULT_RELATIONSHIPS,
         rule: RULE,
         rule_relationships: RULE_RELATIONSHIPS,
+        status: STATUS,
         supported_ssg: SUPPORTED_SSG
       }.freeze
     end

--- a/spec/api/v1/schemas/status.rb
+++ b/spec/api/v1/schemas/status.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require './spec/api/v1/schemas/util'
+
+module Api
+  module V1
+    module Schemas
+      module Status
+        extend Api::V1::Schemas::Util
+
+        STATUS = {
+          type: 'object',
+          properties: { data: {
+            api: {
+              type: 'boolean',
+              example: true
+            }
+          } }
+        }.freeze
+      end
+    end
+  end
+end

--- a/spec/integration/statuses_spec.rb
+++ b/spec/integration/statuses_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'Status API' do
+  path "#{Settings.path_prefix}/#{Settings.app_name}/status" do
+    get 'status' do
+      tags 'status'
+      description 'Display Compliance status'
+      operationId 'Status'
+
+      content_types
+
+      response '200', 'successful status' do
+        schema type: :object,
+               properties: {
+                 data: ref_schema('status')
+               }
+
+        after { |e| autogenerate_examples(e) }
+
+        run_test!
+      end
+
+      response '500', 'unsuccessful status' do
+        before do
+          expect(ActiveRecord::Base).to(receive(:connection)).twice do
+            OpenStruct.new(active?: false)
+          end
+        end
+
+        schema type: :object,
+               properties: {
+                 data: ref_schema('status')
+               }
+
+        after { |e| autogenerate_examples(e) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -1985,6 +1985,62 @@
         }
       }
     },
+    "/api/compliance/status": {
+      "get": {
+        "summary": "status",
+        "tags": [
+          "status"
+        ],
+        "description": "Display Compliance status",
+        "operationId": "Status",
+        "responses": {
+          "200": {
+            "description": "successful status",
+            "examples": {
+              "application/vnd.api+json": {
+                "data": {
+                  "api": true
+                }
+              }
+            },
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/status"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "unsuccessful status",
+            "examples": {
+              "application/vnd.api+json": {
+                "data": {
+                  "api": false
+                }
+              }
+            },
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/status"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/compliance/supported_ssgs": {
       "get": {
         "summary": "List all supported SSGs",
@@ -3150,6 +3206,17 @@
           },
           "rule_references": {
             "$ref": "#/components/schemas/relationship_collection"
+          }
+        }
+      },
+      "status": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "api": {
+              "type": "boolean",
+              "example": true
+            }
           }
         }
       },

--- a/test/controllers/v1/statuses_controller_test.rb
+++ b/test/controllers/v1/statuses_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module V1
+  # Integration test of the statuses controller
+  class StatusesControllerTest < ActionDispatch::IntegrationTest
+    class StatusTest < StatusesControllerTest
+      test 'success' do
+        get status_url
+        assert_response :ok
+      end
+
+      test 'no active connection' do
+        ActiveRecord::Base.stubs(:connection).returns(
+          OpenStruct.new(active?: false)
+        )
+
+        get status_url
+        assert_response :internal_server_error
+      end
+
+      test 'database error' do
+        ActiveRecord::Base.stubs(:connection).raises(PG::Error)
+
+        get status_url
+        assert_response :internal_server_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new status endpoint that returns 200 if everything is OK and 500
otherwise. We can expand the statuses if needed in the future.

It also works with HEAD requests if you're not interested in the individual json statuses.

```
GET compliance/v1/status

HTTP/1.1 200 OK

{
    "data": {
        "api": true
    }
}
```

```
GET compliance/v1/status

HTTP/1.1 500 Internal Server Error

{
    "data": {
        "api": false
    }
}
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices