### PR TITLE
refactor(latest_supported): RHICOMPL-1773 single query

### DIFF
--- a/app/models/concerns/benchmark_searching.rb
+++ b/app/models/concerns/benchmark_searching.rb
@@ -33,7 +33,8 @@ module BenchmarkSearching
       SupportedSsg.by_os_major.inject(none) do |union, (os_major_version, ssgs)|
         ssg_versions = ssgs.map { |ssg| ssg.upstream_version || ssg.version }
         union.or(where(id: order_by_version.os_major_version(os_major_version)
-                                           .find_by(version: ssg_versions)))
+                                           .where(version: ssg_versions)
+                                           .limit(1)))
       end
     }
 


### PR DESCRIPTION
Use where(...).limit(1) instead of find_by(...) to reduce the number of
queries from 4 to 1 for Xccdf::Benchmark.latest_supported. Thanks @vkrizan 
for pointing this out!

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices