### PR TITLE
feat: RHICOMPL-1933 get datastream config from compliance-ssg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 
+config/supported_ssg.yaml
+
 brakeman_output.markdown
 
 Gemfile.local

--- a/app/services/ssg_config_downloader.rb
+++ b/app/services/ssg_config_downloader.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Service for dowloading SSG configuration files
+class SsgConfigDownloader
+  class << self
+    SSG_DS_FILE = File.new('config/supported_ssg.yaml')
+
+    def ssg_ds
+      File.read(SSG_DS_FILE)
+    end
+
+    def ssg_ds_checksum
+      Digest::MD5.file(SSG_DS_FILE).hexdigest
+    end
+
+    def update_ssg_ds
+      ssg_content = download(ssg_datastream_config_url)&.read
+      ssg_content && File.open(SSG_DS_FILE, 'w') do |f|
+        f.write(ssg_content)
+      end
+    end
+
+    def ssg_datastream_config_url
+      [
+        Settings.compliance_ssg_url,
+        Settings.supported_ssg_ds_config
+      ].join('/')
+    end
+
+    private
+
+    def download(url)
+      file = SafeDownloader.download(url)
+      Rails.logger.audit_success("Downloaded config from #{url}")
+      file
+    rescue StandardError => e
+      Rails.logger.audit_fail("Failed to download config from #{url}: #{e}")
+      nil
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,3 +29,4 @@ redis_cache_ssl: false
 slack_webhook: 'this is set through a env var in Openshift and not shared for security reasons'
 disable_rbac: 'false'
 async: true
+supported_ssg_ds_config: 'ssg-datastreams.yaml'

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -14,6 +14,7 @@ RSpec.configure do |config|
     stub_request(:get, /#{Settings.rbac_url}/)
       .to_return(status: 200,
                  body: { 'data': [{ 'permission': 'compliance:*:*' }] }.to_json)
+    stub_request(:get, /#{Settings.compliance_ssg_url}/).to_return(status: 404)
   end
 
   config.swagger_docs = {

--- a/test/models/supported_ssg_test.rb
+++ b/test/models/supported_ssg_test.rb
@@ -3,6 +3,23 @@
 require 'test_helper'
 
 class SupportedSsgTest < ActiveSupport::TestCase
+  test 'updates SSG config when changed' do
+    SupportedSsg.stubs(:ssg_ds_changed?).returns(true)
+
+    SupportedSsg.expects(:clear)
+
+    SupportedSsg.send(:raw_supported)
+  end
+
+  test 'detects when the SSG config is changed' do
+    SupportedSsg.send(:raw_supported) # init checksum
+
+    SsgConfigDownloader.stubs(:update_ssg_ds)
+    SsgConfigDownloader.stubs(:ssg_ds_checksum).returns('different')
+
+    assert SupportedSsg.send(:ssg_ds_changed?)
+  end
+
   test 'loads supported SSGs' do
     assert SupportedSsg.all
   end

--- a/test/services/ssg_config_downloader_test.rb
+++ b/test/services/ssg_config_downloader_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# A class to test the SsgConfigDownloader service
+class ConfigDownloaderTest < ActiveSupport::TestCase
+  setup do
+    @ds_config_file = File.new('config/supported_ssg.yaml')
+  end
+
+  test 'ssg_ds returns SSG datastream config file from disk' do
+    assert_equal @ds_config_file.read, SsgConfigDownloader.ssg_ds
+  end
+
+  test 'ssg_ds_checksum' do
+    assert_equal Digest::MD5.file(@ds_config_file).hexdigest,
+                 SsgConfigDownloader.ssg_ds_checksum
+  end
+
+  test 'update_ssg_ds success' do
+    SafeDownloader.expects(:download)
+
+    SsgConfigDownloader.update_ssg_ds
+    assert_audited 'Downloaded config'
+
+    assert_equal @ds_config_file.read, SsgConfigDownloader.ssg_ds
+  end
+
+  test 'update_ssg_ds handles failure gracefully' do
+    SafeDownloader.expects(:download).raises(StandardError)
+
+    SsgConfigDownloader.update_ssg_ds
+    assert_audited 'Failed to download config'
+
+    assert_equal @ds_config_file.read, SsgConfigDownloader.ssg_ds
+  end
+end


### PR DESCRIPTION
In addition to fetching the supported datastream config from compliance-ssg, this adds a ConfigDownloader which leverages the SafeDownloader to download config files. During failure to download, the backend still requires some kind of valid config, so the ConfigDownloader provides a fallback file fixture. This is also leveraged in our test environment, where no compliance-ssg service exists.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices