### PR TITLE
perf(REST): RHICOMPL-2249 use a subquery for RuleResults by hosts

### DIFF
--- a/app/policies/rule_result_policy.rb
+++ b/app/policies/rule_result_policy.rb
@@ -13,7 +13,7 @@ class RuleResultPolicy < ApplicationPolicy
   # Only show RuleResults belonging to hosts visible by the current user
   class Scope < ::ApplicationPolicy::Scope
     def resolve
-      available_hosts = HostPolicy::Scope.new(user, Host).resolve.pluck(:id)
+      available_hosts = HostPolicy::Scope.new(user, Host).resolve.select(:id)
       scope.where(host_id: available_hosts)
     end
   end


### PR DESCRIPTION
:runner: :racehorse: :zap: 

**Before:**
Completed 200 OK in 13276ms (Views: 3579.5ms | ActiveRecord: 3986.8ms)
**After:**
Completed 200 OK in 5632ms (Views: 56.7ms | ActiveRecord: 5537.0ms)
