### PR TITLE
fix(metrics): RHICOMPL-2114 adjust metrics to non-internal accounts

### DIFF
--- a/lib/prometheus/business_collector.rb
+++ b/lib/prometheus/business_collector.rb
@@ -88,9 +88,7 @@ class BusinessCollector < PrometheusExporter::Server::TypeCollector
 
   def collect
     @total_accounts.observe Account.count
-    client_accounts = Account.distinct.where(
-      id: User.select(:account_id).where.not('email LIKE ?', '%redhat%')
-    )
+    client_accounts = Account.where(is_internal: [nil, false])
     @client_accounts.observe client_accounts.count
     @client_accounts_with_hosts.observe(
       Host.with_policies_or_test_results.where(

--- a/test/lib/prometheus/business_collector_test.rb
+++ b/test/lib/prometheus/business_collector_test.rb
@@ -10,7 +10,7 @@ class BusinessCollectorTest < ActiveSupport::TestCase
   end
 
   test 'metrics' do
-    account, = FactoryBot.create_list(:account, 3)
+    account, = FactoryBot.create_list(:account, 3, is_internal: true)
     FactoryBot.create_list(
       :host,
       2,


### PR DESCRIPTION
If the account has the `is_internal` not set to true, i.e. `nil` or `false` it is treated as a client (non-employee) account.