### PR TITLE
test: Remove vestigial external policy code for coverage++

### DIFF
--- a/app/models/concerns/profile_scoring.rb
+++ b/app/models/concerns/profile_scoring.rb
@@ -33,9 +33,7 @@ module ProfileScoring
   end
 
   def compliant?(host)
-    return policy.compliant?(host) if policy_id
-
-    score(host: host) >= compliance_threshold
+    policy&.compliant?(host) || false
   end
 
   # Disabling MethodLength because it measures things wrong


### PR DESCRIPTION
This line is dead code for all the cases when this method is called.
I've added safe navigation so it doesn't raise an exception if called on
a canonical profile, even though that doesn't really make sense to do.

I think this coverage dropped slightly with the FactoryBot changes, but I'm not 100% sure.

Counterintuitively, local test coverage drops from 2469 / 2525 LOC (97.78%) -> 2467 / 2524 LOC (97.74%) because I removed more lines than covered.

The not-covered line in codecov, brought to my attention with the [last stable PR](https://github.com/RedHatInsights/compliance-backend/pull/826):

![image](https://user-images.githubusercontent.com/761923/118161426-90080d80-b3ed-11eb-9101-235d4718e160.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices