### PR TITLE
devel: Restart inventory on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
     links:
       - db
       - kafka
+    restart: on-failure
   inventory-web:
     image: quay.io/cloudservices/insights-inventory:latest
     command: bash -c 'sleep 10 && make upgrade_db && python run_gunicorn.py'


### PR DESCRIPTION
I noticed this crashing when the DB connection is lost. I suspect that's
how it works in prod, too. Anyway, this is just a quality of life
improvement so you don't need to manually restart the inventory.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices