### PR TITLE
Add Initializer for Clowder config for settings

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -7,32 +7,103 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: compliance-prometheus-exporter
-    annotations:
-      prometheus.io/path: /metrics
-      prometheus.io/port: "9394"
-      prometheus.io/scrape: "true"
+    name: "${APP_NAME}"
   spec:
     envName: ${ENV_NAME}
-# We need to add a shared DB definition here ...
-# Perhaps on the defintion of compliance-backend we
-# should create the DB , and make all services depend
-# on it. The "source DB" for every other service must
-# be the one in charge of running DB migrations. I'd not
-# like it to be compliance-prometheus-exporter. That would
-# look VERY weird ...
-#    database:
-#      sharedDbAppName: compliance-backend
-#      version: 12
-#    dependencies:
-#      compliance-backend
+    dependencies:
+    - host-inventory
+    - ingress
+    - rbac
+#  blocked https://issues.redhat.com/browse/RHCLOUD-10212
+#    - remediations
     database:
       name: compliance
+      version: 12
+    kafkaTopics:
+      - topicName: platform.upload.compliance
+        partitions: 1
+      - topicName: platform.payload-status
+        partitions: 1
+      - topicName: platform.inventory.events
+        partitions: 1
+      - topicName: platform.remediations.events
+        partitions: 1
     inMemoryDb: true
 #    optionalDependencies:
-#    - rbac
+#    - remediations
+    cyndi:
+      enabled: true
+      appName: "compliance"
+      insightsOnly: true
     deployments:
     - name: service
+      # TODO: Check how to auto-scale with Clowder
+      minReplicas: ${{REPLICAS_SERVICE}}
+      webServices:
+        public:
+          enabled: true
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - name: wait-on-migrations
+          image: " "
+          imagePullPolicy: Always
+          command:
+            - bash
+            - -c
+            - |
+              for i in {1..120}; do sleep 1;
+              if bundle exec rake --trace db:abort_if_pending_migrations;
+              then exit 0; fi; done; exit 1
+          env:
+          - name: RAILS_ENV
+            value: "${RAILS_ENV}"
+          - name: PATH_PREFIX
+            value: "${PATH_PREFIX}"
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-backend
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: SETTINGS__REDIS_SSL
+          value: "${REDIS_SSL}"
+        - name: SETTINGS__REDIS_CACHE_SSL
+          value: "${REDIS_SSL}"
+        - name: SETTINGS__DISABLE_RBAC
+          value: ${DISABLE_RBAC}
+        - name: PUMA_WORKERS
+          value: "${PUMA_WORKERS}"
+        - name: PUMA_MAX_THREADS
+          value: "${PUMA_MAX_THREADS}"
+        - name: OLD_PATH_PREFIX
+          value: "${OLD_PATH_PREFIX}"
+# If we can configure the metrics endpoint to listen to 9000 this definitions should go away
+        livenessProbe:
+          httpGet:
+            path: /api/compliance/v1/openapi.json
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /api/compliance/v1/status
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+        resources:
+          limits:
+            cpu: "${CPU_LIMIT_SERV}"
+            memory: "${MEMORY_LIMIT_SERV}"
+          requests:
+            cpu: "${CPU_REQUEST_SERV}"
+            memory: "${MEMORY_REQUEST_SERV}"
+    - name: prometheus-exporter
       minReplicas: ${{REPLICAS_PROMETHEUS}}
 #      webServices:
 #        public:
@@ -56,55 +127,6 @@ objects:
             value: "${PATH_PREFIX}"
           - name: RAILS_LOG_TO_STDOUT
             value: "${RAILS_LOG_TO_STDOUT}"
-          - name: POSTGRESQL_MAX_CONNECTIONS
-            value: ${POSTGRESQL_MAX_CONNECTIONS}
-#          - name: DATABASE_SERVICE_NAME
-#            value: "${DATABASE_SERVICE_NAME}"
-#          - name: POSTGRESQL_USER
-#            valueFrom:
-#              secretKeyRef:
-#                key: db.user
-#                name: compliance-db
-#          - name: POSTGRESQL_PASSWORD
-#            valueFrom:
-#              secretKeyRef:
-#                key: db.password
-#                name: compliance-db
-#          - name: COMPLIANCE_DB_SERVICE_HOST
-#            valueFrom:
-#              secretKeyRef:
-#                key: db.host
-#                name: compliance-db
-#          - name: POSTGRESQL_DATABASE
-#            valueFrom:
-#              secretKeyRef:
-#                key: db.name
-#                name: compliance-db
-#          - name: SECRET_KEY_BASE
-#            valueFrom:
-#              secretKeyRef:
-#                key: secret_key_base
-#                name: compliance-backend
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /playbooks
-            port: web
-            scheme: HTTP
-          initialDelaySeconds: 35
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 120
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /playbooks
-            port: web
-            scheme: HTTP
-          initialDelaySeconds: 35
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 120
         env:
         - name: APPLICATION_TYPE
           value: compliance-prometheus-exporter
@@ -114,89 +136,23 @@ objects:
           value: "${PATH_PREFIX}"
         - name: APP_NAME
           value: "${APP_NAME}"
-        - name: PGSSLMODE
-          value: ${PGSSLMODE}
-        - name: PGSSLROOTCERT
-          value: /etc/rds-certs/rds-cacert
-        - name: POSTGRESQL_MAX_CONNECTIONS
-          value: ${POSTGRESQL_MAX_CONNECTIONS}
         - name: RAILS_LOG_TO_STDOUT
           value: "${RAILS_LOG_TO_STDOUT}"
         - name: SETTINGS__REDIS_SSL
           value: "${REDIS_SSL}"
         - name: SETTINGS__REDIS_CACHE_SSL
           value: "${REDIS_SSL}"
-#        - name: DATABASE_SERVICE_NAME
-#          value: "${DATABASE_SERVICE_NAME}"
-#        - name: POSTGRESQL_USER
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.user
-#              name: compliance-db
-#        - name: POSTGRESQL_PASSWORD
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.password
-#              name: compliance-db
-#        - name: COMPLIANCE_DB_SERVICE_HOST
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.host
-#              name: compliance-db
-#        - name: POSTGRESQL_DATABASE
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.name
-#              name: compliance-db
-#        - name: REDIS_HOST
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.endpoint
-#              name: compliance-elasticache-redis
-#        - name: REDIS_PORT
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.port
-#              name: compliance-elasticache-redis
-#        - name: SETTINGS__REDIS_URL
-#          value: "$(REDIS_HOST):$(REDIS_PORT)"
-#        - name: SETTINGS__REDIS_PASSWORD
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.auth_token
-#              name: compliance-elasticache-redis
-#        - name: SETTINGS__REDIS_CACHE_URL
-#          value: "$(REDIS_HOST):$(REDIS_PORT)"
-#        - name: SETTINGS__REDIS_CACHE_PASSWORD
-#          valueFrom:
-#            secretKeyRef:
-#              key: db.auth_token
-#              name: compliance-elasticache-redis
-#        - name: SECRET_KEY_BASE
-#          valueFrom:
-#            secretKeyRef:
-#              key: secret_key_base
-#              name: compliance-backend
+# If we can configure the metrics endpoint to listen to 9000 this definitions should go away
         livenessProbe:
-#          failureThreshold: 3
           httpGet:
             path: /metrics
             port: 9394
             scheme: HTTP
-#          initialDelaySeconds: 120
-#          periodSeconds: 60
-#          successThreshold: 1
-#          timeoutSeconds: 15
         readinessProbe:
-#          failureThreshold: 3
           httpGet:
             path: /metrics
             port: 9394
             scheme: HTTP
-#          initialDelaySeconds: 60
-#          periodSeconds: 10
-#          successThreshold: 1
-#          timeoutSeconds: 15
         resources:
           limits:
             cpu: "${CPU_LIMIT_PROM}"
@@ -204,14 +160,114 @@ objects:
           requests:
             cpu: "${CPU_REQUEST_PROM}"
             memory: "${MEMORY_REQUEST_PROM}"
-        volumeMounts:
-        - mountPath: /etc/rds-certs
-          name: rds-client-ca
-          readOnly: true
-        volumes:
-        - name: rds-client-ca
-          secret:
-            secretName: rds-client-ca
+
+    - name: compliance-inventory
+      # TODO: check requreiment for RDS CA and Kafka Cert with Clowder
+      minReplicas: ${{REPLICAS_CONSUMER}}
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - name: wait-on-migrations
+          image: " "
+          imagePullPolicy: Always
+          command:
+            - bash
+            - -c
+            - |
+              for i in {1..120}; do sleep 1;
+              if bundle exec rake --trace db:abort_if_pending_migrations;
+              then exit 0; fi; done; exit 1
+          env:
+          - name: RAILS_ENV
+            value: "${RAILS_ENV}"
+          - name: PATH_PREFIX
+            value: "${PATH_PREFIX}"
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: ${POSTGRESQL_MAX_CONNECTIONS}
+          - name: RAILS_LOG_TO_STDOUT
+            value: "${RAILS_LOG_TO_STDOUT}"
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-inventory
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: RACECAR_MIN_MESSAGE_QUEUE_SIZE
+          value: "${RACECAR_QUEUE_SIZE}"
+        - name: RACECAR_OFFSET_COMMIT_INTERVAL
+          value: "${RACECAR_OFFSET_COMMIT_INTERVAL}"
+        readinessProbe:
+          timeoutSeconds: 5
+          exec:
+            command:
+              - bundle
+              - exec
+              - rake
+              - db:status
+              - redis:status
+              - kafka:status
+        resources:
+          limits:
+            cpu: "${CPU_LIMIT_CONS}"
+            memory: "${MEMORY_LIMIT_CONS}"
+          requests:
+            cpu: "${CPU_REQUEST_CONS}"
+            memory: "${MEMORY_REQUEST_CONS}"
+
+    - name: compliance-sidekiq
+      # TODO: check requreiment for RDS CA and Kafka Cert with Clowder
+      minReplicas: ${{REPLICAS_CONSUMER}}
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - name: wait-on-migrations
+          image: " "
+          imagePullPolicy: Always
+          command:
+            - bash
+            - -c
+            - |
+              for i in {1..120}; do sleep 1;
+              if bundle exec rake --trace db:abort_if_pending_migrations;
+              then exit 0; fi; done; exit 1
+          env:
+          - name: RAILS_ENV
+            value: "${RAILS_ENV}"
+          - name: PATH_PREFIX
+            value: "${PATH_PREFIX}"
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: ${POSTGRESQL_MAX_CONNECTIONS}
+          - name: RAILS_LOG_TO_STDOUT
+            value: "${RAILS_LOG_TO_STDOUT}"
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-sidekiq
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: SIDEKIQ_CONCURRENCY
+          value: "${SIDEKIQ_CONCURRENCY}"
+        - name: RAILS_MAX_THREADS
+          value: "${RAILS_MAX_THREADS}"
+        - name: JOBS_ACCOUNT_NUMBER
+          value: ${JOBS_ACCOUNT_NUMBER}
+        resources:
+          limits:
+            cpu: "${CPU_LIMIT_SIDE}"
+            memory: "${MEMORY_LIMIT_SIDE}"
+          requests:
+            cpu: "${CPU_REQUEST_SIDE}"
+            memory: "${MEMORY_REQUEST_SIDE}"
 
 parameters:
 - name: MIN_REPLICAS
@@ -219,15 +275,18 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
-  value: latest
+  value: latest-new
 - description: Image name
   name: IMAGE
-  value: quay.io/cloudservices/compliance-ssg
+  value: quay.io/cloudservices/compliance-backend
 - description: ClowdEnv Name
   name: ENV_NAME
   requred: false
 - description: Replica count for prometheus-exporter
   name: REPLICAS_PROMETHEUS
+  value: "1"
+- description: Replica count for backend service
+  name: REPLICAS_SERVICE
   value: "1"
 - name: RAILS_ENV
   required: true
@@ -252,9 +311,49 @@ parameters:
   value: 400m
 - name: CPU_REQUEST_PROM
   value: 100m
-- name: POSTGRESQL_MAX_CONNECTIONS
-  description: Number of maximum database connections
-  value: "50"
+- name: MEMORY_LIMIT_SERV
+  value: 800Mi
+- name: MEMORY_REQUEST_SERV
+  value: 400Mi
+- name: CPU_LIMIT_SERV
+  value: 700m
+- name: CPU_REQUEST_SERV
+  value: 400m
+- name: MEMORY_LIMIT_CONS
+  value: 800Mi
+- name: MEMORY_REQUEST_CONS
+  value: 400Mi
+- name: CPU_LIMIT_CONS
+  value: 500m
+- name: CPU_REQUEST_CONS
+  value: 50m
+- name: MEMORY_LIMIT_SIDE
+  value: 1000Mi
+- name: MEMORY_REQUEST_SIDE
+  value: 500Mi
+- name: CPU_LIMIT_SIDE
+  value: 500m
+- name: CPU_REQUEST_SIDE
+  value: 50m
 - name: REDIS_SSL
   description: 'Whether to use secured connection to Redis. Use string values of true or false'
   value: "true"
+- name: PUMA_MAX_THREADS
+  value: "5"
+- name: POSTGRESQL_MAX_CONNECTIONS
+  description: Number of maximum database connections
+  value: "50"
+- name: RACECAR_OFFSET_COMMIT_INTERVAL
+  required: true
+  value: "5"
+- name: RACECAR_QUEUE_SIZE
+  required: true
+  value: "5"
+- name: SIDEKIQ_CONCURRENCY
+  value: "1"
+- name: JOBS_ACCOUNT_NUMBER
+  displayName: "Account number used in the import remediations job"
+  value: "6212377"
+  required: true
+- name: RAILS_MAX_THREADS
+  value: "1"

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,7 @@
     db_service = ENV.fetch("DATABASE_SERVICE_NAME","").upcase.sub("-", "_")
     username = ENV.key?("POSTGRESQL_ADMIN_PASSWORD") ? "postgres" : ENV["POSTGRESQL_USER"]
     password = ENV.key?("POSTGRESQL_ADMIN_PASSWORD") ? ENV["POSTGRESQL_ADMIN_PASSWORD"] : ENV["POSTGRESQL_PASSWORD"]
-    host = ENV.fetch("#{db_service}_SERVICE_HOST")
+    host = ENV.fetch("POSTGRES_SERVICE_HOST")
     database = Rails.env.test? ? ENV['POSTGRESQL_TEST_DATABASE'] || ENV["POSTGRESQL_DATABASE"] : ENV["POSTGRESQL_DATABASE"]
     port = ENV.key?("POSTGRESQL_PORT") ? ENV["POSTGRESQL_PORT"] : 5432
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,18 +3,19 @@
 
     config = ClowderCommonRuby::Config.load
 
+    db_service = config.database.hostname
     username = config.database.username
     password = config.database.password
     host = config.database.hostname
     database = config.database.name
+    port = config.database.port
   else
-
     db_service = ENV.fetch("DATABASE_SERVICE_NAME","").upcase.sub("-", "_")
-
     username = ENV.key?("POSTGRESQL_ADMIN_PASSWORD") ? "postgres" : ENV["POSTGRESQL_USER"]
     password = ENV.key?("POSTGRESQL_ADMIN_PASSWORD") ? ENV["POSTGRESQL_ADMIN_PASSWORD"] : ENV["POSTGRESQL_PASSWORD"]
     host = ENV.fetch("#{db_service}_SERVICE_HOST")
     database = Rails.env.test? ? ENV['POSTGRESQL_TEST_DATABASE'] || ENV["POSTGRESQL_DATABASE"] : ENV["POSTGRESQL_DATABASE"]
+    port = ENV.key?("POSTGRESQL_PORT") ? ENV["POSTGRESQL_PORT"] : 5432
   end
  %>
 
@@ -26,6 +27,7 @@ default: &default
   password: <%= password %>
   host: <%= host %>
   database: <%= database %>
+  port: <%= port %>
 
 test:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,6 @@
 
     config = ClowderCommonRuby::Config.load
 
-    db_service = 'postgres'
     username = config.database.username
     password = config.database.password
     host = config.database.hostname
@@ -13,7 +12,7 @@
     db_service = ENV.fetch("DATABASE_SERVICE_NAME","").upcase.sub("-", "_")
     username = ENV.key?("POSTGRESQL_ADMIN_PASSWORD") ? "postgres" : ENV["POSTGRESQL_USER"]
     password = ENV.key?("POSTGRESQL_ADMIN_PASSWORD") ? ENV["POSTGRESQL_ADMIN_PASSWORD"] : ENV["POSTGRESQL_PASSWORD"]
-    host = ENV.fetch("POSTGRES_SERVICE_HOST")
+    host = ENV.fetch("#{db_service}_SERVICE_HOST")
     database = Rails.env.test? ? ENV['POSTGRESQL_TEST_DATABASE'] || ENV["POSTGRESQL_DATABASE"] : ENV["POSTGRESQL_DATABASE"]
     port = ENV.key?("POSTGRESQL_PORT") ? ENV["POSTGRESQL_PORT"] : 5432
   end
@@ -31,6 +30,7 @@ default: &default
 
 test:
   <<: *default
+  database: <%= ENV['POSTGRESQL_TEST_DATABASE'] || database %>
 
 production:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@
 
     config = ClowderCommonRuby::Config.load
 
-    db_service = config.database.hostname
+    db_service = 'postgres'
     username = config.database.username
     password = config.database.password
     host = config.database.hostname

--- a/config/initializers/0_clowder-config.rb
+++ b/config/initializers/0_clowder-config.rb
@@ -1,0 +1,53 @@
+
+if ClowderCommonRuby::Config.clowder_enabled?
+
+  config = ClowderCommonRuby::Config.load
+
+  # TO-DO: Refactor with a helper function (get_service_url(app_name, component)
+# Blocked by https://issues.redhat.com/browse/RHCLOUD-10212
+#  remediations_hostname = config.private_dependency_endpoints.remediations.service.hostname
+#  remediations_port = config.private_dependency_endpoints.remediations.service.port
+#  remediations_url = "#{remediations_hostname}:#{remediations_port}"
+
+  # RBAC
+  rbac_config = config.dependency_endpoints['rbac']['service']
+  rbac_url = "#{rbac_config.hostname}:#{rbac_config.port}"
+
+  # Prometheus
+  prometheus_exporter_config = config.private_dependency_endpoints['compliance']['prometheus-exporter']
+
+  # Inventory
+  host_inventory_config = config.dependency_endpoints['host-inventory']['service']
+  host_inventory_url = "#{host_inventory_config.hostname}:#{host_inventory_config.port}"
+
+  # Redis (in-memory db)
+  redis_url = "#{config.inMemoryDb.hostname}:#{config.inMemoryDb.port}"
+
+  clowder_config = {
+    kafka: { 
+#      brokers: "#{config.kafka_servers[0]['hostname']}:#{config.kafka_servers[0]['port']}"
+      brokers: config.kafka_servers,
+      # Not provided by clowder, not sure which of the following should be: [:plaintext, :ssl, :sasl_plaintext, :sasl_ssl]
+      security_protocol: 'plaintext'
+    },
+    kafka_consumer_topics: {
+      inventory_events: config.kafka_topics['platform.inventory.events'].name
+    },
+    kafka_producer_topics: {
+      upload_validation: config.kafka_topics['platform.upload.compliance'].name,
+      payload_tracker: config.kafka_topics['platform.payload-status'].name,
+      remediation_updates: config.kafka_topics['platform.remediations.events'].name
+    },
+    prometheus_exporter_host: prometheus_exporter_config.hostname,
+    prometheus_exporter_port: prometheus_exporter_config.port,
+    rbac_url: rbac_url,
+    redis_url: redis_url,
+# Blocked by https://issues.redhat.com/browse/RHCLOUD-10212
+#    remediations_url: remediations_url,
+    host_inventory_url: host_inventory_url,
+    clowder_config_enabled: true
+  }
+
+  Settings.add_source!(clowder_config)
+  Settings.reload!
+end

