### PR TITLE
feat(metrics): Label y axis of Traffic graph

### DIFF
--- a/dashboards/grafana-dashboard-insights-compliance-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-compliance-general.configmap.yaml
@@ -1022,7 +1022,7 @@ data:
           "yaxes": [
             {
               "format": "short",
-              "label": null,
+              "label": "per second",
               "logBase": 1,
               "max": null,
               "min": null,


### PR DESCRIPTION
It's a pretty simple change :) The `rate` function measures counts per second. The `$interval` just represents the running average rate over that interval. i.e. 1h means the 1-hour moving average of traffic per-second. This particular graph was confusing to me because I didn't realize `rate` was per-second. Maybe in the future we will change it to use `increase` instead so it actually counts how many requests per `$interval` instead of that confusing explanation I gave previously about the moving average per-second traffic :laughing: 

Before:

![image](https://user-images.githubusercontent.com/761923/120681752-b3146300-c469-11eb-88fc-44e83192a50e.png)

After:

![image](https://user-images.githubusercontent.com/761923/120681643-96782b00-c469-11eb-9f74-f90461fece4e.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices