### PR TITLE
fix: RHICOMPL-2035 Expose rules#show via cert-auth

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -9,7 +9,7 @@ module Authentication
   ALLOWED_CERT_BASED_RBAC_ACTIONS = [
     { controller: 'profiles', action: 'index' },
     { controller: 'profiles', action: 'tailoring_file' },
-    { controller: 'rules', action: 'index' }
+    { controller: 'rules', action: 'show' }
   ].freeze
 
   included do

--- a/test/controllers/v1/rules_controller_test.rb
+++ b/test/controllers/v1/rules_controller_test.rb
@@ -5,80 +5,138 @@ require 'test_helper'
 module V1
   class RulesControllerTest < ActionDispatch::IntegrationTest
     setup do
-      RulesController.any_instance.stubs(:authenticate_user).yields
       User.current = FactoryBot.create(:user)
       @profile = FactoryBot.create(:profile, :with_rules)
     end
 
-    test 'index lists all rules' do
-      RulesController.any_instance.expects(:policy_scope).with(Rule)
-                     .returns(Rule.all).at_least_once
-      get v1_rules_url
+    should 'allow access to rules#show with cert auth' do
+      account = User.current.account
 
-      assert_response :success
-    end
-
-    test 'finds a rule within the user scope' do
-      get v1_rule_url(@profile.rules.first.ref_id)
-      assert_response :success
-    end
-
-    should 'rules can be sorted' do
-      medium, high, u1, low, u2 = @profile.rules
-      high.update!(severity: 'high')
-      medium.update!(severity: 'medium')
-      low.update!(severity: 'low')
-      u1.update!(title: '1', severity: 'unknown')
-      u2.update!(title: 'b', severity: 'unknown')
-
-      get v1_rules_url, params: {
-        sort_by: %w[severity title:desc],
-        policy_id: @profile.policy.id
-      }
-      assert_response :success
-
-      result = JSON.parse(response.body)
-      rules = [u2, u1, low, medium, high].map(&:id)
-
-      assert_equal(rules, result['data'].map do |rule|
-        rule['id']
-      end)
-    end
-
-    should 'fail if wrong sort order is set' do
-      get v1_rules_url, params: { sort_by: ['title:foo'] }
-      assert_response :unprocessable_entity
-    end
-
-    should 'fail if sorting by wrong column' do
-      get v1_rules_url, params: { sort_by: ['foo'] }
-      assert_response :unprocessable_entity
-    end
-
-    test 'finds a rule with similar slug within the user scope' do
-      @profile.rules.first.update(
-        slug: "#{@profile.rules.first.ref_id}-#{SecureRandom.uuid}"
+      encoded_header = Base64.encode64(
+        {
+          'identity': {
+            'account_number': account.account_number,
+            'auth_type': IdentityHeader::CERT_AUTH
+          },
+          'entitlements':
+          {
+            'insights': {
+              'is_entitled': true
+            }
+          }
+        }.to_json
       )
-
-      get v1_rule_url(@profile.rules.first.ref_id)
+      HostInventoryApi.any_instance
+                      .expects(:hosts)
+                      .returns('results' => [:foo])
+      RbacApi.expects(:new).never
+      get rule_url(Rule.first),
+          headers: { 'X-RH-IDENTITY': encoded_header }
       assert_response :success
     end
 
-    test 'finds a rule by ID' do
-      get v1_rule_url(@profile.rules.first.id)
+    should 'disallow access to rules#index with cert auth' do
+      account = User.current.account
 
-      assert_response :success
+      encoded_header = Base64.encode64(
+        {
+          'identity': {
+            'account_number': account.account_number,
+            'auth_type': IdentityHeader::CERT_AUTH
+          },
+          'entitlements':
+          {
+            'insights': {
+              'is_entitled': true
+            }
+          }
+        }.to_json
+      )
+      HostInventoryApi.any_instance
+                      .expects(:hosts)
+                      .never
+      RbacApi.expects(:new).never
+      get rules_url,
+          headers: { 'X-RH-IDENTITY': encoded_header }
+      assert_response :forbidden
     end
 
-    test 'finds latest canonical rules' do
-      parent = FactoryBot.create(:canonical_profile, :with_rules, rule_count: 1)
+    context 'authenticated' do
+      setup do
+        RulesController.any_instance.stubs(:authenticate_user).yields
+      end
 
-      assert_includes(Rule.latest, parent.rules.last)
-      assert_not_includes(User.current.account.profiles.map(&:rules).uniq,
-                          parent.rules.last)
-      get v1_rule_url(parent.rules.last.ref_id)
+      should 'index lists all rules' do
+        RulesController.any_instance.expects(:policy_scope).with(Rule)
+                       .returns(Rule.all).at_least_once
+        get v1_rules_url
 
-      assert_response :success
+        assert_response :success
+      end
+
+      should 'finds a rule within the user scope' do
+        get v1_rule_url(@profile.rules.first.ref_id)
+        assert_response :success
+      end
+
+      should 'rules can be sorted' do
+        medium, high, u1, low, u2 = @profile.rules
+        high.update!(severity: 'high')
+        medium.update!(severity: 'medium')
+        low.update!(severity: 'low')
+        u1.update!(title: '1', severity: 'unknown')
+        u2.update!(title: 'b', severity: 'unknown')
+
+        get v1_rules_url, params: {
+          sort_by: %w[severity title:desc],
+          policy_id: @profile.policy.id
+        }
+        assert_response :success
+
+        result = JSON.parse(response.body)
+        rules = [u2, u1, low, medium, high].map(&:id)
+
+        assert_equal(rules, result['data'].map do |rule|
+          rule['id']
+        end)
+      end
+
+      should 'fail if wrong sort order is set' do
+        get v1_rules_url, params: { sort_by: ['title:foo'] }
+        assert_response :unprocessable_entity
+      end
+
+      should 'fail if sorting by wrong column' do
+        get v1_rules_url, params: { sort_by: ['foo'] }
+        assert_response :unprocessable_entity
+      end
+
+      should 'finds a rule with similar slug within the user scope' do
+        @profile.rules.first.update(
+          slug: "#{@profile.rules.first.ref_id}-#{SecureRandom.uuid}"
+        )
+
+        get v1_rule_url(@profile.rules.first.ref_id)
+        assert_response :success
+      end
+
+      should 'finds a rule by ID' do
+        get v1_rule_url(@profile.rules.first.id)
+
+        assert_response :success
+      end
+
+      should 'finds latest canonical rules' do
+        parent = FactoryBot.create(:canonical_profile, :with_rules,
+                                   rule_count: 1)
+
+        assert_includes(Rule.latest, parent.rules.last)
+        assert_not_includes(User.current.account.profiles.map(&:rules).uniq,
+                            parent.rules.last)
+        get v1_rule_url(parent.rules.last.ref_id)
+
+        assert_response :success
+      end
     end
   end
 end


### PR DESCRIPTION
Turn off rules#index via cert auth in favor of rules#show. The index
endpoint was added due to a misunderstanding on RHICOMPL-2035 of what
was needed by the remediations team.

CC @aleccohan

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices