### PR TITLE
fix(consumer): RHICOMPL-751 reconnect db within kafka consumer

### DIFF
--- a/app/consumers/concerns/validation.rb
+++ b/app/consumers/concerns/validation.rb
@@ -7,15 +7,17 @@ module Validation
   included do
     def validated_reports(report_contents, metadata)
       report_contents.map do |raw_report|
-        begin
-          parsed = XccdfReportParser.new(raw_report, metadata)
-          test_result = parsed.test_result_file.test_result
-        rescue StandardError
-          raise InventoryEventsConsumer::ReportValidationError
-        end
+        test_result = validate_report(raw_report, metadata)
 
         [test_result.profile_id, raw_report]
       end
+    end
+
+    def validate_report(raw_report, metadata)
+      parsed = XccdfReportParser.new(raw_report, metadata)
+      parsed.test_result_file.test_result
+    rescue StandardError
+      raise InventoryEventsConsumer::ReportValidationError
     end
 
     def validation_payload(request_id, valid:)

--- a/app/consumers/concerns/validation.rb
+++ b/app/consumers/concerns/validation.rb
@@ -16,6 +16,8 @@ module Validation
     def validate_report(raw_report, metadata)
       parsed = XccdfReportParser.new(raw_report, metadata)
       parsed.test_result_file.test_result
+    rescue PG::Error, ActiveRecord::StatementInvalid
+      raise
     rescue StandardError
       raise InventoryEventsConsumer::ReportValidationError
     end


### PR DESCRIPTION
The PG:Error-s have been absorbed within the report validation.  Now
they are reraised to upper levels.

Any database error within the InventoryConsumer will:
a) fail the message
b) clear existing db connections for the next iteration to reconnect

Failing the message, by reraising it to the Racecar framework, would
have a side effect of keeping the message offset.  The message will be
repeated/resend by Kafka for next processing.  The drawback is that the
messages and their offsets are linear, therefore no other messages would
be processed until the database errors will disappear.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
