### PR TITLE
fix(migration): RHICOMPL-1956 score profiles only when available

### DIFF
--- a/db/migrate/20210609081621_add_score_to_profiles.rb
+++ b/db/migrate/20210609081621_add_score_to_profiles.rb
@@ -4,21 +4,23 @@ class AddScoreToProfiles < ActiveRecord::Migration[5.2]
 
     Profile.transaction do
       scores = TestResult.latest.joins(:profile).group(:profile_id).average(:score)
-
       # Profile.canonical(false).where(score: nil).joins(:test_results).distinct.find_each(&:calculate_score!)
+
       # TODO: replace this with upsert after upgrading to Rails 6
-      values = scores.map do |k, v|
-        "(#{ActiveRecord::Base.connection.quote(k)}, #{ActiveRecord::Base.connection.quote(v)})"
-      end.join(', ')
+      if scores.any?
+        values = scores.map do |k, v|
+          "(#{ActiveRecord::Base.connection.quote(k)}, #{ActiveRecord::Base.connection.quote(v)})"
+        end.join(', ')
 
-      query = %{
-        UPDATE profiles P
-        SET score = uv.new_score
-        FROM (VALUES #{values}) AS uv (id, new_score)
-        WHERE P.id = uv.id::uuid
-      }.gsub(/\s+/, " ").strip
+        query = %{
+          UPDATE profiles P
+          SET score = uv.new_score
+          FROM (VALUES #{values}) AS uv (id, new_score)
+          WHERE P.id = uv.id::uuid
+        }.gsub(/\s+/, " ").strip
 
-      ActiveRecord::Base.connection.execute(query)
+        ActiveRecord::Base.connection.execute(query)
+      end
     end
   end
 


### PR DESCRIPTION
There's no need to run the query when there are no scores are available, also it would fail as the SQL is invalid without data.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
