### PR TITLE
feat(build): RHICOMPL-2280 enable multistage build to support tableau

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ruby-27
-
+FROM registry.access.redhat.com/ubi8/ruby-27 AS compliance-backend
 
 USER 0
 
@@ -13,9 +12,28 @@ COPY --chown=1001:0 . /tmp/src
 
 USER 1001
 
-ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=true QMAKE=/usr/lib64/qt5/bin/qmake DISABLE_ASSET_COMPILATION=true
+ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=true QMAKE=/usr/lib64/qt5/bin/qmake DISABLE_ASSET_COMPILATION=true BUNDLE_WITHOUT=development:test:tableau
 
 # Install the dependencies
 RUN /usr/libexec/s2i/assemble
+
+CMD ["/opt/app-root/src/entrypoint.sh"]
+
+FROM compliance-backend as compliance-tableau
+
+USER 0
+
+RUN yum config-manager --enable "codeready-builder-for-rhel-8-$(arch)-rpms" && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm && \
+    yum install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
+    yum install -y parquet-glib-devel
+
+USER 1001
+
+ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=true QMAKE=/usr/lib64/qt5/bin/qmake DISABLE_ASSET_COMPILATION=true BUNDLE_WITHOUT=development:test
+
+# Install the additional tableau dependencies
+RUN bundle install --deployment --retry 2 --path ./bundle --with tableau --without development:test && \
+    bundle clean -V
 
 CMD ["/opt/app-root/src/entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,11 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+group :tableau do
+  gem 'aws-sdk-s3', require: false
+  gem 'red-parquet', require: false
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,23 @@ GEM
     ansi (1.5.0)
     arel (9.0.0)
     ast (2.4.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.503.0)
+    aws-sdk-core (3.121.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.48.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.103.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+    bigdecimal (3.0.2)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     brakeman (4.8.1)
@@ -120,6 +137,7 @@ GEM
     exception_notification (4.4.0)
       actionmailer (>= 4.0, < 7)
       activesupport (>= 4.0, < 7)
+    extpp (0.0.9)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.1.0)
@@ -132,10 +150,17 @@ GEM
     ffi (1.12.2)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
+    gio2 (3.4.9)
+      gobject-introspection (= 3.4.9)
     gitlab-sidekiq-fetcher (0.5.2)
       sidekiq (~> 5)
+    glib2 (3.4.9)
+      native-package-installer (>= 1.0.3)
+      pkg-config (>= 1.3.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gobject-introspection (3.4.9)
+      glib2 (= 3.4.9)
     graphiql-rails (1.7.0)
       railties
       sprockets-rails
@@ -150,6 +175,7 @@ GEM
     irb (1.2.4)
       reline (>= 0.0.1)
     jaro_winkler (1.5.4)
+    jmespath (1.4.0)
     json (2.5.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -188,6 +214,7 @@ GEM
     mocha (1.11.2)
     msgpack (1.3.3)
     multipart-post (2.1.1)
+    native-package-installer (1.1.1)
     nio4r (2.5.7)
     nokogiri (1.11.4)
       mini_portile2 (~> 2.5.0)
@@ -199,6 +226,7 @@ GEM
     parser (2.7.1.2)
       ast (~> 2.4.0)
     pg (1.2.3)
+    pkg-config (1.4.6)
     prometheus_exporter (0.5.1)
     promise.rb (0.7.4)
     pry (0.13.1)
@@ -261,6 +289,14 @@ GEM
       ffi (~> 1.9)
       mini_portile2 (~> 2.1)
       rake (>= 12.3)
+    red-arrow (5.0.0)
+      bigdecimal (>= 2.0.3)
+      extpp (>= 0.0.7)
+      gio2 (>= 3.4.5)
+      native-package-installer
+      pkg-config
+    red-parquet (5.0.0)
+      red-arrow (= 5.0.0)
     redis (4.2.1)
     reline (0.1.4)
       io-console (~> 0.5)
@@ -361,6 +397,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  aws-sdk-s3
   bootsnap (>= 1.1.0)
   brakeman
   bullet
@@ -397,6 +434,7 @@ DEPENDENCIES
   rack (>= 2.1.4)
   rack-cors
   rails (~> 5.2.4, >= 5.2.4.4)
+  red-parquet
   redis (~> 4.0)
   request_store
   rspec-rails

--- a/README.md
+++ b/README.md
@@ -139,10 +139,12 @@ They are being read by dotenv.
 First, let's install all dependencies and initialize the database.
 
 ```shell
-bundle install
+bundle install --without=tableau
 bundle exec rake db:setup # invoke only on first setup!
 bundle exec rake db:test:prepare # for test DB setup
 ```
+
+Note that the `tableau` group is not necessary for running the Rails application, however, it needs some [additional dependencies](https://arrow.apache.org/install/) if you decide to install it.
 
 Once you have database initialized, you might want to import SSG policies:
 

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  system('bundle check') || system!('bundle install --without tableau')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/bin/update
+++ b/bin/update
@@ -17,7 +17,7 @@ chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  system('bundle check') || system!('bundle install --without tableau')
 
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -7,5 +7,6 @@ source 'deploy/build-deploy-common.sh'
 BACKWARDS_COMPATIBILITY_TAGS="latest qa"
 IMAGE_NAME="${IMAGE_NAME:-quay.io/cloudservices/compliance-backend}"
 IMAGE_TAG="${IMAGE_TAG}"
+TARGET_BUILD_STAGE="${TARGET_BUILD_STAGE:-compliance-backend}"
 
 build_deploy_main || exit 1

--- a/deploy/build-deploy-common.sh
+++ b/deploy/build-deploy-common.sh
@@ -160,9 +160,9 @@ build_image() {
 
     if [ -n "$BUILD_ARGS" ]; then
         BUILD_ARGS_CMD=$(_get_build_args)
-        container_engine_cmd build --pull -f "$DOCKERFILE" $BUILD_ARGS_CMD -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+        container_engine_cmd build --pull -f "$DOCKERFILE" $BUILD_ARGS_CMD -t "${IMAGE_NAME}:${IMAGE_TAG}" --target=${TARGET_BUILD_STAGE} .
     else
-        container_engine_cmd build --pull -f "$DOCKERFILE" -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+        container_engine_cmd build --pull -f "$DOCKERFILE" -t "${IMAGE_NAME}:${IMAGE_TAG}" --target=${TARGET_BUILD_STAGE} .
     fi
 
 }

--- a/devel.Dockerfile
+++ b/devel.Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-buster
+FROM ruby:2.7-buster AS compliance-backend
 
 WORKDIR /app
 
@@ -10,7 +10,19 @@ COPY vendor/ ./vendor
 COPY Gemfile* ./
 COPY devel.entrypoint.sh ./
 
-RUN bundle -j4
+RUN bundle -j4 --without=tableau
+
+ENTRYPOINT ["/app/devel.entrypoint.sh"]
+CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]
+
+FROM compliance-backend AS compliance-tableau
+
+RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+    apt-get install -y ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+    apt-get update && \
+    apt-get install -y libparquet-dev
+
+RUN bundle -j4 --with=tableau
 
 ENTRYPOINT ["/app/devel.entrypoint.sh"]
 CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
     build:
       context: .
       dockerfile: devel.Dockerfile
+      target: compliance-backend
     image: compliance-backend-rails
     tty: true
     stdin_open: true

--- a/docker-compose_nonclowder.yml
+++ b/docker-compose_nonclowder.yml
@@ -195,6 +195,7 @@ services:
     build:
       context: .
       dockerfile: devel.Dockerfile
+      target: compliance-backend
     image: compliance-backend-rails
     tty: true
     stdin_open: true

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -76,7 +76,7 @@ echo '===================================='
 echo '=== Installing Gem Dependencies ===='
 echo '===================================='
 set +e
-docker exec "$TEST_CONTAINER_ID" /bin/bash -c 'bundle install --with test'
+docker exec "$TEST_CONTAINER_ID" /bin/bash -c 'bundle install --with test --without tableau'
 TEST_RESULT=$?
 set -e
 if [[ $TEST_RESULT -ne 0 ]]; then


### PR DESCRIPTION
Introducing a new bundler group for tableau extraction and a next stage of the container build that creates a container with the dependencies for this bundler group. The exclusion/inclusion of these gems is enforced via bundler's `--without` and `--with` arguments, so please keep in mind that you need the proper depds when you try to `bundle install` without :exploding_head: the [dependencies for red-parquet](https://arrow.apache.org/install/).