### PR TITLE
feat: RHICOMPL-2386 Leverage revision for import-remediations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 
 config/supported_ssg.yaml
+config/ssg-ansible-tasks.yaml
 
 brakeman_output.markdown
 

--- a/app/services/ssg_config_downloader.rb
+++ b/app/services/ssg_config_downloader.rb
@@ -2,21 +2,38 @@
 
 # Service for dowloading SSG configuration files
 class SsgConfigDownloader
-  FILE_PATH = 'config/supported_ssg.yaml'
-  FALLBACK_PATH = 'config/supported_ssg.default.yaml'
+  DS_FILE_PATH = 'config/supported_ssg.yaml'
+  DS_FALLBACK_PATH = 'config/supported_ssg.default.yaml'
+  AT_FILE_PATH = 'config/ssg-ansible-tasks.yaml'
+  AT_FALLBACK_PATH = 'config/ssg-ansible-tasks.default.yaml'
 
   class << self
     def ssg_ds
       File.read(ssg_ds_file)
     end
 
+    def ssg_ansible_tasks
+      File.read(ssg_ansible_tasks_file)
+    end
+
     def ssg_ds_checksum
       Digest::MD5.file(ssg_ds_file).hexdigest
     end
 
+    def ssg_ansible_tasks_checksum
+      Digest::MD5.file(ssg_ansible_tasks_file).hexdigest
+    end
+
     def update_ssg_ds
       ssg_content = download(ssg_datastream_config_url)&.read
-      ssg_content && File.open(FILE_PATH, 'w') do |f|
+      ssg_content && File.open(DS_FILE_PATH, 'w') do |f|
+        f.write(ssg_content)
+      end
+    end
+
+    def update_ssg_ansible_tasks
+      ssg_content = download(ssg_ansible_tasks_config_url)&.read
+      ssg_content && File.open(AT_FILE_PATH, 'w') do |f|
         f.write(ssg_content)
       end
     end
@@ -28,10 +45,21 @@ class SsgConfigDownloader
       ].join('/')
     end
 
+    def ssg_ansible_tasks_config_url
+      [
+        Settings.compliance_ssg_url,
+        Settings.supported_ssg_ansible_tasks_config
+      ].join('/')
+    end
+
     private
 
     def ssg_ds_file
-      File.new(File.exist?(FILE_PATH) ? FILE_PATH : FALLBACK_PATH)
+      File.new(File.exist?(DS_FILE_PATH) ? DS_FILE_PATH : DS_FALLBACK_PATH)
+    end
+
+    def ssg_ansible_tasks_file
+      File.new(File.exist?(AT_FILE_PATH) ? AT_FILE_PATH : AT_FALLBACK_PATH)
     end
 
     def download(url)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,3 +30,4 @@ slack_webhook: 'this is set through a env var in Openshift and not shared for se
 disable_rbac: 'false'
 async: true
 supported_ssg_ds_config: 'ssg-datastreams.yaml'
+supported_ssg_ansible_tasks_config: 'ssg-ansible-tasks.yaml'

--- a/config/ssg-ansible-tasks.default.yaml
+++ b/config/ssg-ansible-tasks.default.yaml
@@ -1,0 +1,15 @@
+---
+revision: '2021-07-15'
+supported:
+  RHEL-6:
+    - package: scap-security-guide-rule-playbooks-0.1.52-3.el7_9.noarch.rpm
+      version: 0.1.52
+      brew_url: https://docs.engineering.redhat.com/download/attachments/187625058/scap-security-guide-rule-playbooks-0.1.52-3.el7_9.noarch.rpm
+  RHEL-7:
+    - package: scap-security-guide-rule-playbooks-0.1.54-7.el7_9.noarch.rpm
+      version: 0.1.54
+      brew_url: https://download.eng.bos.redhat.com/brewroot/vol/rhel-7/packages/scap-security-guide/0.1.54/7.el7_9/noarch/scap-security-guide-rule-playbooks-0.1.54-7.el7_9.noarch.rpm
+  RHEL-8:
+    - package: scap-security-guide-rule-playbooks-0.1.56-2.el8.noarch.rpm
+      version: 0.1.56
+      brew_url: https://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/scap-security-guide/0.1.56/2.el8/noarch/scap-security-guide-rule-playbooks-0.1.56-2.el8.noarch.rpm


### PR DESCRIPTION
In the same way we record the revision when syncing datastreams (i.e
import-ssg), we now check/record the revision of the ansible tasks
config file and skip importing remediations if the revision has not been
changed.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [x] File Management
- [ ] Memory Management
- [x] General Coding Practices
