### PR TITLE
feat(REST): RHICOMPL-1717 introduce pagination for benchmark->rules

### DIFF
--- a/app/controllers/concerns/rendering.rb
+++ b/app/controllers/concerns/rendering.rb
@@ -27,6 +27,7 @@ module Rendering
     def serializer_opts
       opts = index? ? metadata : {}
       opts.merge!(include: params[:include].split(',')) if params[:include]
+      opts.merge!(params: pagination)
 
       opts
     end
@@ -50,5 +51,14 @@ module Rendering
     end
 
     def includes; end
+
+    def pagination
+      {
+        limit:
+          params[:include_limit].present? ? params[:include_limit].to_i : 10,
+        offset:
+          params[:include_offset].present? ? params[:include_offset].to_i : 1
+      }
+    end
   end
 end

--- a/app/serializers/benchmark_serializer.rb
+++ b/app/serializers/benchmark_serializer.rb
@@ -3,9 +3,12 @@
 # JSON API serialization for an OpenSCAP Benchmark
 class BenchmarkSerializer
   include FastJsonapi::ObjectSerializer
+
   attributes :ref_id, :title, :version, :description, :os_major_version,
              :latest_supported_os_minor_versions
-  has_many :rules
+  has_many :rules do |benchmark, params|
+    benchmark.rules.paginate(per_page: params[:limit], page: params[:offset])
+  end
   has_many :profiles do |benchmark|
     Pundit.policy_scope(User.current, Profile).where(benchmark: benchmark)
   end


### PR DESCRIPTION
I haven't found any documentation on HTTP params regarding the pagination of included relations of the main resource, so I introduced my own `included_offset` and `included_limit`. ActiveRecord doesn't really support the pagination of nested entities out of the box, so I introduced it in the `BenchmarkSerializer` as the `FastJsonapi` allows the passing of custom params to the nested retrieval blocks. It's not the nices solution, but I haven't found any other good place to have this. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
