### PR TITLE
feat: RHICOMPL-2076 Export metrics on each pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The Insights Compliance backend comprises of these components/services:
 * Sidekiq — job runner connected through Redis (see [app/jobs](app/jobs))
 * Inventory Consumer (racecar) — processor of Kafka messages,
   mainly to process and parse reports
-* Prometheus Exporter (optional) — providing metrics (port 9394)
 
 ### Dependent Services
 
@@ -335,10 +334,6 @@ Basic authentication ([`platform_basic_auth` option](config/settings/development
 might be needed for platform services such as inventory, rbac, and remediations.
 Anything not deployed locally will require basic auth instead of using
 an identity header (i.e. rbac, remediations).
-
-### Disabling Prometheus
-
-To disable Prometheus (e.g. in develompent) clear `prometheus_exporter_host` setting (set to empty).
 
 ### Tagging
 

--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-if Settings.prometheus_exporter_host.present?
-  require 'prometheus_exporter/client'
-end
+require 'prometheus_exporter/client'
 require 'compliance_timeout'
 require_relative 'types/query'
 require_relative 'types/mutation'
@@ -11,9 +9,7 @@ require_relative 'types/mutation'
 # GraphQL-ruby documentation to find out what to add or
 # remove here.
 class Schema < GraphQL::Schema
-  if Settings.prometheus_exporter_host.present?
-    use GraphQL::Tracing::PrometheusTracing
-  end
+  use GraphQL::Tracing::PrometheusTracing
   use ComplianceTimeout, max_seconds: 20
   query Types::Query
   mutation Types::Mutation

--- a/app/services/openshift_environment.rb
+++ b/app/services/openshift_environment.rb
@@ -4,7 +4,7 @@
 module OpenshiftEnvironment
   class << self
     def environment
-      (Settings.prometheus_exporter_host || '').split('.')[1]
+      namespace&.send(:[], /(ci|qa|eph|stage|prod)/) || 'dev'
     end
 
     def application

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -5,14 +5,6 @@ metadata:
   name: "${APP_NAME}"
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
-  metadata:
-    name: compliance
-  spec:
-    appName: compliance
-    jobs:
-      - import-ssg
-- apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
     name: "${APP_NAME}"
@@ -42,31 +34,17 @@ objects:
       enabled: true
       appName: "compliance"
       insightsOnly: true
-    jobs:
-    - name: compliance-import-ssg
+    deployments:
+    - name: db-migrations
       podSpec:
-        imagePullPolicy: Always
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:
         - command:
             - bash
             - -c
             - |
-              for i in {1..120}; do sleep 1;
-              if bundle exec rake --trace db:abort_if_pending_migrations;
-              then exit 0; fi; done; exit 1
-          env:
-          - name: RAILS_ENV
-            value: "${RAILS_ENV}"
-          - name: PATH_PREFIX
-            value: "${PATH_PREFIX}"
-          - name: POSTGRESQL_MAX_CONNECTIONS
-            value: ${POSTGRESQL_MAX_CONNECTIONS}
-          - name: RAILS_LOG_TO_STDOUT
-            value: "${RAILS_LOG_TO_STDOUT}"
-          # Should be a secret ?
-          - name: SECRET_KEY_BASE
-            value: "secret_key_base"
+              bundle exec rake --trace db:debug db:migrate
+          inheritEnv: true
         resources:
           limits:
             cpu: ${CPU_LIMIT_SIDE}
@@ -76,7 +54,7 @@ objects:
             memory: ${MEMORY_REQUEST_SIDE}
         env:
         - name: APPLICATION_TYPE
-          value: compliance-import-ssg
+          value: sleep
         - name: RAILS_ENV
           value: "${RAILS_ENV}"
         - name: RAILS_LOG_TO_STDOUT
@@ -85,16 +63,45 @@ objects:
           value: "${PATH_PREFIX}"
         - name: APP_NAME
           value: "${APP_NAME}"
-        - name: SIDEKIQ_CONCURRENCY
-          value: "${SIDEKIQ_CONCURRENCY}"
-        - name: RAILS_MAX_THREADS
-          value: "${RAILS_MAX_THREADS}"
         - name: JOBS_ACCOUNT_NUMBER
           value: ${JOBS_ACCOUNT_NUMBER}
         # Should be a secret ?
         - name: SECRET_KEY_BASE
           value: "secret_key_base"
-    deployments:
+    - name: compliance-import-ssg
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command:
+            - bash
+            - -c
+            - |
+              while ! bundle exec rake --trace db:abort_if_pending_migrations; do sleep 1; done;
+              bundle exec rake ssg:import_rhel_supported --trace
+          inheritEnv: true
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_SIDE}
+            memory: ${MEMORY_LIMIT_SIDE}
+          requests:
+            cpu: ${CPU_REQUEST_SIDE}
+            memory: ${MEMORY_REQUEST_SIDE}
+        env:
+        - name: APPLICATION_TYPE
+          value: sleep
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: JOBS_ACCOUNT_NUMBER
+          value: ${JOBS_ACCOUNT_NUMBER}
+        # Should be a secret ?
+        - name: SECRET_KEY_BASE
+          value: "secret_key_base"
     - name: compliance-backend
       # TODO: Check how to auto-scale with Clowder
       minReplicas: ${{REPLICAS_BACKEND}}
@@ -102,7 +109,6 @@ objects:
         public:
           enabled: true
       podSpec:
-        imagePullPolicy: Always
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:
         - command:
@@ -164,79 +170,10 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_SERV}
             memory: ${MEMORY_REQUEST_SERV}
-    - name: compliance-prometheus-exporter
-      minReplicas: ${{REPLICAS_PROMETHEUS}}
-      webServices:
-        private:
-          enabled: true
-      podSpec:
-        imagePullPolicy: Always
-        image: ${IMAGE}:${IMAGE_TAG}
-        initContainers:
-        - command:
-          - bash
-          - -c
-          - |
-            set -e
-            RAILS_ENV="${RAILS_ENV}" bundle exec rake --trace db:debug db:migrate
-          resources:
-            limits:
-              cpu: ${CPU_LIMIT_SIDE}
-              memory: ${MEMORY_LIMIT_SIDE}
-            requests:
-              cpu: ${CPU_REQUEST_SIDE}
-              memory: ${MEMORY_REQUEST_SIDE}
-          env:
-          - name: RAILS_ENV
-            value: "${RAILS_ENV}"
-          - name: PATH_PREFIX
-            value: "${PATH_PREFIX}"
-          - name: RAILS_LOG_TO_STDOUT
-            value: "${RAILS_LOG_TO_STDOUT}"
-          # Should be a secret ?
-          - name: SECRET_KEY_BASE
-            value: "secret_key_base"
-          - name: JOBS_ACCOUNT_NUMBER
-            value: ${JOBS_ACCOUNT_NUMBER}
-        env:
-        - name: APPLICATION_TYPE
-          value: compliance-prometheus-exporter
-        - name: RAILS_ENV
-          value: "${RAILS_ENV}"
-        - name: PATH_PREFIX
-          value: "${PATH_PREFIX}"
-        - name: APP_NAME
-          value: "${APP_NAME}"
-        - name: RAILS_LOG_TO_STDOUT
-          value: "${RAILS_LOG_TO_STDOUT}"
-        - name: SETTINGS__REDIS_SSL
-          value: "${REDIS_SSL}"
-        - name: SETTINGS__REDIS_CACHE_SSL
-          value: "${REDIS_SSL}"
-        # Should be a secret ?
-        - name: SECRET_KEY_BASE
-          value: "secret_key_base"
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: private
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: private
-        resources:
-          limits:
-            cpu: ${CPU_LIMIT_PROM}
-            memory: ${MEMORY_LIMIT_PROM}
-          requests:
-            cpu: ${CPU_REQUEST_PROM}
-            memory: ${MEMORY_REQUEST_PROM}
-
     - name: compliance-inventory
       # TODO: check requreiment for RDS CA and Kafka Cert with Clowder
       minReplicas: ${{REPLICAS_CONSUMER}}
       podSpec:
