### PR TITLE
build(Dockerfile): RHICOMPL-1268 remove unused packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM registry.access.redhat.com/ubi8/ruby-27
 
-# Install dependencies and clean cache to make the image cleaner
 
 USER 0
+
+# Install dependencies and clean cache to make the image cleaner
+# also remove unused packages added by ubi8/s2i-base.
 RUN yum install -y hostname shared-mime-info && \
+    yum remove -y mariadb-connector-c-devel npm && \
     yum clean all -y
 
 COPY --chown=1001:0 . /tmp/src


### PR DESCRIPTION
Backend does not use mariadb nor npm.

There could be more of these removed (like kernel-headers and libX11), however with their removal it removes couple of other possibly useful packages (like gcc, libpng, ...).

References:
* https://catalog.redhat.com/software/containers/ubi8/s2i-base/5c83976a5a13464733ec6790?container-tabs=dockerfile

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
