### PR TITLE
fix(consumer): RHICOMPL-2395 Harden validation producing

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -35,8 +35,9 @@ class InventoryEventsConsumer < ApplicationConsumer
   end
 
   def handle_report_parsing
-    produce(parse_report,
-            topic: Settings.kafka_producer_topics.upload_validation)
+    parse_output = parse_report
+    validation_topic = Settings.kafka_producer_topics.upload_validation
+    produce(parse_output, topic: validation_topic) if validation_topic
   end
 
   def handle_host_delete

--- a/test/consumers/inventory_events_consumer_test.rb
+++ b/test/consumers/inventory_events_consumer_test.rb
@@ -5,6 +5,7 @@ require 'sidekiq/testing'
 
 class InventoryEventsConsumerTest < ActiveSupport::TestCase
   setup do
+    Settings.kafka_producer_topics.upload_validation = 'validation'
     @message = stub(message: nil)
     @consumer = InventoryEventsConsumer.new
     DeleteHost.clear


### PR DESCRIPTION
- Parse the report first and capture the output
- Only produce to the validation topic if it exists

If something errors in the configuration of the validation producer, it shouldn't impact the report parsing enqueue.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
