### PR TITLE
fix(parsing): RHICOMPL-2114 Inject b64_identity into metadata

### DIFF
--- a/app/consumers/concerns/report_parsing.rb
+++ b/app/consumers/concerns/report_parsing.rb
@@ -83,7 +83,8 @@ module ReportParsing
 
     def metadata
       (@msg_value.dig('platform_metadata', 'metadata') || {}).merge(
-        'id' => id
+        'id' => id,
+        'b64_identity' => b64_identity
       )
     end
 

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -31,11 +31,11 @@ class XccdfReportParser
   BENCHMARK_PREFIX = 'xccdf_org.ssgproject.content_benchmark_'
 
   def initialize(report_contents, message)
-    unless valid_message_format?(message)
-      raise MissingIdError, 'Missing Host id in message'
-    end
-
+    @id = message['id']
     @b64_identity = message['b64_identity']
+
+    validate_message_format!
+
     @account = Account.from_identity_header(IdentityHeader.new(@b64_identity))
     @host = Host.find(message['id'])
     @test_result_file = OpenscapParser::TestResultFile.new(report_contents)
@@ -49,8 +49,13 @@ class XccdfReportParser
     raise WrongFormatError, 'Wrong format or benchmark'
   end
 
-  def valid_message_format?(message)
-    message['id'].present?
+  def validate_message_format!
+    msg = "Missing data in message: id=#{@id} b64_identity=#{@b64_identity}"
+    raise(MissingIdError, msg) unless valid_message_format?
+  end
+
+  def valid_message_format?
+    @id.present? && @b64_identity.present?
   end
 
   def check_os_version

--- a/test/consumers/inventory_events_consumer_test.rb
+++ b/test/consumers/inventory_events_consumer_test.rb
@@ -46,6 +46,27 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
     assert_equal 0, DeleteHost.jobs.size
   end
 
+  test 'b64_identity is included in metadata' do
+    class TestReportParsing
+      include ReportParsing
+
+      def initialize
+        @msg_value = {
+          'platform_metadata' => {
+            'b64_identity' => 'identity'
+          },
+          'host' => {
+            'id' => 'id'
+          }
+        }
+      end
+    end
+
+    assert_equal('identity',
+                 TestReportParsing.new.send(:metadata)['b64_identity'])
+    assert_equal 'id', TestReportParsing.new.send(:metadata)['id']
+  end
+
   context 'report upload messages' do
     setup do
       ParseReportJob.clear

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -159,13 +159,24 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     end
   end
 
-  context 'missing ID' do
+  context 'error handling' do
     should 'raise error if message ID is not present' do
       assert_raises(XccdfReportParser::MissingIdError) do
         TestParser.new(
           'fakereport',
           'account' => @account.account_number,
           'b64_identity' => @account.b64_identity,
+          'metadata' => { 'display_name': '123' }
+        )
+      end
+    end
+
+    should 'validate b64_identity is present' do
+      assert_raises(XccdfReportParser::MissingIdError) do
+        TestParser.new(
+          'fakereport',
+          'account' => @account.account_number,
+          'id' => @host.id,
           'metadata' => { 'display_name': '123' }
         )
       end


### PR DESCRIPTION
Two different jiras solved here:

- fix(ReportParser): RHICOMPL-2266 Handle nil identities
- fix(parsing): RHICOMPL-2114 Inject b64_identity into metadata

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
