### PR TITLE
fix(import_remediations): RHICOMPL-1863 fall back to new Account

### DIFF
--- a/lib/tasks/import_remediations.rake
+++ b/lib/tasks/import_remediations.rake
@@ -16,7 +16,7 @@ task import_remediations: :environment do
     start_time = Time.now.utc
     puts "Starting import_remediations job at #{start_time}"
     RemediationsAPI.new(
-      Account.find_by!(account_number: ENV['JOBS_ACCOUNT_NUMBER'])
+      Account.find_by(account_number: ENV['JOBS_ACCOUNT_NUMBER']) || Account.new
     ).import_remediations
     end_time = Time.now.utc
     duration = end_time - start_time


### PR DESCRIPTION
When not providing JOBS_ACCOUNT_NUMBER, we used to fall back to just any new account. This adds that behavior back.

See https://github.com/RedHatInsights/compliance-backend/pull/844/files#diff-6aa5378d9c24177aba76fd391d9a51792d0d1b289be2a00a9bcbc0af24637ee0L27

This is required to unblock the smoke tests here: https://github.com/RedHatInsights/compliance-backend/pull/846

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices