### PR TITLE
fix(Dockerfile): RHICOMPL-1890 reduce layer duplication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.
     yum install -y hostname shared-mime-info && \
     yum clean all -y
 
-COPY . /tmp/src
-RUN chown -R 1001:0 /tmp/src
+COPY --chown=1001:0 . /tmp/src
 
 USER 1001
 


### PR DESCRIPTION
Use chown within the COPY statement to reduce duplication of layers.

A build from my local code-base reduced the size by ~1G.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
