### PR TITLE
devel: Adjust host factory for development

### DIFF
--- a/test/factories/host.rb
+++ b/test/factories/host.rb
@@ -3,36 +3,78 @@
 FactoryBot.define do
   # This is necessary to convince spring that the class is not defined elsewhere
   Object.send(:remove_const, :WHost) if defined?(WHost)
+  Object.send(:remove_const, :SSGS) if defined?(SSGS)
+
+  SSGS = SupportedSsg.all
 
   # A writable version of the Host model for the factory only
   class WHost < Host
-    self.table_name = 'inventory.hosts_v1_1'
+    if Rails.env.test?
+      self.table_name = 'inventory.hosts_v1_1'
+    elsif Rails.env.development?
+      self.table_name = 'hosts'
+
+      establish_connection(
+        Rails.configuration.database_configuration[Rails.env].merge(
+          'database' => 'insights'
+        )
+      )
+    end
 
     def readonly?
       false
     end
   end
 
+  sequence(:account_number) { |n| format('%05<num>d', num: n) }
+
   factory :host, class: WHost do
     id { SecureRandom.uuid }
-    account { User.current&.account&.account_number }
-    display_name { Faker::Lorem.sentence }
+    account do
+      User.current&.account&.account_number || generate(:account_number)
+    end
+    display_name { Faker::Internet.domain_name }
     tags { {} }
-    created { Time.zone.now }
-    updated { Time.zone.now }
     stale_timestamp { 10.years.since(Time.zone.now) }
-    system_profile do
-      {
-        'operating_system' => {
-          'major' => os_major_version,
-          'minor' => os_minor_version
+    if Rails.env.test?
+      created { Time.zone.now }
+      updated { Time.zone.now }
+      system_profile do
+        system_profile_data
+      end
+    elsif Rails.env.development?
+      reporter { 'puptoo' }
+      modified_on { Time.zone.now }
+      facts { {} }
+      canonical_facts do
+        {
+          'fqdn' => Faker::Internet.domain_name,
+          'insights_id' => UUID.generate
         }
-      }
+      end
+
+      system_profile_facts do
+        system_profile_data
+      end
     end
 
     transient do
-      os_major_version { 7 }
-      os_minor_version { 9 }
+      os_version_arr do
+        ssg = SSGS.sample
+        [ssg.os_major_version, ssg.os_minor_version]
+      end
+      os_version { os_version_arr.join('.') }
+      os_major_version { os_version_arr[0].to_i }
+      os_minor_version { os_version_arr[1].to_i }
+      system_profile_data do
+        {
+          'os_release' => os_version,
+          'operating_system' => {
+            'major' => os_major_version,
+            'minor' => os_minor_version
+          }
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
I don't expect this to stay super stable, since it depends on the inventory's hosts table, which could change at any time, but for devel, this is still very useful to be able to create thousands of fake hosts, optionally in your own account.

```rb
User.current = User.new(account: Account.find_by(account_number: '123456')) # optional
FactoryBot.create(:host)
FactoryBot.create_list(:host, 1000)
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices