### PR TITLE
fix(devel): RHICOMPL-1947 run the test db prepare in the test env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
         bundle exec rake db:setup;
       fi;
       RAILS_ENV=test bundle exec rake db:create;
-      bundle exec rake db:test:prepare;
+      RAILS_ENV=test bundle exec rake db:test:prepare;
       bundle exec rails db < db/cyndi_setup_devel.sql;
       RAILS_ENV=test bundle exec rails db < db/cyndi_setup_test.sql;
       '


### PR DESCRIPTION
So apparently when `db:test:prepare` runs in any other environment, it messes up stuff :laughing: who would think that :see_no_evil: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
