### PR TITLE
fix(api): RHICOMPL-2175 display the sortable fields in openapi.json

### DIFF
--- a/spec/integration/benchmarks_spec.rb
+++ b/spec/integration/benchmarks_spec.rb
@@ -15,7 +15,7 @@ describe 'Benchmarks API' do
       auth_header
       pagination_params
       search_params
-      sort_params
+      sort_params(Xccdf::Benchmark)
 
       include_param
 

--- a/spec/integration/business_objectives_spec.rb
+++ b/spec/integration/business_objectives_spec.rb
@@ -27,7 +27,7 @@ describe 'Business Objectives API' do
       auth_header
       pagination_params
       search_params
-      sort_params
+      sort_params(BusinessObjective)
 
       include_param
 

--- a/spec/integration/profiles_spec.rb
+++ b/spec/integration/profiles_spec.rb
@@ -23,7 +23,7 @@ describe 'Profiles API' do
       auth_header
       pagination_params
       search_params
-      sort_params
+      sort_params(Profile)
 
       include_param
 

--- a/spec/integration/rule_results_spec.rb
+++ b/spec/integration/rule_results_spec.rb
@@ -31,7 +31,7 @@ describe 'RuleResults API' do
       auth_header
       pagination_params
       search_params
-      sort_params
+      sort_params(RuleResult)
 
       include_param
 

--- a/spec/integration/rules_spec.rb
+++ b/spec/integration/rules_spec.rb
@@ -23,7 +23,7 @@ describe 'Rules API' do
       auth_header
       pagination_params
       search_params
-      sort_params
+      sort_params(Rule)
 
       include_param
 

--- a/spec/integration/systems_spec.rb
+++ b/spec/integration/systems_spec.rb
@@ -32,7 +32,7 @@ describe 'Systems API' do
       pagination_params
       search_params
       tags_params
-      sort_params
+      sort_params(Host)
 
       include_param
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -94,15 +94,25 @@ def tags_params
             schema: { type: :array, items: { type: 'string' }, default: '' }
 end
 
-def sort_params
+def sort_params(model = nil)
   parameter name: :sort_by, in: :query, required: false,
             type: { oneOf: [{ type: :string }, { type: :array }] },
             description: 'An array of fields with an optional direction '\
              '(:asc or :desc) to sort the results.',
             schema: {
               type: { oneOf: [{ type: :string }, { type: :array }] },
+              items: { enum: sort_combinations(model) },
               default: ''
             }
+end
+
+def sort_combinations(model)
+  fields = model.instance_variable_get(:@sortable_by).keys
+  fields + fields.flat_map do |field|
+    %w[asc desc].map do |direction|
+      [field, direction].join(':')
+    end
+  end
 end
 
 def content_types

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -84,6 +84,16 @@
                   }
                 ]
               },
+              "items": {
+                "enum": [
+                  "title",
+                  "version",
+                  "title:asc",
+                  "title:desc",
+                  "version:asc",
+                  "version:desc"
+                ]
+              },
               "default": ""
             }
           },
@@ -397,6 +407,13 @@
                   }
                 ]
               },
+              "items": {
+                "enum": [
+                  "title",
+                  "title:asc",
+                  "title:desc"
+                ]
+              },
               "default": ""
             }
           },
@@ -680,6 +697,19 @@
                   {
                     "type": "array"
                   }
+                ]
+              },
+              "items": {
+                "enum": [
+                  "name",
+                  "os_minor_version",
+                  "score",
+                  "name:asc",
+                  "name:desc",
+                  "os_minor_version:asc",
+                  "os_minor_version:desc",
+                  "score:asc",
+                  "score:desc"
                 ]
               },
               "default": ""
@@ -1704,6 +1734,13 @@
                   }
                 ]
               },
+              "items": {
+                "enum": [
+                  "result",
+                  "result:asc",
+                  "result:desc"
+                ]
+              },
               "default": ""
             }
           },
@@ -1873,6 +1910,19 @@
                   {
                     "type": "array"
                   }
+                ]
+              },
+              "items": {
+                "enum": [
+                  "title",
+                  "severity",
+                  "remediation_available",
+                  "title:asc",
+                  "title:desc",
+                  "severity:asc",
+                  "severity:desc",
+                  "remediation_available:asc",
+                  "remediation_available:desc"
                 ]
               },
               "default": ""
@@ -2805,19 +2855,18 @@
                   }
                 ]
               },
-              "default": ""
-            }
-          },
-          {
-            "name": "tags",
-            "in": "query",
-            "required": false,
-            "type": "array",
-            "description": "An array of tags to narrow down the results against.",
-            "schema": {
-              "type": "array",
               "items": {
-                "type": "string"
+                "enum": [
+                  "name",
+                  "os_major_version",
+                  "os_minor_version",
+                  "name:asc",
+                  "name:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "os_minor_version:asc",
+                  "os_minor_version:desc"
+                ]
               },
               "default": ""
             }


### PR DESCRIPTION
:shrug: not sure about the validity of this spec if the sort_by isn't passed as an array, but I guess it should be fine :thinking: 