### PR TITLE
dev: remove puptoo prometheus port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
   puptoo:
     image: quay.io/cloudservices/insights-puptoo:latest
-    ports:
-      - 8001:8001 #for prometheus endpoint
     environment:
       - REJECTION_TOPIC=platform.upload.validation
       - LOGLEVEL=INFO


### PR DESCRIPTION
This port conflicts with the minikube dashboard by default and is not
even used by the Compliance team in development.

See https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices