### PR TITLE
fix(score): RHICOMPL-2026 search hosts based on the correct scoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ gem 'stronger_parameters'
 # Clowder config
 gem 'clowder-common-ruby'
 
+# Support for per request thread-local variables
+gem 'request_store'
+
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,8 @@ GEM
     redis (4.2.1)
     reline (0.1.4)
       io-console (~> 0.5)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.1)
@@ -396,6 +398,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 5.2.4, >= 5.2.4.4)
   redis (~> 4.0)
+  request_store
   rspec-rails
   rswag-api
   rswag-specs


### PR DESCRIPTION
When searching for hosts with a certain profile score we were calculating this score based on the number of passing rules, however, this is incorrect and also slow. Instead we should rely the score that is already set in the latest test results.
So this change should not just correct the searching, but also speed up the process when having a lot of records.

Closes https://github.com/RedHatInsights/compliance-backend/pull/910

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