-        imagePullPolicy: Always
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:
         - command:
@@ -302,7 +239,6 @@ objects:
       # TODO: check requreiment for RDS CA and Kafka Cert with Clowder
       minReplicas: ${{REPLICAS_SIDEKIQ}}
       podSpec:
-        imagePullPolicy: Always
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:
         - command:
@@ -368,9 +304,6 @@ parameters:
   value: quay.io/cloudservices/compliance-backend
 - description: ClowdEnv Name
   name: ENV_NAME
-- description: Replica count for prometheus-exporter
-  name: REPLICAS_PROMETHEUS
-  value: "1"
 - description: Replica count for backend service
   name: REPLICAS_BACKEND
   value: "1"

--- a/config/initializers/0_clowder-config.rb
+++ b/config/initializers/0_clowder-config.rb
@@ -14,9 +14,6 @@ if ClowderCommonRuby::Config.clowder_enabled?
   rbac_config = config.dependency_endpoints.dig('rbac', 'service')
   rbac_url = "http://#{rbac_config&.hostname}:#{rbac_config&.port}"
 
-  # Prometheus
-  prometheus_exporter_config = config.private_dependency_endpoints&.dig('compliance', 'prometheus-exporter')
-
   # Inventory
   host_inventory_config = config.dependency_endpoints&.dig('host-inventory', 'service')
   host_inventory_url = "http://#{host_inventory_config&.hostname}:#{host_inventory_config&.port}"
@@ -40,14 +37,14 @@ if ClowderCommonRuby::Config.clowder_enabled?
       payload_tracker: config.kafka_topics&.dig('platform.payload-status', 'name'),
       remediation_updates: config.kafka_topics&.dig('platform.remediation-updates.compliance', 'name')
     },
-    prometheus_exporter_host: prometheus_exporter_config&.hostname,
-    prometheus_exporter_port: prometheus_exporter_config&.port,
     rbac_url: rbac_url,
     redis_url: redis_url,
     redis_password: redis_password,
     remediations_url: remediations_url,
     host_inventory_url: host_inventory_url,
-    clowder_config_enabled: true
+    clowder_config_enabled: true,
+    prometheus_exporter_port: config&.metricsPort,
+    prometheus_exporter_host: '127.0.0.1'
   }
 
   Settings.add_source!(clowder_config)

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,18 +1,47 @@
-if Settings.prometheus_exporter_host.present? && !$0.include?('prometheus_exporter')
+unless Rails.env.test?
+  require 'prometheus_exporter'
   require 'prometheus_exporter/client'
   require 'prometheus_exporter/metric'
   require 'prometheus_exporter/middleware'
   require 'prometheus_exporter/instrumentation'
-  client = PrometheusExporter::Client.new(
+
+  def ensure_exporter_server
+    require 'socket'
+    TCPSocket.open(Settings.prometheus_exporter_host, Settings.prometheus_exporter_port) {}
+  rescue Errno::ECONNREFUSED
+    start_exporter_server
+  end
+
+  def start_exporter_server
+    require 'prometheus_exporter/server'
+
+    server = PrometheusExporter::Server::WebServer.new(port: Settings.prometheus_exporter_port)
+    server.start
+
+    if $0.include?('puma')
+      require './lib/prometheus/graphql_collector'
+      require './lib/prometheus/engineering_collector'
+      require './lib/prometheus/business_collector'
+
+      server.collector.register_collector(GraphQLCollector.new)
+      server.collector.register_collector(EngineeringCollector.new)
+      server.collector.register_collector(BusinessCollector.new)
+    end
+  rescue Errno::EADDRINUSE
+  end
+
+  ensure_exporter_server unless $0.include?('prometheus_exporter')
+
+  PrometheusExporter::Client.default = PrometheusExporter::Client.new(
     host: Settings.prometheus_exporter_host,
     port: Settings.prometheus_exporter_port
-    # Add custom_labels for app_name here (consumer and webserver)
   )
-  PrometheusExporter::Metric::Base.default_prefix = 'compliance'
-  PrometheusExporter::Client.default = client
 
-  # This reports stats per request like HTTP status and timings
+  PrometheusExporter::Metric::Base.default_prefix = 'compliance'
+
+  # stats per request like HTTP status and timings
   Rails.application.middleware.unshift PrometheusExporter::Middleware
+
+  # basic process stats like RSS and GC info
   PrometheusExporter::Instrumentation::Process.start(type: "master")
-  PrometheusExporter::Instrumentation::Process.start(type: "web")
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,24 +9,20 @@ sidekiq_config = lambda do |config|
   }
   Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
 
