### PR TITLE
devel: RHICOMPL-2160 Build and push the image during pr_check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -2,6 +2,21 @@
 
 set -exv
 
+# Install bonfire repo/initialize
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+export APP_NAME="compliance"  # name of app-sre "application" folder this component lives in
+export COMPONENT_NAME="compliance"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+export IMAGE="quay.io/cloudservices/compliance-backend"
+cat /etc/redhat-release
+
+# build the PR commit image
+source $CICD_ROOT/build.sh
+
 # Make directory for artifacts
 mkdir -p artifacts
 


### PR DESCRIPTION
Just the image building parts of https://github.com/RedHatInsights/compliance-backend/pull/921. This helps development by building the image on each PR so it can be specified for testing in bonfire deployments.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices