### PR TITLE
fix(GraphQL): RHICOMPL-2254 Disable GraphQL introspection on prod

### DIFF
--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -19,4 +19,5 @@ class Schema < GraphQL::Schema
   use GraphQL::Batch
   use GraphQL::Execution::Interpreter
   use GraphQL::Analysis::AST
+  disable_introspection_entry_points if Rails.env.production?
 end


### PR DESCRIPTION
Closes RHICOMPL-2254.

See : https://github.com/rmosolgo/graphql-ruby/blob/master/guides/schema/introspection.md#disabling-introspection

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
