### PR TITLE
feat(auth): RHICOMPL-2035 Allow /rules endpoint via cert auth

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -8,7 +8,8 @@ module Authentication
 
   ALLOWED_CERT_BASED_RBAC_ACTIONS = [
     { controller: 'profiles', action: 'index' },
-    { controller: 'profiles', action: 'tailoring_file' }
+    { controller: 'profiles', action: 'tailoring_file' },
+    { controller: 'rules', action: 'index' }
   ].freeze
 
   included do


### PR DESCRIPTION
Remediations needs to request the /rules endpoint via cert auth with the
new RHC client.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices