### PR TITLE
feat(REST): RHICOMPL-1979 Allow disabling relationships

### DIFF
--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -25,7 +25,8 @@ module Metadata
           tags: tags,
           limit: pagination_limit,
           offset: pagination_offset,
-          sort_by: params[:sort_by]
+          sort_by: params[:sort_by],
+          relationships: relationships_enabled?
         }.compact,
         links: links(last_offset(opts[:total]))
       }
@@ -84,7 +85,8 @@ module Metadata
         include: params[:include],
         limit: pagination_limit,
         tags: params[:tags],
-        sort_by: params[:sort_by]
+        sort_by: params[:sort_by],
+        relationships: relationships_enabled?
       }
     end
 

--- a/app/controllers/concerns/parameters.rb
+++ b/app/controllers/concerns/parameters.rb
@@ -12,6 +12,11 @@ module Parameters
   )
 
   included do
+    def relationships_enabled?
+      params.permit(relationships: ParamType.boolean)
+            .with_defaults(relationships: true)[:relationships]
+    end
+
     def resource_params
       params.permit(data: ParamType.map(
         attributes: ParamType.map,

--- a/app/controllers/concerns/rendering.rb
+++ b/app/controllers/concerns/rendering.rb
@@ -27,6 +27,7 @@ module Rendering
     def serializer_opts
       opts = index? ? metadata : {}
       opts.merge!(params: { root_resource: resource })
+      opts[:params].merge!(relationships: relationships_enabled?)
       opts.merge!(include: params[:include].split(',')) if params[:include]
 
       opts

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -10,7 +10,9 @@ class ApplicationSerializer
     # rubocop:disable Layout/LineLength
     def relationships_hash(record, relationships, fieldset, includes_list, params = {})
       # rubocop:enable Layout/LineLength
-      return {} if params[:root_resource] != record.class
+      relationships_disabled = params[:root_resource] != record.class ||
+                               !params[:relationships]
+      return {} if relationships_disabled
 
       super(record, relationships, fieldset, includes_list, params)
     end

--- a/swagger/v1/openapi.json
+++ b/swagger/v1/openapi.json
@@ -157,11 +157,12 @@
                   "total": 1,
                   "search": null,
                   "limit": 10,
-                  "offset": 1
+                  "offset": 1,
+                  "relationships": true
                 },
                 "links": {
-                  "first": "/api/compliance/benchmarks?limit=10&offset=1",
-                  "last": "/api/compliance/benchmarks?limit=10&offset=1"
+                  "first": "/api/compliance/benchmarks?limit=10&offset=1&relationships=true",
+                  "last": "/api/compliance/benchmarks?limit=10&offset=1&relationships=true"
                 }
               }
             },
@@ -473,11 +474,13 @@
                   "total": 2,
                   "search": null,
                   "limit": 10,
-                  "offset": 1
+                  "offset": 1,
+                  "sort_by": "title",
+                  "relationships": true
                 },
                 "links": {
-                  "first": "/api/compliance/business_objectives?limit=10&offset=1",
-                  "last": "/api/compliance/business_objectives?limit=10&offset=1"
+                  "first": "/api/compliance/business_objectives?limit=10&offset=1&relationships=true&sort_by=title",
+                  "last": "/api/compliance/business_objectives?limit=10&offset=1&relationships=true&sort_by=title"
                 }
               }
             },
@@ -857,11 +860,13 @@
                   "total": 2,
                   "search": "os_major_version = 7",
                   "limit": 10,
-                  "offset": 1
+                  "offset": 1,
+                  "sort_by": "score",
+                  "relationships": true
                 },
                 "links": {
-                  "first": "/api/compliance/profiles?limit=10&search=os_major_version = 7&offset=1",
-                  "last": "/api/compliance/profiles?limit=10&search=os_major_version = 7&offset=1"
+                  "first": "/api/compliance/profiles?limit=10&offset=1&relationships=true&search=os_major_version+%3D+7&sort_by=score",
+                  "last": "/api/compliance/profiles?limit=10&offset=1&relationships=true&search=os_major_version+%3D+7&sort_by=score"
                 }
               }
             },
@@ -1787,11 +1792,12 @@
                   "total": 1,
                   "search": null,
                   "limit": 10,
-                  "offset": 1
+                  "offset": 1,
+                  "relationships": true
                 },
                 "links": {
-                  "first": "/api/compliance/rule_results?limit=10&offset=1",
-                  "last": "/api/compliance/rule_results?limit=10&offset=1"
+                  "first": "/api/compliance/rule_results?limit=10&offset=1&relationships=true",
+                  "last": "/api/compliance/rule_results?limit=10&offset=1&relationships=true"
                 }
               }
             },
@@ -1985,11 +1991,12 @@
                   "total": 1,
                   "search": null,
                   "limit": 10,
-                  "offset": 1
+                  "offset": 1,
+                  "relationships": true
                 },
                 "links": {
-                  "first": "/api/compliance/rules?limit=10&offset=1",
-                  "last": "/api/compliance/rules?limit=10&offset=1"
+                  "first": "/api/compliance/rules?limit=10&offset=1&relationships=true",
+                  "last": "/api/compliance/rules?limit=10&offset=1&relationships=true"
                 }
               }
             },
@@ -2932,11 +2939,12 @@
                     "foo/bar=baz"
                   ],
                   "limit": 10,
-                  "offset": 1
+                  "offset": 1,
+                  "relationships": true
                 },
                 "links": {
-                  "first": "/api/compliance/systems?limit=10&search=has_test_results=true or has_policy=true&offset=1",
-                  "last": "/api/compliance/systems?limit=10&search=has_test_results=true or has_policy=true&offset=1"
+                  "first": "/api/compliance/systems?limit=10&offset=1&relationships=true&search=has_test_results%3Dtrue+or+has_policy%3Dtrue&tags=foo%2Fbar%3Dbaz",
+                  "last": "/api/compliance/systems?limit=10&offset=1&relationships=true&search=has_test_results%3Dtrue+or+has_policy%3Dtrue&tags=foo%2Fbar%3Dbaz"
                 }
               }
             },

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -93,6 +93,22 @@ class MetadataTest < ActionDispatch::IntegrationTest
     assert_includes json_body['links']['previous'], 'search=name+%21%3D+%22%22'
   end
 
+  test 'meta adds relationships param to JSON response' do
+    authenticate
+    3.times do
+      FactoryBot.create(:profile)
+    end
+
+    get profiles_url, params: { relationships: false, limit: 1, offset: 2 }
+    assert_response :success
+    assert_includes json_body['links']['first'], 'relationships=false'
+    assert_includes json_body['links']['last'], 'relationships=false'
+    assert_includes json_body['links']['next'], 'relationships=false'
+    assert_includes json_body['links']['previous'], 'relationships=false'
+    assert_equal({}, parsed_data[0]['relationships'])
+    assert_equal false, json_body['meta']['relationships']
+  end
+
   context 'pagination' do
     setup do
       authenticate

--- a/test/controllers/concerns/parameters_test.rb
+++ b/test/controllers/concerns/parameters_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Tests for the parameters concern
+class ParametersTest < ActionDispatch::IntegrationTest
+  def authenticate
+    V1::ProfilesController.any_instance.stubs(:authenticate_user).yields
+    User.current = FactoryBot.create(:user)
+  end
+
+  test 'validates relationships param to be a boolean' do
+    authenticate
+
+    get profiles_url(relationships: 'foo')
+    assert_response :unprocessable_entity
+
+    get profiles_url(relationships: 12_345)
+    assert_response :unprocessable_entity
+
+    get profiles_url(relationships: true)
+    assert_response :success
+
+    get profiles_url(relationships: false)
+    assert_response :success
+  end
+
+  test 'defaults relationships param to be true' do
+    authenticate
+
+    get profiles_url(relationships: false)
+    assert_equal false, json_body['meta']['relationships']
+
+    get profiles_url
+    assert_equal true, json_body['meta']['relationships']
+  end
+end


### PR DESCRIPTION
Introduce a new param in our REST API to disable relationships in the
response entirely. Simply provide relationships=false to disable
relationships. The default is true and does not change existing API
functionality.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
