### PR TITLE
cleanup(tests): RHICOMPL-2183 use response.parsed_body everywhere

### DIFF
--- a/test/controllers/concerns/collection_test.rb
+++ b/test/controllers/concerns/collection_test.rb
@@ -24,7 +24,7 @@ class ControlleCollectionTest < ActionDispatch::IntegrationTest
     100.times do
       get url_path, params: params
       assert_response :success
-      data = JSON.parse(response.body)
+      data = response.parsed_body
 
       batch = data['data']
       batch_ids = batch.map { |p| p['id'] }.to_set

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -163,7 +163,7 @@ module V1
     end
 
     def parsed_data
-      JSON.parse(response.body).dig('data')
+      response.parsed_body.dig('data')
     end
 
     class TailoringFileTest < ProfilesControllerTest
@@ -200,7 +200,7 @@ module V1
         get v1_profiles_url
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
         assert_equal 1, profiles['data'].length
         assert_equal profile.policy_profile_id,
                      profiles.dig('data', 0, 'attributes', 'policy_profile_id')
@@ -218,7 +218,7 @@ module V1
 
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
 
         assert_equal(%w[a b], profiles['data'].map do |profile|
           profile['attributes']['name']
@@ -239,7 +239,7 @@ module V1
 
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
 
         assert_equal(%w[b a], profiles['data'].map do |profile|
           profile['attributes']['name']
@@ -257,7 +257,7 @@ module V1
         }
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
 
         assert_equal(%w[2 1 3], profiles['data'].map do |profile|
           profile['attributes']['os_minor_version']
@@ -280,7 +280,7 @@ module V1
         get v1_profiles_url, params: { search: search_query }
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
         assert_equal 1, profiles['data'].length
         assert_equal profile.id, profiles['data'].first['id']
       end
@@ -291,7 +291,7 @@ module V1
         get v1_profiles_url, params: { search: search_query }
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
         assert_equal 1, profiles['data'].length
         assert_equal profile.parent_profile.id, profiles['data'].first['id']
       end
@@ -300,7 +300,7 @@ module V1
         get v1_profiles_url
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
         assert_empty profiles['data']
       end
 
@@ -310,7 +310,7 @@ module V1
         get v1_profiles_url
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
         assert_equal profile.parent_profile.name,
                      profiles.dig('data', 0, 'attributes', 'policy_type')
       end
@@ -321,7 +321,7 @@ module V1
         get v1_profiles_url
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
         assert_equal profile.id, profiles['data'].first['id']
       end
 
@@ -336,7 +336,7 @@ module V1
         get v1_profiles_url, params: { search: search_query }
         assert_response :success
 
-        profiles = JSON.parse(response.body)
+        profiles = response.parsed_body
         returned_ids = profiles['data'].map { |p| p['id'] }
         assert_equal 3, profiles['data'].length
         assert_includes returned_ids, internal.id
@@ -374,7 +374,7 @@ module V1
         get v1_profiles_url, params: { search: search_query }
         assert_response :success
 
-        profiles = JSON.parse(response.body)['data']
+        profiles = response.parsed_body['data']
         assert_equal 2, profiles.length
 
         profiles.each do |returned_profile|
@@ -395,7 +395,7 @@ module V1
         get v1_profiles_url, params: { search: 'external = true' }
         assert_response :success
 
-        returned_profiles = JSON.parse(response.body)['data']
+        returned_profiles = response.parsed_body['data']
 
         assert_equal 1, returned_profiles.length
 
@@ -418,7 +418,7 @@ module V1
         get v1_profile_url(@profile.id)
         assert_response :success
 
-        body = JSON.parse(response.body)
+        body = response.parsed_body
         assert_equal @profile.policy_profile_id,
                      body.dig('data', 'attributes', 'policy_profile_id')
       end
@@ -427,8 +427,8 @@ module V1
         get v1_profile_url(@profile.id)
         assert_response :success
 
-        assert_not_nil JSON.parse(response.body).dig('data', 'attributes',
-                                                     'os_minor_version')
+        assert_not_nil response.parsed_body.dig('data', 'attributes',
+                                                'os_minor_version')
       end
     end
 
@@ -447,7 +447,7 @@ module V1
         end
         assert_response :success
         assert_equal 202, response.status, 'Response should be 202 accepted'
-        assert_equal profile_id, JSON.parse(response.body).dig('data', 'id'),
+        assert_equal profile_id, response.parsed_body.dig('data', 'id'),
                      'Profile ID did not match deleted profile'
         assert_audited 'Removed profile'
         assert_audited profile_id
@@ -460,7 +460,7 @@ module V1
         end
         assert_response :success
         assert_equal 202, response.status, 'Response should be 202 accepted'
-        assert_equal profile_id, JSON.parse(response.body).dig('data', 'id'),
+        assert_equal profile_id, response.parsed_body.dig('data', 'id'),
                      'Profile ID did not match deleted profile'
         assert_audited 'Removed profile'
         assert_audited profile_id
@@ -480,7 +480,7 @@ module V1
         end
         assert_response :success
         assert_equal 202, response.status, 'Response should be 202 accepted'
-        assert_equal profile_id, JSON.parse(response.body).dig('data', 'id'),
+        assert_equal profile_id, response.parsed_body.dig('data', 'id'),
                      'Profile ID did not match deleted profile'
         assert_audited 'Removed profile'
         assert_audited profile_id
@@ -535,7 +535,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: data',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'create with invalid data' do
@@ -544,7 +544,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'data must be a hash',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'create with empty attributes' do
@@ -553,7 +553,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: data',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'create with invalid attributes' do
@@ -562,7 +562,7 @@ module V1
         end
         assert_response :unprocessable_entity
         assert_match 'attributes must be a hash',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'create with empty parent_profile_id' do
@@ -574,7 +574,7 @@ module V1
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: '\
                      'parent_profile_id',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'create with an unfound parent_profile_id' do
@@ -876,21 +876,21 @@ module V1
         patch v1_profile_path(@profile.id), params: params({})
         assert_response :unprocessable_entity
         assert_match 'param is missing or the value is empty: data',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'update with invalid data' do
         patch profile_path(@profile.id), params: params('foo')
         assert_response :unprocessable_entity
         assert_match 'data must be a hash',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'update with invalid attributes' do
         patch profile_path(@profile.id), params: params(attributes: 'foo')
         assert_response :unprocessable_entity
         assert_match 'attributes must be a hash',
-                     JSON.parse(response.body).dig('errors', 0)
+                     response.parsed_body.dig('errors', 0)
       end
 
       test 'update with a single attribute' do

--- a/test/controllers/v1/rules_controller_test.rb
+++ b/test/controllers/v1/rules_controller_test.rb
@@ -93,7 +93,7 @@ module V1
         }
         assert_response :success
 
-        result = JSON.parse(response.body)
+        result = response.parsed_body
         rules = [u2, u1, low, medium, high].map(&:id)
 
         assert_equal(rules, result['data'].map do |rule|

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -39,7 +39,7 @@ module V1
         }
         assert_response :success
 
-        result = JSON.parse(response.body)
+        result = response.parsed_body
         hosts = policy.hosts.pluck(:display_name).sort.reverse
 
         assert_equal(hosts, result['data'].map do |profile|
@@ -64,7 +64,7 @@ module V1
 
         assert_response :success
         assert_equal 'has_test_results=true or has_policy=true',
-                     JSON.parse(response.body).dig('meta', 'search')
+                     response.parsed_body.dig('meta', 'search')
       end
 
       should 'allow custom search' do
@@ -73,7 +73,7 @@ module V1
         get v1_systems_url, params: { search: '' }
 
         assert_response :success
-        assert_empty JSON.parse(response.body).dig('meta', 'search')
+        assert_empty response.parsed_body.dig('meta', 'search')
       end
 
       should 'allow filtering by tags' do
@@ -113,10 +113,10 @@ module V1
         ].join('?')
 
         assert_response :success
-        results = JSON.parse(response.body)['data']
+        results = response.parsed_body['data']
         assert_equal results.count, 1
         assert_equal results.first['id'], host1.id
-        assert_not_empty JSON.parse(response.body).dig('meta', 'tags')
+        assert_not_empty response.parsed_body.dig('meta', 'tags')
       end
 
       %w[
@@ -127,7 +127,7 @@ module V1
       ].each do |qstr|
         should "properly parse #{qstr}" do
           get [v1_systems_url, qstr].join('?')
-          tags = JSON.parse(response.body)['meta']['tags']
+          tags = response.parsed_body['meta']['tags']
 
           assert_equal tags, %w[satellite/lifecycle_environment=Library]
         end
@@ -139,7 +139,7 @@ module V1
         host = FactoryBot.create(:host)
         get system_path(host)
         assert_response :success
-        assert_equal host.id, JSON.parse(response.body).dig('data', 'id')
+        assert_equal host.id, response.parsed_body.dig('data', 'id')
       end
 
       should 'return 404 for hosts in other accounts' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,7 +74,7 @@ unless Rails.env.production?
   module ActionDispatch
     class IntegrationTest
       def json_body
-        JSON.parse(response.body)
+        response.parsed_body
       end
 
       def params(data)


### PR DESCRIPTION
```ruby
JSON.parse(response)
```
vs
```ruby
response.parsed_body
```