### PR TITLE
feat(GraphQL): RHICOMPL-2037 allow filtering results by tags

### DIFF
--- a/app/controllers/concerns/collection.rb
+++ b/app/controllers/concerns/collection.rb
@@ -14,7 +14,9 @@ module Collection
     end
 
     def filter_by_tags(data)
-      return data unless tags_supported? && params[:tags]&.any?
+      unless TagFiltering.tags_supported?(resource) && params[:tags]&.any?
+        return data
+      end
 
       tags = parse_tags(params[:tags])
       data.where('tags @> ?', tags.to_json)
@@ -30,12 +32,6 @@ module Collection
       return data if params[:sort_by].blank?
 
       data.order(build_order_by(data.klass, params[:sort_by]))
-    end
-
-    private
-
-    def tags_supported?
-      resource.column_names.include?('tags')
     end
   end
 end

--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -13,7 +13,6 @@ module Metadata
     end
 
     # This is part of a JSON schema, no need for strict metrics
-    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def metadata(opts = {})
       opts[:total] ||= resolve_collection.count
@@ -22,14 +21,13 @@ module Metadata
         meta: {
           total: opts[:total],
           search: params[:search],
-          tags: tags_supported? ? params.fetch(:tags, []) : nil,
+          tags: tags,
           limit: pagination_limit,
           offset: pagination_offset
         }.compact,
         links: links(last_offset(opts[:total]))
       }
     end
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
     def links(last_offset)
@@ -88,6 +86,10 @@ module Metadata
     def meta_link(other_params = {})
       link_params = base_link_params.merge(other_params).compact
       "#{base_link_url}?#{link_params.to_query}"
+    end
+
+    def tags
+      TagFiltering.tags_supported?(resource) ? params.fetch(:tags, []) : nil
     end
   end
 end

--- a/app/controllers/concerns/tag_filtering.rb
+++ b/app/controllers/concerns/tag_filtering.rb
@@ -31,4 +31,8 @@ module TagFiltering
          .scrub
     end
   end
+
+  def self.tags_supported?(resource)
+    resource.column_names.include?('tags')
+  end
 end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -379,6 +379,11 @@ type Query implements Node {
     Sort results
     """
     sortBy: [String!]
+
+    """
+    Filter by tags
+    """
+    tags: [String!]
   ): SystemConnection!
   testResult(
     """


### PR DESCRIPTION
I (more or less) kept the same format as for the REST API, but here we can use proper arrays :wink: 
```
{
  "operationName": "getSystems",
  "query": "query getSystems($perPage: Int, $page: Int, $tags: [String!]) {
    systems(limit: $perPage, offset: $page, tags: $tags) {
      totalCount
      edges {
        node {
          id
          name
          osMajorVersion
          osMinorVersion
          __typename
        }
        __typename
      }
      __typename
    }
  }",
  "variables": {
    "perPage": 50,
    "page": 1, "tags": ["foo/bar=baz"]
  }
}
```


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
