### PR TITLE
fix(REST): RHICOMPL-2109 deterministic pagination

### DIFF
--- a/app/controllers/concerns/collection.rb
+++ b/app/controllers/concerns/collection.rb
@@ -29,8 +29,6 @@ module Collection
     end
 
     def sort(data)
-      return data if params[:sort_by].blank?
-
       data.order(build_order_by(data.klass, params[:sort_by]))
     end
   end

--- a/app/controllers/concerns/sorting.rb
+++ b/app/controllers/concerns/sorting.rb
@@ -8,7 +8,14 @@ module Sorting
 
   included do
     def build_order_by(model, *fields)
-      fields.flatten.each_with_object({}) do |field, obj|
+      order = build_fields_order_by(model, *fields)
+      # add id for deterministic pagination
+      order[:id] = :asc unless order.include?(:id)
+      order
+    end
+
+    def build_fields_order_by(model, *fields)
+      fields.compact.flatten.each_with_object({}) do |field, obj|
         column, direction = field.underscore.split(':')
 
         unless model::SORTABLE_BY.key?(column.to_sym)

--- a/test/controllers/concerns/collection_test.rb
+++ b/test/controllers/concerns/collection_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ControlleCollectionTest < ActionDispatch::IntegrationTest
+  setup do
+    ApplicationController.any_instance
+                         .expects(:authenticate_user)
+                         .at_least_once
+                         .yields
+    User.current = FactoryBot.create(:user)
+  end
+
+  test 'deterministic pagination' do
+    created_profiles = FactoryBot.create_list(
+      :profile, 44,
+      name: 'The same name',
+      parent_profile_id: nil
+    )
+
+    collected_profiles = []
+    url_path = v1_profiles_url
+    params = { search: '', sort_by: 'name' }
+    100.times do
+      get url_path, params: params
+      assert_response :success
+      data = JSON.parse(response.body)
+
+      batch = data['data']
+      batch_ids = batch.map { |p| p['id'] }.to_set
+      collected_ids = collected_profiles.map { |p| p['id'] }.to_set
+      intersection = collected_ids.intersection(batch_ids)
+
+      assert_equal 0, intersection.count,
+                   'Intersected items from previous page(s):' \
+                   " #{intersection}"
+
+      collected_profiles.append(*batch)
+
+      url_path = data.dig('links', 'next')
+      break unless url_path
+
+      params = { sort_by: 'name' }
+    end
+
+    assert_equal created_profiles.count, collected_profiles.count
+    created_ids = created_profiles.map(&:id).to_set
+    assert_equal created_profiles.count, created_ids.count
+    collected_ids = collected_profiles.map { |p| p['id'] }.to_set
+    assert_equal 0, (created_ids - collected_ids).count
+  end
+end

--- a/test/graphql/resolvers/collection_test.rb
+++ b/test/graphql/resolvers/collection_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GraphQLCollectionTest < ActiveSupport::TestCase
+  setup do
+    @user = FactoryBot.create(:user)
+    User.current = @user
+  end
+
+  test 'deterministic pagination' do
+    @num_created = 44
+    @per_page = 10
+
+    created_profiles = FactoryBot.create_list(
+      :profile, @num_created,
+      name: 'The same name',
+      parent_profile_id: nil
+    )
+
+    collected_ids = Set.new
+    pages = (@num_created / @per_page.to_f).ceil
+
+    pages.times do |page|
+      query = <<-GRAPHQL
+        query Profiles($offset: Int, $limit: Int){
+          profiles(search: "", sortBy: ["name"], offset: $offset, limit: $limit) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = Schema.execute(
+        query,
+        variables: { limit: @per_page, offset: page + 1 },
+        context: { current_user: @user }
+      )
+      batch = result.dig('data', 'profiles', 'edges').map do |edge|
+        edge['node']
+      end
+
+      batch_ids = batch.map { |p| p['id'] }.to_set
+      intersection = collected_ids.intersection(batch_ids)
+
+      assert_equal 0, intersection.count,
+                   'Intersected items from previous page(s):' \
+                   " #{intersection}"
+
+      collected_ids.merge(batch_ids)
+    end
+
+    assert_equal created_profiles.count, collected_ids.count
+    created_ids = created_profiles.map(&:id).to_set
+    assert_equal created_profiles.count, created_ids.count
+    assert_equal 0, (created_ids - collected_ids).count
+  end
+end


### PR DESCRIPTION
Ordering database resources by a field that contains duplicate
values with a queried set does not give deterministic result to
paginate.

This should fix pagination within REST API by adding unique id into the
ORDER BY.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