-  if Settings.prometheus_exporter_host.present?
-    config.server_middleware do |chain|
-      require 'prometheus_exporter/instrumentation'
-      chain.add PrometheusExporter::Instrumentation::Sidekiq
-    end
-    config.on :startup do
-      require 'prometheus_exporter/instrumentation'
-      PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
-    end
-    config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+  config.server_middleware do |chain|
+    require 'prometheus_exporter/instrumentation'
+    chain.add PrometheusExporter::Instrumentation::Sidekiq
+  end
+  config.on :startup do
+    require 'prometheus_exporter/instrumentation'
+    PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
+  end
+  config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
 
-    at_exit do
-      PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
-    end
+  at_exit do
+    PrometheusExporter::Client.default.stop(wait_timeout_seconds: 10)
   end
 end
-
-return if $0.include?('prometheus_exporter')
 
 if $0.include?('sidekiq')
   Sidekiq.configure_server(&sidekiq_config)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,8 +41,6 @@ environment ENV.fetch('RAILS_ENV') { 'development' }
 plugin :tmp_restart
 
 after_worker_boot do
-  if Settings.prometheus_exporter_host.present?
-    require 'prometheus_exporter/instrumentation'
-    PrometheusExporter::Instrumentation::Puma.start
-  end
+  require 'prometheus_exporter/instrumentation'
+  PrometheusExporter::Instrumentation::Puma.start(type: 'puma')
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,7 +18,7 @@ host_inventory_url: http://insights-inventory.platform-ci.svc.cluster.local:8080
 remediations_url: https://ci.cloud.redhat.com
 rbac_url: http://rbac.rbac-ci.svc.cluster.local:9002
 report_download_ssl_only: false
-prometheus_exporter_host: compliance-prometheus-exporter.compliance-ci.svc
+prometheus_exporter_host: '127.0.0.1'
 prometheus_exporter_port: 9394
 redis_url: compliance-redis.compliance-ci.svc.cluster.local:6379
 redis_password:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,7 +4,7 @@ rbac_url: https://ci.console.redhat.com
 # disable_rbac: true
 # platform_basic_auth_username: myusername
 # platform_basic_auth_password: secret
-prometheus_exporter_host: prometheus
+prometheus_exporter_host: '127.0.0.1'
 prometheus_exporter_port: 9394
 redis_url: localhost:6379
 redis_cache_url: localhost:6379

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,6 @@
 host_inventory_url: http://insights-inventory.platform-prod.svc:8080
 rbac_url: http://rbac.rbac-prod.svc.cluster.local:9002
-prometheus_exporter_host: compliance-prometheus-exporter.compliance-prod.svc
+prometheus_exporter_host: '127.0.0.1'
 prometheus_exporter_port: 9394
 report_download_ssl_only: true
 redis_url: compliance-redis:6379

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,2 @@
 host_inventory_url: http://test-host-inventory:8000
 rbac_url: http://test-rbac-url:9002
-# Disable Prometheus
-prometheus_exporter_host:

--- a/devel.json
+++ b/devel.json
@@ -1,7 +1,7 @@
 {
     "webPort": 8000,
-    "metricsPort": 9000,
-    "privatePort": 9394,
+    "metricsPort": 9090,
+    "privatePort": 10000,
     "metricsPath": "/metrics",
     "logging": {
         "type": "cloudwatch",
@@ -77,12 +77,6 @@
         }
     ],
     "privateEndpoints": [
-        {
-            "name": "prometheus-exporter",
-            "app": "compliance",
-            "hostname": "prometheus",
-            "port": 9394
-        },
         {
             "name": "service",
             "app": "compliance-ssg",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,10 +155,8 @@ services:
       - .:/app:z
     depends_on:
       - db
-      - prometheus
     links:
       - db
-      - prometheus
     environment:
       - POSTGRESQL_TEST_DATABASE=compliance_test
       - ACG_CONFIG=/app/devel.json
@@ -171,15 +169,12 @@ services:
       - .:/app:z
     depends_on:
       - db
-      - prometheus
       - compliance-ssg
     links:
       - db
-      - prometheus
       - compliance-ssg
     environment:
       - POSTGRESQL_TEST_DATABASE=compliance_test
-      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
       - ACG_CONFIG=/app/devel.json
   rails:
     env_file: .env
@@ -201,12 +196,10 @@ services:
       - .:/app:z
     depends_on:
       - db
-      - prometheus
       - redis
       - compliance-ssg
     links:
       - db
-      - prometheus
       - redis
       - compliance-ssg
   inventory-consumer:
@@ -223,26 +216,10 @@ services:
       - .:/app:z
     depends_on:
       - db
-      - prometheus
       - kafka
     links:
       - db
-      - prometheus
       - kafka
-  prometheus:
-    image: compliance-backend-rails
-    tty: true
-    environment:
-      - RAILS_ENV=development
-      - RAILS_LOG_TO_STDOUT=true
-      - HOSTNAME=prometheus
-      - ACG_CONFIG=/app/devel.json
-    restart: on-failure
-    volumes:
-      - .:/app:z
-    ports:
-      - '9394:9394'
-    command: bundle exec prometheus_exporter -b 0.0.0.0 -t 50 --verbose -a lib/prometheus/graphql_collector.rb -a lib/prometheus/business_collector.rb -a lib/prometheus/engineering_collector.rb
   sidekiq:
     image: compliance-backend-rails
     restart: on-failure

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,11 +68,12 @@ elif [ "$APPLICATION_TYPE" = "compliance-prometheus-exporter" ]; then
 
   echo "PORT:$PORT"
   exec bundle exec prometheus_exporter -b 0.0.0.0 --port "$PORT" --prefix compliance_ -t 50 --verbose -a lib/prometheus/graphql_collector.rb -a lib/prometheus/business_collector.rb
-
 elif [ "$APPLICATION_TYPE" = "compliance-import-remediations" ]; then
   exec bundle exec rake import_remediations --trace
 elif [ "$APPLICATION_TYPE" = "compliance-import-ssg" ]; then
   exec bundle exec rake ssg:import_rhel_supported --trace
+elif [ "$APPLICATION_TYPE" = "sleep" ]; then
+  while true; do sleep 60; done
 else
   echo "Application type '$APPLICATION_TYPE' not supported"
 fi

--- a/lib/prometheus/graphql_collector.rb
+++ b/lib/prometheus/graphql_collector.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'graphql/tracing'
+require 'graphql/tracing' if $0.include?('prometheus_exporter')
+require 'graphql/tracing/prometheus_tracing/graphql_collector'
 
 class GraphQLCollector < GraphQL::Tracing::PrometheusTracing::GraphQLCollector
 end


### PR DESCRIPTION
To test, spin up an ephemeral environment against this IMAGE_TAG and template ref:

```sh
IMAGE_TAG=$(git rev-parse --short=7 HEAD);
TEMPLATE_REF=$(git rev-parse HEAD)
bonfire deploy -sappsre --no-remove-resources compliance -i quay.io/cloudservices/compliance-backend=$IMAGE_TAG --single-replicas --set-template-ref compliance=$TEMPLATE_REF compliance
```

Check in each of the three pods (backend, sidekiq, consumer) that metrics are exposed:

```sh
oc rsh <pod>
$ curl localhost:9000/metrics | less
```

Sidekiq should report sidekiq metrics (only once at least one job is processed), the backend should be the only pod containing DB related metrics (i.e. `complianceclient_policies_by_os_major`), and all pods should have process related metrics (memory/cpu usage, etc).

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices