### PR TITLE
feat(rules): RHICOMPL-2081 mark upstream rules with a new field

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -77,7 +77,8 @@ class Rule < ApplicationRecord
     rule.assign_attributes(title: op_rule.title,
                            description: op_rule.description,
                            rationale: op_rule.rationale,
-                           severity: op_rule.severity)
+                           severity: op_rule.severity,
+                           upstream: false)
 
     rule
   end

--- a/app/services/concerns/xccdf/benchmarks.rb
+++ b/app/services/concerns/xccdf/benchmarks.rb
@@ -24,6 +24,8 @@ module Xccdf
       end
 
       def benchmark_contents_equal_to_op?
+        return false if Settings.force_import_ssgs
+
         benchmark_saved? && benchmark_rules_saved? && benchmark_profiles_saved?
       end
 

--- a/app/services/concerns/xccdf/rules.rb
+++ b/app/services/concerns/xccdf/rules.rb
@@ -12,12 +12,24 @@ module Xccdf
         end
 
         ::Rule.import!(new_rules, ignore: true)
+        # Mark already existing rules to be imported as non-upstream
+        # rubocop:disable Rails/SkipsModelValidations
+        ::Rule.where(id: old_rules.pluck(:id)).update_all(upstream: false)
+        # rubocop:enable Rails/SkipsModelValidations
       end
 
       private
 
+      def split_rules
+        @split_rules ||= @rules.partition(&:new_record?)
+      end
+
       def new_rules
-        @new_rules ||= @rules.select(&:new_record?)
+        @new_rules ||= split_rules.first
+      end
+
+      def old_rules
+        split_rules.last
       end
     end
   end

--- a/db/migrate/20210830070917_add_upstream_for_rules.rb
+++ b/db/migrate/20210830070917_add_upstream_for_rules.rb
@@ -1,0 +1,6 @@
+class AddUpstreamForRules < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rules, :upstream, :boolean, null: false, default: true
+    add_index :rules, :upstream
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_19_144533) do
+ActiveRecord::Schema.define(version: 2021_08_30_070917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
@@ -166,9 +166,11 @@ ActiveRecord::Schema.define(version: 2021_08_19_144533) do
     t.string "slug"
     t.boolean "remediation_available", default: false, null: false
     t.uuid "benchmark_id", null: false
+    t.boolean "upstream", default: true, null: false
     t.index ["ref_id", "benchmark_id"], name: "index_rules_on_ref_id_and_benchmark_id", unique: true
     t.index ["ref_id"], name: "index_rules_on_ref_id"
     t.index ["slug"], name: "index_rules_on_slug", unique: true
+    t.index ["upstream"], name: "index_rules_on_upstream"
   end
 
   create_table "test_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
This is the mark phase of the non-invasive cleanup of unused upstream rules from our database. I'm initially marking every rule as an upstream and during the SSG import, all the imported rules will set the `upstream` field to be `false`. This way we will know which rules should be kept in a future cleanup.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
