### PR TITLE
fix(clowder): use dig to access the kafka broker hash

### DIFF
--- a/config/initializers/0_clowder-config.rb
+++ b/config/initializers/0_clowder-config.rb
@@ -27,7 +27,7 @@ if ClowderCommonRuby::Config.clowder_enabled?
   clowder_config = {
     compliance_ssg_url: compliance_ssg_url,
     kafka: {
-      brokers: config.dig('kafka', 'brokers')&.map { |b| "#{b&.hostname}:#{b&.port}" }.join(','),
+      brokers: config.dig('kafka', 'brokers')&.map { |b| "#{b&.dig('hostname')}:#{b&.dig('port')}" }.join(','),
       # Not provided by clowder, not sure which of the following should be: [:plaintext, :ssl, :sasl_plaintext, :sasl_ssl]
       security_protocol: 'plaintext'
     },


### PR DESCRIPTION
Fixes an oversight of https://github.com/RedHatInsights/compliance-backend/pull/975

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices