### PR TITLE
fix(SSG): RHICOMPL-1863 import remediatons after SSG import

### DIFF
--- a/app/services/datastream_importer.rb
+++ b/app/services/datastream_importer.rb
@@ -16,16 +16,6 @@ class DatastreamImporter
   def import!
     Xccdf::Benchmark.transaction do
       save_all_benchmark_info
-      import_remediations
     end
-  end
-
-  private
-
-  def import_remediations
-    RemediationsAPI.new(
-      Account.find_by(account_number: ENV['JOBS_ACCOUNT_NUMBER']) ||
-        Account.new
-    ).import_remediations
   end
 end

--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -36,6 +36,7 @@ namespace :ssg do
       ENV['DATASTREAM_FILE'] = filename
       Rake::Task['ssg:import'].execute
     end
+    Rake::Task['import_remediations'].execute
   end
 
   desc 'Update compliance DB with data from an Xccdf datastream file'


### PR DESCRIPTION
Update available remediations on rules after all SSGs have been imported
to avoid a PG deadlock.

The remediations where being imported on every single SSG that has been
imported.  It has been updating all existing rules regardless of the
current SSG being imported.

That could have been one of the reasons for the deadlock.  Another fact
to consider here that it waited on the API response from the remediation
service within a transaction.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
