### PR TITLE
feat(rake): RHICOMPL-56 db:status redis:status kafka:status tasks

### DIFF
--- a/app/producers/test_producer.rb
+++ b/app/producers/test_producer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# A Kafka producer client for testing connectivity
+class TestProducer < ApplicationProducer
+  TOPIC = Settings.kafka_producer_topics.test
+
+  def self.deliver
+    deliver_message(msg: 'ping')
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,7 @@ kafka_producer_topics:
   upload_validation: 'platform.upload.validation'
   payload_tracker: 'platform.payload-status'
   remediation_updates: 'platform.remediation-updates.compliance'
+  test: 'test'
 host_inventory_url: http://insights-inventory.platform-ci.svc.cluster.local:8080
 remediations_url: http://remediations.remediations-ci.svc.cluster.local:9002
 rbac_url: http://rbac.rbac-ci.svc.cluster.local:9002

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,6 +192,7 @@ services:
     stdin_open: true
     restart: on-failure
     environment:
+      - SETTINGS__KAFKA__BROKERS=kafka:29092
       - DATABASE_SERVICE_NAME=postgres
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev
@@ -243,6 +244,7 @@ services:
     image: compliance-backend-rails
     tty: true
     environment:
+      - SETTINGS__KAFKA__BROKERS=kafka:29092
       - DATABASE_SERVICE_NAME=postgres
       - POSTGRES_SERVICE_HOST=db
       - POSTGRESQL_DATABASE=compliance_dev

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -11,3 +11,18 @@ namespace :db do
     end
   end
 end
+
+namespace :redis do
+  desc 'Check for available redis connection'
+  task status: [:environment] do
+    begin
+      Redis.new(
+        url: "redis://#{Settings.redis_url}",
+        password: Settings.redis_password.presence,
+        ssl: Settings.redis_ssl
+      ).ping
+    rescue Redis::BaseError
+      abort('ERROR: Redis unavailable')
+    end
+  end
+end

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -26,3 +26,14 @@ namespace :redis do
     end
   end
 end
+
+namespace :kafka do
+  desc 'Check for available kafka connection'
+  task status: [:environment] do
+    begin
+      TestProducer.deliver
+    rescue StandardError
+      abort('ERROR: Kafka unavailable')
+    end
+  end
+end

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc 'Check for available database connection'
+  task status: [:environment] do
+    begin
+      ActiveRecord::Base.connection
+    rescue StandardError # rubocop:disable Lint/SuppressedException
+    ensure
+      abort('ERROR: Database unavailable') unless ActiveRecord::Base.connected?
+    end
+  end
+end

--- a/test/tasks/status_test.rb
+++ b/test/tasks/status_test.rb
@@ -42,3 +42,23 @@ class RedisStatusTest < ActiveSupport::TestCase
     end
   end
 end
+
+class KafkaStatusTest < ActiveSupport::TestCase
+  test 'kafka:status fails without a kafka connection' do
+    TestProducer.stubs(:deliver_message).raises(Kafka::ConnectionError)
+    assert_raises SystemExit do
+      capture_io do
+        Rake::Task['kafka:status'].execute
+      end
+    end
+  end
+
+  test 'kafka:status succeeds with a kafka connection' do
+    TestProducer.any_instance.stubs(:deliver_message)
+    assert_nothing_raised do
+      capture_io do
+        Rake::Task['kafka:status'].execute
+      end
+    end
+  end
+end

--- a/test/tasks/status_test.rb
+++ b/test/tasks/status_test.rb
@@ -22,3 +22,23 @@ class DbStatusTest < ActiveSupport::TestCase
     end
   end
 end
+
+class RedisStatusTest < ActiveSupport::TestCase
+  test 'redis:status fails without a redis connection' do
+    Redis.any_instance.stubs(:ping).raises(Redis::BaseError)
+    assert_raises SystemExit do
+      capture_io do
+        Rake::Task['redis:status'].execute
+      end
+    end
+  end
+
+  test 'redis:status succeeds with a redis connection' do
+    Redis.any_instance.stubs(:ping).returns(true)
+    assert_nothing_raised do
+      capture_io do
+        Rake::Task['redis:status'].execute
+      end
+    end
+  end
+end

--- a/test/tasks/status_test.rb
+++ b/test/tasks/status_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class DbStatusTest < ActiveSupport::TestCase
+  test 'db:status fails without a database connection' do
+    ActiveRecord::Base.stubs(:connected?)
+    assert_raises SystemExit do
+      capture_io do
+        Rake::Task['db:status'].execute
+      end
+    end
+  end
+
+  test 'db:status succeeds with a database connection' do
+    ActiveRecord::Base.stubs(:connected?).returns(true)
+    assert_nothing_raised do
+      capture_io do
+        Rake::Task['db:status'].execute
+      end
+    end
+  end
+end


### PR DESCRIPTION
These rake tasks can be used to check database, kafka, or redis availability for non-web ruby
services in a readiness or liveness probe.

```sh
bundle exec rake db:status
bundle exec rake redis:status
bundle exec rake kafka:status
```

Readiness/liveness probes can chain together multiple rake status invocations, depending on what services they depend on. So, inventory-consumer might run something like `rake db:status kafka:status redis:status`, and none should abort.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices