### PR TITLE
devel(Dockerfile): install less into the container

### DIFF
--- a/devel.Dockerfile
+++ b/devel.Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y qt5-default libqt5webkit5-dev \
       gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x libopenscap-dev \
-      postgresql-client shared-mime-info
+      postgresql-client shared-mime-info less
 
 COPY vendor/ ./vendor
 COPY Gemfile* ./


### PR DESCRIPTION
`pry` has a weak dependency on the `less` command as it utilizes it for pagination of a long(er) output when debugging or running `rails console`. It's kinda annoying to install this every time manually and we have a separate dockerfile for development, so I guess it's safe to have this :pray: 

*;Without less:*;
```
<page break> --- Press enter to continue ( q<enter> to break ) --- <page break>
```

;*With less:*;
```
:
```
Basically provides a regular `less` session where you can use arrows to move and and search in the output.