### PR TITLE
dev(prometheus): RHICOMPL-2251 disableable Prometheus Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,11 @@ might be needed for platform services such as inventory, rbac, and remediations.
 Anything not deployed locally will require basic auth instead of using
 an identity header (i.e. rbac, remediations).
 
+### Disabling Prometheus
+
+To disable Prometheus (e.g. in develompent) clear `prometheus_exporter_host`
+(`SETTINGS__PROMETHEUS_EXPORTER_HOST` env var) setting (set to empty).
+
 ### Tagging
 
 If there is a `tags` column defined in any model, it always should be a `jsonb` column and follow the structured representation of tags described in Insights, i.e. an array of hashes. If this convention is not kept, the controllers might break when a user tries to pass the `tags` attribute to a GET request.

--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -9,7 +9,9 @@ require_relative 'types/mutation'
 # GraphQL-ruby documentation to find out what to add or
 # remove here.
 class Schema < GraphQL::Schema
-  use GraphQL::Tracing::PrometheusTracing unless Rails.env.test?
+  if Settings.prometheus_exporter_host.present? && !Rails.env.test?
+    use GraphQL::Tracing::PrometheusTracing
+  end
   use ComplianceTimeout, max_seconds: 20
   query Types::Query
   mutation Types::Mutation

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,4 +1,4 @@
-unless Rails.env.test?
+if Settings.prometheus_exporter_host.present? && !Rails.env.test?
   require 'prometheus_exporter'
   require 'prometheus_exporter/client'
   require 'prometheus_exporter/metric'

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,7 @@ sidekiq_config = lambda do |config|
   }
   Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
 
-  unless Rails.env.test?
+  if Settings.prometheus_exporter_host.present? && !Rails.env.test?
     config.server_middleware do |chain|
       require 'prometheus_exporter/instrumentation'
       chain.add PrometheusExporter::Instrumentation::Sidekiq

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,6 +41,8 @@ environment ENV.fetch('RAILS_ENV') { 'development' }
 plugin :tmp_restart
 
 after_worker_boot do
-  require 'prometheus_exporter/instrumentation'
-  PrometheusExporter::Instrumentation::Puma.start(type: 'puma')
+  if Settings.prometheus_exporter_host.present?
+    require 'prometheus_exporter/instrumentation'
+    PrometheusExporter::Instrumentation::Puma.start(type: 'puma')
+  end
 end


### PR DESCRIPTION
Reverts changes, after Prometheus running along side main processes, to
have Prometheus disableable by clearing the settings constant.

This is useful when developing locally, especially when Spring holds the
processes.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [X] Input Validation
- [X] Output Encoding
- [X] Authentication and Password Management
- [X] Session Management
- [X] Access Control
- [X] Cryptographic Practices
- [X] Error Handling and Logging
- [X] Data Protection
- [X] Communication Security
- [X] System Configuration
- [X] Database Security
- [X] File Management
- [X] Memory Management
- [X] General Coding Practices
