### PR TITLE
perf(GraphQL): preload collections under systems with scoped context

### DIFF
--- a/app/graphql/types/concerns/system_profiles.rb
+++ b/app/graphql/types/concerns/system_profiles.rb
@@ -12,13 +12,18 @@ module Types
 
     def test_result_profiles(policy_id: nil)
       context_parent
-      scope_profiles(object.test_result_profiles, policy_id)
+      ::CollectionLoader.for(object.class, :test_result_profiles)
+                        .load(object).then do |profiles|
+        scope_profiles(profiles, policy_id)
+      end
     end
 
     def policies(policy_id: nil)
       context_parent
-      policy_profiles = object.assigned_profiles.external(false)
-      scope_profiles(policy_profiles, policy_id)
+      ::CollectionLoader.for(object.class, :assigned_internal_profiles)
+                        .load(object).then do |profiles|
+        scope_profiles(profiles, policy_id)
+      end
     end
 
     private

--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -61,7 +61,7 @@ module Types
     private
 
     def context_parent
-      context[:parent_system_id] = object.id
+      context.scoped_set!(:parent_system_id, object.id)
     end
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -26,6 +26,8 @@ class Host < ApplicationRecord
   has_many :test_result_profiles, through: :test_results, source: :profile
   has_many :policies, through: :policy_hosts
   has_many :assigned_profiles, through: :policies, source: :profiles
+  has_many :assigned_internal_profiles, -> { external(false) },
+           through: :policies, source: :profiles
 
   def self.os_minor_versions(hosts)
     distinct.where(id: hosts).pluck(OS_MINOR_VERSION)


### PR DESCRIPTION
This reintroduces the [previously](https://github.com/RedHatInsights/compliance-backend/pull/895) reverted [collection loader](https://github.com/RedHatInsights/compliance-backend/pull/845) for systems' child entities. The problem with the original PR was the lack of scoping in an asynchronous environment, that has been solved by using [`context.scoped_set`](https://github.com/rmosolgo/graphql-ruby/pull/2634) for setting the parent object's ID.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
