### PR TITLE
devel: Temporarily add back the non-clowder compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,14 @@ To disable Prometheus (e.g. in develompent) clear `prometheus_exporter_host` set
 
 If there is a `tags` column defined in any model, it always should be a `jsonb` column and follow the structured representation of tags described in Insights, i.e. an array of hashes. If this convention is not kept, the controllers might break when a user tries to pass the `tags` attribute to a GET request.
 
+### Non-Clowder Development with docker-compose
+
+Use the alternate docker-compose_nonclowder.yml with:
+
+```sh
+docker-compose -f docker-compose_nonclowder.yml ...
+```
+
 ## API documentation
 
 The API documentation can be found at `Settings.path_prefix/Settings.app_name`. To generate the docs, run `rake rswag:specs:swaggerize`. You may also get the OpenAPI definition at `Settings.path_prefix/Settings.app_name/v1/openapi.json`

--- a/docker-compose_nonclowder.yml
+++ b/docker-compose_nonclowder.yml
@@ -1,0 +1,299 @@
+# This docker-compose file will stand up the entire stack including ingress and inventory.
+version: "3"
+services:
+  zookeeper:
+    image: quay.io/cloudservices/cp-zookeeper
+    environment:
+      - ZOOKEEPER_CLIENT_PORT=32181
+      - ZOOKEEPER_SERVER_ID=1
+      - KAFKA_OPTS=-Dzookeeper.admin.enableServer=false
+  kafka:
+    image: quay.io/cloudservices/cp-kafka
+    ports:
+      - 29092:29092
+    depends_on:
+      - zookeeper
+    links:
+      - zookeeper
+    environment:
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092
+      - KAFKA_BROKER_ID=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
+  puptoo:
+    image: quay.io/cloudservices/insights-puptoo:latest
+    environment:
+      - REJECTION_TOPIC=platform.upload.validation
+      - LOGLEVEL=INFO
+      - PROMETHEUS_PORT=8001
+    depends_on:
+      - kafka
+    links:
+      - kafka
+  minio:
+    image: quay.io/cloudservices/minio
+    command: server /data
+    volumes:
+      - /data
+    ports:
+      - 9000:9000
+    env_file: .env
+  createbuckets:
+    image: docker.io/minio/mc
+    depends_on:
+      - minio
+    links:
+      - minio
+    entrypoint: /bin/sh
+    command: -c '
+      until /usr/bin/mc config host add myminio http://minio:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY >/dev/null; do sleep 1; done ;
+      /usr/bin/mc mb myminio/insights-upload-perma;
+      /usr/bin/mc mb myminio/insights-upload-rejected;
+      /usr/bin/mc policy set download myminio/insights-upload-perma;
+      /usr/bin/mc policy set download myminio/insights-upload-rejected;
+      exit 0;'
+    volumes:
+      - /data
+    env_file: .env
+  ingress:
+    image: quay.io/cloudservices/insights-ingress:stable
+    environment:
+      - AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY
+      - AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY
+      - AWS_REGION=us-east-1
+      - INGRESS_STAGEBUCKET=insights-upload-perma
+      - INGRESS_REJECTBUCKET=insights-upload-rejected
+      - INGRESS_VALIDTOPICS=testareno,advisor,buckit,compliance #if you test a different topic, add it here
+      - INGRESS_INVENTORYURL=inventory-web:8081/api/inventory/v1/hosts
+      - OPENSHIFT_BUILD_COMMIT=woopwoop
+      - INGRESS_PORT=8080
+      - INGRESS_WEBPORT=8080
+      - INGRESS_METRICSPORT=3001
+      - INGRESS_MINIODEV=true
+      - INGRESS_MINIOACCESSKEY=$MINIO_ACCESS_KEY
+      - INGRESS_MINIOSECRETKEY=$MINIO_SECRET_KEY
+      - INGRESS_MINIOENDPOINT=minio:9000
+      - INGRESS_MAXSIZE=104857600 # 100 MB
+    env_file: .env
+    ports:
+      - 8080:8080
+    depends_on:
+      - kafka
+    links:
+      - kafka
+  db:
+    image: docker.io/library/postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: insights
+      POSTGRES_USER: insights
+      POSTGRES_DB: insights
+    ports:
+      - 5432:5432
+    volumes:
+      - /var/lib/postgresql/data
+  inventory:
+    image: quay.io/cloudservices/insights-inventory:latest
+    command: bash -c 'sleep 10 && make upgrade_db && make run_inv_mq_service'
+    environment:
+      - INVENTORY_DB_HOST=db
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - INVENTORY_LOG_LEVEL=ERROR
+      - KAFKA_SECONDARY_TOPIC_ENABLED=True
+    depends_on:
+      - db
+      - kafka
+    links:
+      - db
+      - kafka
+    restart: on-failure
+  inventory-web:
+    image: quay.io/cloudservices/insights-inventory:latest
+    command: bash -c 'sleep 10 && make upgrade_db && python run_gunicorn.py'
+    environment:
+      - INVENTORY_DB_HOST=db
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - KAFKA_TOPIC=platform.system_profile
+        KAFKA_GROUP=inventory
+      - INVENTORY_LOG_LEVEL=DEBUG
+      - KAFKA_SECONDARY_TOPIC_ENABLED=True
+      - LISTEN_PORT=8081
+    ports:
+      - 8081:8081
+    depends_on:
+      - db
+      - kafka
+    links:
+      - db
+      - kafka
+  compliance-ssg:
+    image: quay.io/cloudservices/compliance-ssg
+    restart: on-failure
+    environment:
+      - NGINX_PORT=8088
+    ports:
+      - 8088:8088
+  #
+  # NOTE: The following two 'services' are only required for a new DB
+  # Feel free to comment them out for subsequent use
+  #
+  build-rails-db:
+    image: compliance-backend-rails
+    entrypoint: ''
+    command: sh -c '
+      if bundle exec rake db:version 2> /dev/null; then
+        bundle exec rake db:migrate;
+      else
+        bundle exec rake db:setup;
+      fi;
+      RAILS_ENV=test bundle exec rake db:create;
+      RAILS_ENV=test bundle exec rake db:test:prepare;
+      bundle exec rails db < db/cyndi_setup_devel.sql;
+      RAILS_ENV=test bundle exec rails db < db/cyndi_setup_test.sql;
+      '
+    volumes:
+      - .:/app:z
+    depends_on:
+      - db
+      - prometheus
+    links:
+      - db
+      - prometheus
+    environment:
+      - DATABASE_SERVICE_NAME=postgres
+      - POSTGRES_SERVICE_HOST=db
+      - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
+      - POSTGRESQL_USER=insights
+      - POSTGRESQL_PASSWORD=insights
+      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+  ssg-import-rhel-supported:
+    image: compliance-backend-rails
+    entrypoint: ''
+    command: 'bundle exec rake ssg:import_rhel_supported'
+    restart: on-failure
+    volumes:
+      - .:/app:z
+    depends_on:
+      - db
+      - prometheus
+      - compliance-ssg
+    links:
+      - db
+      - prometheus
+      - compliance-ssg
+    environment:
+      - DATABASE_SERVICE_NAME=postgres
+      - POSTGRES_SERVICE_HOST=db
+      - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
+      - POSTGRESQL_USER=insights
+      - POSTGRESQL_PASSWORD=insights
+      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+  rails:
+    env_file: .env
+    build:
+      context: .
+      dockerfile: devel.Dockerfile
+    image: compliance-backend-rails
+    tty: true
+    stdin_open: true
+    restart: on-failure
+    environment:
+      - SETTINGS__KAFKA__BROKERS=kafka:29092
+      - DATABASE_SERVICE_NAME=postgres
+      - POSTGRES_SERVICE_HOST=db
+      - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
+      - POSTGRESQL_USER=insights
+      - POSTGRESQL_PASSWORD=insights
+      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+      - HOSTNAME=rails
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/app:z
+    depends_on:
+      - db
+      - prometheus
+      - redis
+      - compliance-ssg
+    links:
+      - db
+      - prometheus
+      - redis
+      - compliance-ssg
+  inventory-consumer:
+    image: compliance-backend-rails
+    restart: on-failure
+    entrypoint: ''
+    command: 'bundle exec racecar -l log/inventory-consumer.log InventoryEventsConsumer'
+    environment:
+      - SETTINGS__KAFKA__BROKERS=kafka:29092
+      - DATABASE_SERVICE_NAME=postgres
+      - POSTGRES_SERVICE_HOST=db
+      - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
+      - POSTGRESQL_USER=insights
+      - POSTGRESQL_PASSWORD=insights
+      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+      - HOSTNAME=inventory-consumer
+    volumes:
+      - .:/app:z
+    depends_on:
+      - db
+      - prometheus
+      - kafka
+    links:
+      - db
+      - prometheus
+      - kafka
+  prometheus:
+    image: compliance-backend-rails
+    tty: true
+    environment:
+      - SETTINGS__KAFKA__BROKERS=kafka:29092
+      - DATABASE_SERVICE_NAME=postgres
+      - POSTGRES_SERVICE_HOST=db
+      - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_USER=insights
+      - POSTGRESQL_PASSWORD=insights
+      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - RAILS_ENV=development
+      - RAILS_LOG_TO_STDOUT=true
+      - HOSTNAME=prometheus
+    restart: on-failure
+    volumes:
+      - .:/app:z
+    ports:
+      - '9394:9394'
+    command: bundle exec prometheus_exporter -b 0.0.0.0 -t 50 --verbose -a lib/prometheus/graphql_collector.rb -a lib/prometheus/business_collector.rb -a lib/prometheus/engineering_collector.rb
+  sidekiq:
+    image: compliance-backend-rails
+    restart: on-failure
+    volumes:
+      - .:/app:z
+    depends_on:
+      - redis
+    links:
+      - redis
+    command: bundle exec sidekiq
+    environment:
+      - MALLOC_ARENA_MAX=2
+      - SETTINGS__REDIS_URL=redis:6379
+      - SETTINGS__PROMETHEUS_EXPORTER_HOST=prometheus
+      - SETTINGS__KAFKA__BROKERS=kafka:29092
+      - DATABASE_SERVICE_NAME=postgres
+      - POSTGRES_SERVICE_HOST=db
+      - POSTGRESQL_DATABASE=compliance_dev
+      - POSTGRESQL_TEST_DATABASE=compliance_test
+      - POSTGRESQL_USER=insights
+      - POSTGRESQL_PASSWORD=insights
+      - SIDEKIQ_CONCURRENCY=1
+      - HOSTNAME=sidekiq
+  redis:
+    image: quay.io/cloudservices/redis:latest
+    ports:
+      - 6379:6379


### PR DESCRIPTION
This helps testing compatibility of old non-clowder deployments. We can
remove it after fully migrating to clowder.

```sh
docker-compose -f docker-compose_nonclowder.yml ...
```

This uses env variables per container instead of the shared devel.json and ACG_CONFIG variable. (Un)setting the ACG_CONFIG env variable toggles all clowder config logic within Compliance.

Used to help debug/test https://github.com/RedHatInsights/compliance-backend/pull/945

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices