### PR TITLE
refactor(COMP-E-133): RHICOMPL-1761 Remove the feature flag

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -51,7 +51,7 @@ class Policy < ApplicationRecord
 
     removed = policy_hosts.where.not(host_id: new_host_ids).destroy_all
     imported = PolicyHost.import_from_policy(id, new_host_ids - host_ids)
-    update_os_minor_versions if Settings.feature_133_os_tailoring
+    update_os_minor_versions
 
     [imported.ids.count, removed.count]
   end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -20,7 +20,7 @@ class ProfileSerializer
   attributes :ref_id, :score, :parent_profile_id,
              :external, :compliance_threshold, :os_major_version,
              :os_version, :policy_profile_id
-  attribute :os_minor_version, if: proc { Settings.feature_133_os_tailoring }
+  attribute :os_minor_version
   attribute :parent_profile_ref_id do |profile|
     profile.parent_profile&.ref_id
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,4 +21,3 @@ redis_cache_ssl: false
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'
 async: true
-feature_133_os_tailoring: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,4 +8,3 @@ prometheus_exporter_host: prometheus
 prometheus_exporter_port: 9394
 redis_url: localhost:6379
 redis_cache_url: localhost:6379
-feature_133_os_tailoring: true

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -225,8 +225,6 @@ module V1
       end
 
       test 'profiles can be sorted' do
-        Settings.feature_133_os_tailoring = true
-
         FactoryBot.create(:profile, name: 'a', os_minor_version: '1')
         FactoryBot.create(:profile, name: 'a', os_minor_version: '2')
         FactoryBot.create(:profile, name: 'b', os_minor_version: '3')
@@ -403,17 +401,7 @@ module V1
                      body.dig('data', 'attributes', 'policy_profile_id')
       end
 
-      test 'os_minor_version is not serialized when COMP-E-133 is disabled' do
-        Settings.feature_133_os_tailoring = false
-        get v1_profile_url(@profile.id)
-        assert_response :success
-
-        assert_nil JSON.parse(response.body).dig('data', 'attributes',
-                                                 'os_minor_version')
-      end
-
-      test 'os_minor_version is serialized when COMP-E-133 is enabled' do
-        Settings.feature_133_os_tailoring = true
+      test 'os_minor_version is serialized' do
         get v1_profile_url(@profile.id)
         assert_response :success
 

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -103,19 +103,9 @@ class PolicyTest < ActiveSupport::TestCase
     end
 
     should 'update_os_minor_versions' do
-      Settings.feature_133_os_tailoring = true
       @policy.update(hosts: [@hosts.first])
 
       @policy.expects(:update_os_minor_versions)
-
-      @policy.update_hosts([])
-    end
-
-    should 'not update_os_minor_versions if COMP-E-133 feature is disabled' do
-      Settings.feature_133_os_tailoring = false
-      @policy.update(hosts: [@hosts.first])
-
-      @policy.expects(:update_os_minor_versions).never
 
       @policy.update_hosts([])
     end


### PR DESCRIPTION
I was about to add a new feature flag for downstream SSG sync and noticed this 133 flag still exists! :scissors: 

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices