### PR TITLE
fix(sort): RHICOMPL-2179 overridable default sort of business objectives

### DIFF
--- a/app/controllers/v1/business_objectives_controller.rb
+++ b/app/controllers/v1/business_objectives_controller.rb
@@ -4,7 +4,8 @@ module V1
   # API for BusinessObjectives
   class BusinessObjectivesController < ApplicationController
     def index
-      render_json resolve_collection.sort_by(&:title)
+      params[:sort_by] ||= 'title'
+      render_json resolve_collection
     end
 
     def show


### PR DESCRIPTION
This is some legacy stuff that doesn't allow to override the default sort in business objectives. Replacing it with *The Right Way&trade;* :wink: 