### PR TITLE
feat(grafana): RHICOMPL-2097 piechart of systems by OS version

### DIFF
--- a/dashboards/grafana-dashboard-insights-compliance-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-compliance-general.configmap.yaml
@@ -2806,6 +2806,118 @@ data:
           "steppedLine": false,
           "timeFrom": null,
           "timeShift": null
+        },
+        {
+          "datasource": "$datasource",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 23763571993,
+          "links": [],
+          "targets": [
+            {
+              "expr": "sum(compliance_total_systems_by_os) by (version)",
+              "legendFormat": "{{version}}",
+              "interval": "",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total number of systems reporting by OS version",
+          "type": "grafana-piechart-panel",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "pluginVersion": "7.2.1",
+          "pieType": "pie",
+          "legend": {
+            "show": true,
+            "values": true,
+            "header": "Count",
+            "percentage": true
+          },
+          "interval": null,
+          "cacheTimeout": null,
+          "nullPointMode": "connected",
+          "legendType": "Right side",
+          "breakPoint": "50%",
+          "aliasColors": {},
+          "format": "string",
+          "valueName": "current",
+          "strokeWidth": 1,
+          "fontSize": "80%",
+          "combine": {
+            "threshold": 0,
+            "label": "Others"
+          },
+          "description": "",
+          "decimals": null
+        },
+        {
+          "datasource": "$datasource",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 23763571993,
+          "links": [],
+          "targets": [
+            {
+              "expr": "sum(compliance_client_systems_by_os) by (version)",
+              "legendFormat": "{{version}}",
+              "interval": "",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Client number of systems reporting by OS version",
+          "type": "grafana-piechart-panel",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "pluginVersion": "7.2.1",
+          "pieType": "pie",
+          "legend": {
+            "show": true,
+            "values": true,
+            "header": "Count",
+            "percentage": true
+          },
+          "interval": null,
+          "cacheTimeout": null,
+          "nullPointMode": "connected",
+          "legendType": "Right side",
+          "breakPoint": "50%",
+          "aliasColors": {},
+          "format": "string",
+          "valueName": "current",
+          "strokeWidth": 1,
+          "fontSize": "80%",
+          "combine": {
+            "threshold": 0,
+            "label": "Others"
+          },
+          "description": "",
+          "decimals": null
         }
       ],
       "refresh": false,


### PR DESCRIPTION
There's actually 2 pie charts, one for the total and one for the client systems. I guess we don't care that much about the trend of this graph, but I can add that one in a followup PR as well.

![Screenshot from 2021-08-18 12-59-18](https://user-images.githubusercontent.com/649130/129886863-56d25230-20e9-4969-bd16-1e8e9f0190c3.png)

Depends on: https://github.com/RedHatInsights/compliance-backend/pull/957