### PR TITLE
feat(import-ssg): RHICOMPL-1558 sync newest SSGs first

### DIFF
--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -26,7 +26,9 @@ namespace :ssg do
   desc 'Update compliance DB with the supported SCAP Security Guide versions'
   task import_rhel_supported: [:environment] do
     # DATASTREAM_FILENAMES from openscap_parser's ssg:sync
-    ENV['DATASTREAMS'] = ::SupportedSsg.available_upstream.map do |ssg|
+    ENV['DATASTREAMS'] = ::SupportedSsg.available_upstream
+                                       .sort_by(&:comparable_version)
+                                       .reverse.map do |ssg|
       "v#{ssg.upstream_version || ssg.version}:rhel#{ssg.os_major_version}"
     end.uniq.join(',')
     Rake::Task['ssg:sync'].invoke


### PR DESCRIPTION
```
Tasks: TOP => ssg:import_rhel_supported
(See full trace by running task with --trace)
`Redis#exists(key)` will return an Integer by default in redis-rb 4.3. The option to explicitly disable this behaviour via `Redis.exists_returns_integer` will be removed in 5.0. You should use `exists?` instead.
2021-05-20T14:50:07.244Z 1 TID-cat INFO: GitLab reliable fetch activated!
Fetching scap-security-guide-0.1.54.zip
Fetching scap-security-guide-0.1.52.zip
Fetching scap-security-guide-0.1.50.zip
Fetching scap-security-guide-0.1.48.zip
Fetching scap-security-guide-0.1.47.zip
Fetching scap-security-guide-0.1.46.zip
Fetching scap-security-guide-0.1.43.zip
Fetching scap-security-guide-0.1.42.zip
Fetching scap-security-guide-0.1.40.zip
Fetching scap-security-guide-0.1.36.zip
Fetching scap-security-guide-0.1.33.zip
Fetching scap-security-guide-0.1.30.zip
Fetching scap-security-guide-0.1.28.zip
Fetching scap-security-guide-0.1.25.zip
Archive:  scap-security-guide-0.1.54.zip
  inflating: scap-security-guide-0.1.54/ssg-rhel7-ds.xml
  inflating: scap-security-guide-0.1.54/ssg-rhel8-ds.xml
Archive:  scap-security-guide-0.1.52.zip
  inflating: scap-security-guide-0.1.52/ssg-rhel7-ds.xml
Archive:  scap-security-guide-0.1.50.zip
  inflating: scap-security-guide-0.1.50/ssg-rhel7-ds.xml
  inflating: scap-security-guide-0.1.50/ssg-rhel8-ds.xml
Archive:  scap-security-guide-0.1.48.zip
  inflating: scap-security-guide-0.1.48/ssg-rhel8-ds.xml
Archive:  scap-security-guide-0.1.47.zip
  inflating: scap-security-guide-0.1.47/ssg-rhel8-ds.xml
Archive:  scap-security-guide-0.1.46.zip
  inflating: scap-security-guide-0.1.46/ssg-rhel7-ds.xml
  inflating: scap-security-guide-0.1.46/ssg-rhel8-ds.xml
Archive:  scap-security-guide-0.1.43.zip
  inflating: scap-security-guide-0.1.43/ssg-rhel7-ds.xml
Archive:  scap-security-guide-0.1.42.zip
  inflating: scap-security-guide-0.1.42/ssg-rhel8-ds.xml
Archive:  scap-security-guide-0.1.40.zip
  inflating: scap-security-guide-0.1.40/ssg-rhel7-ds.xml
Archive:  scap-security-guide-0.1.36.zip
  inflating: scap-security-guide-0.1.36/ssg-rhel7-ds.xml
Archive:  scap-security-guide-0.1.33.zip
  inflating: scap-security-guide-0.1.33/ssg-rhel7-ds.xml
Archive:  scap-security-guide-0.1.30.zip
  inflating: scap-security-guide-0.1.30/ssg-rhel7-ds.xml
Archive:  scap-security-guide-0.1.28.zip
  inflating: scap-security-guide-0.1.28/ssg-rhel6-ds.xml
Archive:  scap-security-guide-0.1.25.zip
  inflating: scap-security-guide-0.1.25/ssg-rhel7-ds.xml
Importing scap-security-guide-0.1.54/ssg-rhel8-ds.xml at 2021-05-20 14:50:34 UTC
Finished importing scap-security-guide-0.1.54/ssg-rhel8-ds.xml in 63.903662319 seconds.
Importing scap-security-guide-0.1.54/ssg-rhel7-ds.xml at 2021-05-20 14:51:38 UTC
Finished importing scap-security-guide-0.1.54/ssg-rhel7-ds.xml in 31.406213973 seconds.
Importing scap-security-guide-0.1.52/ssg-rhel7-ds.xml at 2021-05-20 14:52:10 UTC
Finished importing scap-security-guide-0.1.52/ssg-rhel7-ds.xml in 32.854462768 seconds.
Importing scap-security-guide-0.1.50/ssg-rhel8-ds.xml at 2021-05-20 14:52:43 UTC
Finished importing scap-security-guide-0.1.50/ssg-rhel8-ds.xml in 32.333646697 seconds.
Importing scap-security-guide-0.1.50/ssg-rhel7-ds.xml at 2021-05-20 14:53:15 UTC
Finished importing scap-security-guide-0.1.50/ssg-rhel7-ds.xml in 34.104518448 seconds.
Importing scap-security-guide-0.1.48/ssg-rhel8-ds.xml at 2021-05-20 14:53:49 UTC
Finished importing scap-security-guide-0.1.48/ssg-rhel8-ds.xml in 61.425099295 seconds.
Importing scap-security-guide-0.1.47/ssg-rhel8-ds.xml at 2021-05-20 14:54:51 UTC
Finished importing scap-security-guide-0.1.47/ssg-rhel8-ds.xml in 65.05272439 seconds.
Importing scap-security-guide-0.1.46/ssg-rhel8-ds.xml at 2021-05-20 14:55:56 UTC
Finished importing scap-security-guide-0.1.46/ssg-rhel8-ds.xml in 39.005475399 seconds.
Importing scap-security-guide-0.1.46/ssg-rhel7-ds.xml at 2021-05-20 14:56:35 UTC
Finished importing scap-security-guide-0.1.46/ssg-rhel7-ds.xml in 40.012443842 seconds.
Importing scap-security-guide-0.1.43/ssg-rhel7-ds.xml at 2021-05-20 14:57:15 UTC
Finished importing scap-security-guide-0.1.43/ssg-rhel7-ds.xml in 38.17782694 seconds.
Importing scap-security-guide-0.1.42/ssg-rhel8-ds.xml at 2021-05-20 14:57:53 UTC
Finished importing scap-security-guide-0.1.42/ssg-rhel8-ds.xml in 36.118939555 seconds.
Importing scap-security-guide-0.1.40/ssg-rhel7-ds.xml at 2021-05-20 14:58:29 UTC
Finished importing scap-security-guide-0.1.40/ssg-rhel7-ds.xml in 41.383201327 seconds.
Importing scap-security-guide-0.1.36/ssg-rhel7-ds.xml at 2021-05-20 14:59:10 UTC
Finished importing scap-security-guide-0.1.36/ssg-rhel7-ds.xml in 39.052404374 seconds.
Importing scap-security-guide-0.1.33/ssg-rhel7-ds.xml at 2021-05-20 14:59:49 UTC
Finished importing scap-security-guide-0.1.33/ssg-rhel7-ds.xml in 39.416864917 seconds.
Importing scap-security-guide-0.1.30/ssg-rhel7-ds.xml at 2021-05-20 15:00:29 UTC
Finished importing scap-security-guide-0.1.30/ssg-rhel7-ds.xml in 56.49428137 seconds.
Importing scap-security-guide-0.1.28/ssg-rhel6-ds.xml at 2021-05-20 15:01:25 UTC
Finished importing scap-security-guide-0.1.28/ssg-rhel6-ds.xml in 40.137951116 seconds.
Importing scap-security-guide-0.1.25/ssg-rhel7-ds.xml at 2021-05-20 15:02:05 UTC
Finished importing scap-security-guide-0.1.25/ssg-rhel7-ds.xml in 40.003812208 seconds.
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices