### PR TITLE
fix(Host): RHICOMPL-2063 deduplicate Host#test_result_profiles

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -23,7 +23,8 @@ class Host < ApplicationRecord
   has_many :test_results, dependent: :destroy
   include SystemLike
 
-  has_many :test_result_profiles, through: :test_results, source: :profile
+  has_many :test_result_profiles, -> { distinct },
+           through: :test_results, source: :profile
   has_many :policies, through: :policy_hosts
   has_many :assigned_profiles, through: :policies, source: :profiles
   has_many :assigned_internal_profiles, -> { external(false) },

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -61,6 +61,15 @@ class SystemQueryTest < ActiveSupport::TestCase
         @host1.policies << p.policy
       end
 
+      # An outdated test result made in the past
+      FactoryBot.create(
+        :test_result,
+        profile: @profile1,
+        host: @host1,
+        end_time: 1.minute.ago,
+        score: 10
+      )
+
       FactoryBot.create(
         :rule_result,
         host: @host1,


### PR DESCRIPTION
When requesting profiles through test results under hosts, it is possible that the JOIN between the two tables produces duplicate profiles between the results if there are outdated test results for a given profile. All the other fields, like score are taken from the latest test result, so these values will be correct. As a solution I passed a `distinct` into the `scope` that resolves this problem.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
