### PR TITLE
feat(REST): RHICOMPL-1284 implemented filtering by tags for systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ an identity header (i.e. rbac, remediations).
 
 To disable Prometheus (e.g. in develompent) clear `prometheus_exporter_host` setting (set to empty).
 
+### Tagging
+
+If there is a `tags` column defined in any model, it always should be a `jsonb` column and follow the structured representation of tags described in Insights, i.e. an array of hashes. If this convention is not kept, the controllers might break when a user tries to pass the `tags` attribute to a GET request.
+
 ## API documentation
 
 The API documentation can be found at `Settings.path_prefix/Settings.app_name`. To generate the docs, run `rake rswag:specs:swaggerize`. You may also get the OpenAPI definition at `Settings.path_prefix/Settings.app_name/v1/openapi.json`

--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -12,14 +12,25 @@ module Metadata
       response.headers['Content-Type'] = 'application/vnd.api+json'
     end
 
+    # This is part of a JSON schema, no need for strict metrics
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def metadata(opts = {})
       opts[:total] ||= resolve_collection.count
-      options = {}
-      options[:meta] = { total: opts[:total], search: params[:search],
-                         limit: pagination_limit, offset: pagination_offset }
-      options[:links] = links(last_offset(opts[:total]))
-      options
+
+      {
+        meta: {
+          total: opts[:total],
+          search: params[:search],
+          tags: tags_supported? ? params.fetch(:tags, []) : nil,
+          limit: pagination_limit,
+          offset: pagination_offset
+        }.compact,
+        links: links(last_offset(opts[:total]))
+      }
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     def links(last_offset)
       {

--- a/app/controllers/concerns/tag_filtering.rb
+++ b/app/controllers/concerns/tag_filtering.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Concern to support filtering by tags
+module TagFiltering
+  extend ActiveSupport::Concern
+
+  TAG_RIGHT_RE = %r{^([^\/]+)\/([^\=]+)(\=(.+))?}.freeze
+
+  included do
+    def parse_tags(tags = [])
+      tags.map { |tag| parse_tag(tag) }.compact
+    end
+
+    private
+
+    def parse_tag(tag)
+      namespace, key, _, value = tag.scan(TAG_RIGHT_RE).first
+
+      return nil if namespace.nil? || key.nil?
+
+      {
+        namespace: Rack::Utils.unescape(namespace),
+        key: Rack::Utils.unescape(key),
+        value: value && Rack::Utils.unescape(value)
+      }
+    end
+
+    def decode_value(str)
+      str.gsub(/\+|%\h\h/, URI::TBLDECWWWCOMP_)
+         .force_encoding(Encoding::UTF_8)
+         .scrub
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,9 @@ module ComplianceBackend
     # Attach audit logging for requests
     require 'audit_log/audit_log'
     config.middleware.use Insights::API::Common::AuditLog::Middleware
+    # Adjust params[tags] to be array
+    require 'adjust_tags/middleware'
+    config.middleware.use Insights::API::Common::AdjustTags::Middleware
 
     # GraphiQL
     if Rails.env.development?

--- a/lib/adjust_tags/middleware.rb
+++ b/lib/adjust_tags/middleware.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Common space for Insights API stuff
+module Insights
+  module API
+    module Common
+      module AdjustTags
+        # Rack middleware to adjust params[tags] to be an array
+        class Middleware
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            qs = env['QUERY_STRING'].sub(/^tags=/, 'tags[]=')
+                                    .gsub(/&tags=/, '&tags[]=')
+
+            # Match the QUERY_STRING at the end of the line only
+            re = /#{Regexp.quote(env['QUERY_STRING'])}$/
+
+            env['REQUEST_URI'] = env['REQUEST_URI'].sub(re, qs)
+            env['QUERY_STRING'] = qs
+
+            @app.call(env)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/api/v1/schemas.rb
+++ b/spec/api/v1/schemas.rb
@@ -33,6 +33,7 @@ module Api
         relationship_collection: RELATIONSHIP_COLLECTION,
         error: ERROR,
         metadata: METADATA,
+        tags: TAGS,
         host: HOST,
         host_relationships: HOST_RELATIONSHIPS,
         links: LINKS,

--- a/spec/api/v1/schemas/metadata.rb
+++ b/spec/api/v1/schemas/metadata.rb
@@ -23,6 +23,17 @@ module Api
             }
           }
         }.freeze
+
+        TAGS = {
+          type: 'array',
+          items: {
+            type: 'string',
+            properties: {
+              type: 'string',
+              example: 'insights/environment=production'
+            }
+          }
+        }.freeze
       end
     end
   end

--- a/spec/integration/systems_spec.rb
+++ b/spec/integration/systems_spec.rb
@@ -18,6 +18,7 @@ describe 'Systems API' do
       auth_header
       pagination_params
       search_params
+      tags_params
       sort_params
 
       include_param

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -88,6 +88,12 @@ def search_params
             schema: { type: :string, default: '' }
 end
 
+def tags_params
+  parameter name: :tags, in: :query, required: false, type: :array,
+            description: 'An array of tags to narrow down the results against.',
+            schema: { type: :array, items: { type: 'string' }, default: '' }
+end
+
 def sort_params
   parameter name: :sort_by, in: :query, required: false,
             type: { oneOf: [{ type: :string }, { type: :array }] },

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -2795,6 +2795,20 @@
             }
           },
           {
+            "name": "tags",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "description": "An array of tags to narrow down the results against.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": ""
+            }
+          },
+          {
             "name": "include",
             "in": "query",
             "type": "string",
@@ -3091,6 +3105,16 @@
           "filter": {
             "type": "string",
             "example": "name='Standard System Security Profile for Fedora'"
+          }
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "properties": {
+            "type": "string",
+            "example": "insights/environment=production"
           }
         }
       },

--- a/test/controllers/concerns/tag_filtering_test.rb
+++ b/test/controllers/concerns/tag_filtering_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TagFilteringTest < ActiveSupport::TestCase
+  class TagParserDummy
+    include TagFiltering
+  end
+
+  setup do
+    @parser = TagParserDummy.new
+  end
+
+  test '#parse_tags' do
+    {
+      %w[foo bar] => [],
+      ['foo/bar'] => [
+        {
+          namespace: 'foo',
+          key: 'bar',
+          value: nil
+        }
+      ],
+      ['foo/bar=baz%3Dar', 'foo/bar=x%3Dx%2F'] => [
+        {
+          namespace: 'foo',
+          key: 'bar',
+          value: 'baz=ar'
+        },
+        {
+          namespace: 'foo',
+          key: 'bar',
+          value: 'x=x/'
+        }
+      ]
+    }.each do |input, output|
+      assert_equal @parser.parse_tags(input), output
+    end
+  end
+end

--- a/test/lib/adjust_tags/middleware_test.rb
+++ b/test/lib/adjust_tags/middleware_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'adjust_tags/middleware'
+
+class MiddlewareTest < ActiveSupport::TestCase
+  class DummyRack
+    def call(env)
+      env
+    end
+  end
+
+  setup do
+    @mw = Insights::API::Common::AdjustTags::Middleware.new(DummyRack.new)
+  end
+
+  test 'replaces tags= with tags[]=' do
+    env = {
+      'QUERY_STRING' => 'x=y&tags=foo&tags=bar',
+      'REQUEST_URI' => 'http://localhost:3000/?x=y&tags=foo&tags=bar'
+    }
+    result = @mw.call(env)
+    assert_equal result['QUERY_STRING'], 'x=y&tags[]=foo&tags[]=bar'
+    assert_equal result['REQUEST_URI'], 'http://localhost:3000/?x=y&tags[]=foo&tags[]=bar'
+  end
+
+  test 'matches the query string only at the end of the uri' do
+    env = {
+      'QUERY_STRING' => 'x=y&tags=foo&tags=bar',
+      'REQUEST_URI' => 'http://localhost:3000/tags=foo/?x=y&tags=foo&tags=bar'
+    }
+    result = @mw.call(env)
+    assert_equal result['QUERY_STRING'], 'x=y&tags[]=foo&tags[]=bar'
+    assert_equal result['REQUEST_URI'], 'http://localhost:3000/tags=foo/?x=y&tags[]=foo&tags[]=bar'
+  end
+end


### PR DESCRIPTION
I traced back how Rails and Rack handle the parsing of the query string and found that the `Rack::Request::Env#query_parser` method holds the reference to their parser. So I am monkeypatching this single method in an initializer to hold our parser, which is just a delegation to the original parser with the addition of overriding the already parsed tags with our correct values.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
