### PR TITLE
fix(tests): RHICOMPL-1857 make random OS version picking optional

### DIFF
--- a/test/factories/host.rb
+++ b/test/factories/host.rb
@@ -58,14 +58,21 @@ FactoryBot.define do
       end
     end
 
-    transient do
-      os_version_arr do
-        ssg = SSGS.sample
-        [ssg.os_major_version, ssg.os_minor_version]
+    trait :random_os_version do
+      transient do
+        os_version_arr do
+          ssg = SSGS.sample
+          [ssg.os_major_version, ssg.os_minor_version]
+        end
       end
+    end
+
+    transient do
+      os_version_arr { [7, 9] }
       os_version { os_version_arr.join('.') }
       os_major_version { os_version_arr[0].to_i }
       os_minor_version { os_version_arr[1].to_i }
+
       system_profile_data do
         {
           'os_release' => os_version,


### PR DESCRIPTION
Makes the OS version in the host factory fixed to 7.9 and introduces a new trait to have the version randomly selected for future use. This should unblock us from the random CI failures.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
