### PR TITLE
cleanup(db): RHICOMPL-2440 remove upstream profiles with test results

### DIFF
--- a/app/services/upstream_profile_remover.rb
+++ b/app/services/upstream_profile_remover.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Service for removing upstream profiles
+class UpstreamProfileRemover
+  class << self
+    def run!
+      Profile.canonical(false)
+             .joins(:parent_profile)
+             .joins(:test_results)
+             .where(parent_profiles_profiles: { upstream: true })
+             .distinct.destroy_all
+    end
+  end
+end

--- a/db/migrate/20211104070445_delete_upstream_profiles.rb
+++ b/db/migrate/20211104070445_delete_upstream_profiles.rb
@@ -1,0 +1,10 @@
+class DeleteUpstreamProfiles < ActiveRecord::Migration[5.2]
+  def up
+    UpstreamProfileRemover.run!
+    DanglingAccountRemover.run!
+  end
+
+  def down
+    # nop
+  end
+end

--- a/test/services/upstream_profile_remover_test.rb
+++ b/test/services/upstream_profile_remover_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UpstreamProfileRemoverTest < ActiveSupport::TestCase
+  setup do
+    @account = FactoryBot.create(:account)
+    @parent = FactoryBot.create(:canonical_profile, upstream: true)
+    @upstream = FactoryBot.create(
+      :profile,
+      account: @account,
+      parent_profile: @parent
+    )
+    @downstream = FactoryBot.create(:profile, account: @account)
+  end
+
+  test 'removes upstream non-canonical profiles' do
+    host = FactoryBot.create(:host, account: @account.account_number)
+    FactoryBot.create(:test_result, profile: @upstream, host: host)
+    FactoryBot.create(:test_result, profile: @downstream, host: host)
+
+    assert_difference(
+      '@downstream.test_results.count' => 0,
+      '@upstream.test_results.count' => -1,
+      'Profile.canonical(false).count' => -1,
+      'Policy.count' => -1
+    ) do
+      UpstreamProfileRemover.run!
+    end
+
+    assert_not Profile.exists?(@upstream.id)
+  end
+end


### PR DESCRIPTION
Also removing any possible dangling account that has been created during the process.