### PR TITLE
fix(controllers): RHICOMPL-1465 escape values in links metadata

### DIFF
--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -23,8 +23,8 @@ module Metadata
 
     def links(last_offset)
       {
-        first: "#{base_link}&offset=1",
-        last: "#{base_link}&offset=#{last_offset}",
+        first: meta_link(offset: 1),
+        last: meta_link(offset: last_offset),
         previous: previous_link(last_offset),
         next: next_link(last_offset)
       }.compact
@@ -37,13 +37,13 @@ module Metadata
     def previous_link(last_offset)
       return unless pagination_offset > 1 && pagination_offset <= last_offset
 
-      "#{base_link}&offset=#{previous_offset}"
+      meta_link(offset: previous_offset)
     end
 
     def next_link(last_offset)
       return unless pagination_offset < last_offset
 
-      "#{base_link}&offset=#{next_offset(last_offset)}"
+      meta_link(offset: next_offset(last_offset))
     end
 
     def previous_offset
@@ -62,17 +62,21 @@ module Metadata
 
     private
 
-    def includes_link
-      "&include=#{params[:include]}" if params[:include].present?
+    def base_link_url
+      "#{path_prefix}/#{Settings.app_name}/#{controller_name}"
     end
 
-    def base_link
-      base_url = "#{path_prefix}/#{Settings.app_name}"\
-                 "/#{controller_name}"
-      base = "#{base_url}?limit=#{pagination_limit}"
-      base += "&search=#{params[:search]}" if params[:search].present?
-      base += includes_link.to_s
-      base
+    def base_link_params
+      {
+        search: params[:search],
+        include: params[:include],
+        limit: pagination_limit
+      }
+    end
+
+    def meta_link(other_params = {})
+      link_params = base_link_params.merge(other_params).compact
+      "#{base_link_url}?#{link_params.to_query}"
     end
   end
 end

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -48,6 +48,21 @@ class MetadataTest < ActionDispatch::IntegrationTest
     assert_equal search_query, json_body['meta']['search']
   end
 
+  test 'meta escapes parameter values in links' do
+    authenticate
+    3.times do
+      FactoryBot.create(:profile)
+    end
+
+    search_query = 'name != ""'
+    get profiles_url, params: { search: search_query, limit: 1, offset: 2 }
+    assert_response :success
+    assert_includes json_body['links']['first'], 'search=name+%21%3D+%22%22'
+    assert_includes json_body['links']['last'], 'search=name+%21%3D+%22%22'
+    assert_includes json_body['links']['next'], 'search=name+%21%3D+%22%22'
+    assert_includes json_body['links']['previous'], 'search=name+%21%3D+%22%22'
+  end
+
   context 'pagination' do
     setup do
       authenticate


### PR DESCRIPTION
Leverages ActiveSupport's `.to_query` on a Hash.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