--- a/devel.json
+++ b/devel.json
@@ -1,0 +1,86 @@
+{
+    "webPort": 8000,
+    "metricsPort": 9000,
+    "metricsPath": "/metrics",
+    "logging": {
+        "type": "cloudwatch",
+        "cloudwatch": {
+            "accessKeyId": "ACCESS_KEY",
+            "secretAccessKey": "SECRET_ACCESS_KEY",
+            "region": "EU",
+            "logGroup": "base_app"
+            }
+        },
+    "kafka": {
+        "brokers": [
+            {
+                "hostname": "kafka",
+                "port": 29092
+            }
+        ],
+        "topics": [
+            {
+                "requestedName": "platform.inventory.events",
+                "name": "platform.inventory.events",
+                "consumerGroup": "someGroupName"
+            },
+            {
+                "requestedName": "platform.upload.compliance",
+                "name": "platform.upload.compliance",
+                "consumerGroup": "someGroupName"
+            },
+            {
+                "requestedName": "platform.payload-status",
+                "name": "platform.payload-status",
+                "consumerGroup": "someGroupName"
+            },
+            {
+                "requestedName": "platform.remediations.events",
+                "name": "platform.remediations.events",
+                "consumerGroup": "someGroupName"
+            },
+            {
+                "requestedName": "originalName",
+                "name": "someTopic",
+                "consumerGroup": "someGroupName"
+            }
+        ]
+    },
+    "inMemoryDb": {
+        "hostname": "redis",
+        "port": "6379"
+    },
+    "database": {
+        "name": "compliance_dev",
+        "username": "insights",
+        "password": "insights",
+        "hostname": "db",
+        "port": 5432,
+        "adminUsername": "postgres",
+        "adminPassword": "insights",
+        "rdsCa": "ca",
+        "sslMode": "disable"
+    },
+    "endpoints": [
+        {
+            "name": "service",
+            "app": "rbac",
+            "hostname": "rbac",
+            "port": 8000
+        },
+        {
+            "name": "service",
+            "app": "host-inventory",
+            "hostname": "host-inventory.svc",
+            "port": 8000
+        }
+    ],
+    "privateEndpoints": [
+        {
+            "name": "prometheus-exporter",
+            "app": "compliance",
+            "hostname": "prometheus",
+            "port": 9394
+        }
+    ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,13 +163,8 @@ services:
       - db
       - prometheus
     environment:
-      - DATABASE_SERVICE_NAME=postgres
-      - POSTGRES_SERVICE_HOST=db
-      - POSTGRESQL_DATABASE=compliance_dev
       - POSTGRESQL_TEST_DATABASE=compliance_test
-      - POSTGRESQL_USER=insights
-      - POSTGRESQL_PASSWORD=insights
-      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - ACG_CONFIG=/app/devel.json
   ssg-import-rhel-supported:
     image: compliance-backend-rails
     entrypoint: ''
@@ -185,13 +180,9 @@ services:
       - prometheus
       - compliance-ssg
     environment:
-      - DATABASE_SERVICE_NAME=postgres
-      - POSTGRES_SERVICE_HOST=db
-      - POSTGRESQL_DATABASE=compliance_dev
       - POSTGRESQL_TEST_DATABASE=compliance_test
-      - POSTGRESQL_USER=insights
-      - POSTGRESQL_PASSWORD=insights
       - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - ACG_CONFIG=/app/devel.json
   rails:
     env_file: .env
     build:
@@ -202,16 +193,10 @@ services:
     stdin_open: true
     restart: on-failure
     environment:
-      - SETTINGS__KAFKA__BROKERS=kafka:29092
-      - DATABASE_SERVICE_NAME=postgres
-      - POSTGRES_SERVICE_HOST=db
-      - POSTGRESQL_DATABASE=compliance_dev
       - POSTGRESQL_TEST_DATABASE=compliance_test
-      - POSTGRESQL_USER=insights
-      - POSTGRESQL_PASSWORD=insights
-      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
       - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
       - HOSTNAME=rails
+      - ACG_CONFIG=/app/devel.json
     ports:
       - 3000:3000
     volumes:
@@ -232,16 +217,10 @@ services:
     entrypoint: ''
     command: 'bundle exec racecar -l log/inventory-consumer.log InventoryEventsConsumer'
     environment:
-      - SETTINGS__KAFKA__BROKERS=kafka:29092
-      - DATABASE_SERVICE_NAME=postgres
-      - POSTGRES_SERVICE_HOST=db
-      - POSTGRESQL_DATABASE=compliance_dev
       - POSTGRESQL_TEST_DATABASE=compliance_test
-      - POSTGRESQL_USER=insights
-      - POSTGRESQL_PASSWORD=insights
-      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
       - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
       - HOSTNAME=inventory-consumer
+      - ACG_CONFIG=/app/devel.json
     volumes:
       - .:/app:z
     depends_on:
@@ -256,16 +235,10 @@ services:
     image: compliance-backend-rails
     tty: true
     environment:
-      - SETTINGS__KAFKA__BROKERS=kafka:29092
-      - DATABASE_SERVICE_NAME=postgres
-      - POSTGRES_SERVICE_HOST=db
-      - POSTGRESQL_DATABASE=compliance_dev
-      - POSTGRESQL_USER=insights
-      - POSTGRESQL_PASSWORD=insights
-      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
       - RAILS_ENV=development
       - RAILS_LOG_TO_STDOUT=true
       - HOSTNAME=prometheus
+      - ACG_CONFIG=/app/devel.json
     restart: on-failure
     volumes:
       - .:/app:z
@@ -284,17 +257,10 @@ services:
     command: bundle exec sidekiq
     environment:
       - MALLOC_ARENA_MAX=2
-      - SETTINGS__REDIS_URL=redis:6379
-      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
-      - SETTINGS__KAFKA__BROKERS=kafka:29092
-      - DATABASE_SERVICE_NAME=postgres
-      - POSTGRES_SERVICE_HOST=db
-      - POSTGRESQL_DATABASE=compliance_dev
       - POSTGRESQL_TEST_DATABASE=compliance_test
-      - POSTGRESQL_USER=insights
-      - POSTGRESQL_PASSWORD=insights
       - SIDEKIQ_CONCURRENCY=1
       - HOSTNAME=sidekiq
+      - ACG_CONFIG=/app/devel.json
   redis:
     image: quay.io/cloudservices/redis:latest
     ports:


### PR DESCRIPTION
UPDATE - I've modified the `docker-compose` file to read the configuration as if it was on a Clowder environment. In order to do so, I've added the `devel.json` file, which would be added to each pod's volume, and I've added the variable `ACG_CONFIG` to each of Compliance's pods. This should emulate the "clowder config injection" that happens on a Clowder deployed app. The Clowder_config::isClowderEnabled? function now returns true and uses the values from the JSON file to provide the mocked config values that are pretended to be provided by Clowder.

If you wanna test this, you should be able to do a podman-compose up and see the application working normally. Please test thoroughly and provide feedback.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
