### PR TITLE
fix(Accounts): RHICOMPL-2114 set is_internal from the identity header

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -52,7 +52,7 @@ module Authentication
   end
 
   def user
-    User.new(account: account_from_header)
+    User.new(account: Account.from_identity_header(identity_header))
   end
 
   def rbac_allowed?
@@ -94,11 +94,5 @@ module Authentication
 
   def identity_header
     @identity_header ||= IdentityHeader.new(raw_identity_header)
-  end
-
-  def account_from_header
-    Account.find_or_create_by(
-      account_number: identity_header.identity['account_number']
-    )
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -13,6 +13,21 @@ class Account < ApplicationRecord
 
   validates :account_number, presence: true
 
+  class << self
+    def from_identity_header(identity_header)
+      account = Account.find_or_create_by(
+        account_number: identity_header.identity['account_number']
+      )
+
+      # Update the is_internal if set and differs from the stored one
+      unless identity_header.is_internal.nil?
+        account.update!(is_internal: identity_header.is_internal)
+      end
+
+      account
+    end
+  end
+
   # rubocop:disable Metrics/MethodLength
   def fake_identity_header
     {

--- a/app/models/identity_header.rb
+++ b/app/models/identity_header.rb
@@ -31,6 +31,12 @@ class IdentityHeader
     content['identity']
   end
 
+  # rubocop:disable Naming/PredicateName
+  def is_internal
+    identity&.dig('user', 'is_internal')
+  end
+  # rubocop:enable Naming/PredicateName
+
   def entitlements
     content['entitlements']
   end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -36,7 +36,7 @@ class XccdfReportParser
     end
 
     @b64_identity = message['b64_identity']
-    @account = Account.find_or_create_by(account_number: message['account'])
+    @account = Account.from_identity_header(IdentityHeader.new(@b64_identity))
     @host = Host.find(message['id'])
     @test_result_file = OpenscapParser::TestResultFile.new(report_contents)
     set_openscap_parser_data

--- a/db/migrate/20210830130754_rename_internal_in_accounts.rb
+++ b/db/migrate/20210830130754_rename_internal_in_accounts.rb
@@ -1,0 +1,5 @@
+class RenameInternalInAccounts < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :accounts, :internal, :is_internal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_30_080830) do
+ActiveRecord::Schema.define(version: 2021_08_30_130754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2021_08_30_080830) do
 
   create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "account_number"
-    t.boolean "internal"
+    t.boolean "is_internal"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_number"], name: "index_accounts_on_account_number", unique: true

--- a/test/services/reports_tar_reader_test.rb
+++ b/test/services/reports_tar_reader_test.rb
@@ -14,7 +14,7 @@ class ReportsTarReaderTest < ActiveSupport::TestCase
           report,
           'account' => account.account_number,
           'id' => host.id,
-          'b64_identity' => 'b64_fake_identity',
+          'b64_identity' => account.b64_identity,
           'metadata' => {
             'display_name' => 'foo.example.com'
           }

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -24,7 +24,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     @report_parser = TestParser
                      .new(fake_report,
                           'account' => @account.account_number,
-                          'b64_identity' => 'b64_fake_identity',
+                          'b64_identity' => @account.b64_identity,
                           'id' => @host.id,
                           'metadata' => {
                             'display_name' => @host.name
@@ -165,7 +165,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         TestParser.new(
           'fakereport',
           'account' => @account.account_number,
-          'b64_identity' => 'b64_fake_identity',
+          'b64_identity' => @account.b64_identity,
           'metadata' => { 'display_name': '123' }
         )
       end
@@ -288,7 +288,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
           fake_report,
           'account' => @account.account_number,
           'id' => @host.id,
-          'b64_identity' => 'b64_fake_identity',
+          'b64_identity' => @account.b64_identity,
           'metadata' => {
             'display_name' => @host.name
           }


### PR DESCRIPTION
I moved around the `account_from_header` method and generalized it into `Account.from_identity_header`. The method now tries to look up for both the account number and the `user.is_internal` boolean and if the latter one isn't set, an exception happens, the handler looks for the account by the number only, updates the `is_internal` field and retries. This way any user interaction will keep the information about the account being internal or not.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
