### PR TITLE
feat(REST): RHICOMPL-2374 Add attributes to rule identifier serializer

### DIFF
--- a/app/serializers/rule_identifier_serializer.rb
+++ b/app/serializers/rule_identifier_serializer.rb
@@ -2,4 +2,5 @@
 
 # JSON API serialization for a Rule Identifier
 class RuleIdentifierSerializer < ApplicationSerializer
+  attributes :label, :system
 end

--- a/test/controllers/v1/rules_controller_test.rb
+++ b/test/controllers/v1/rules_controller_test.rb
@@ -111,6 +111,27 @@ module V1
         assert_response :unprocessable_entity
       end
 
+      should 'fail if invalid include parameter when finding rules' do
+        get v1_rules_url, params: { include: ['foo'] }
+        assert_response :unprocessable_entity
+      end
+
+      should 'fail if invalid include parameter when finding rule by ID' do
+        get v1_rule_url(@profile.rules.first.id), params: { include: 'foo' }
+        assert_response :unprocessable_entity
+      end
+
+      should 'find rules with rule identifier included' do
+        get v1_rules_url, params: { include: 'rule_identifier' }
+        assert_response :success
+      end
+
+      should 'find a rule by ID with rule identifier included' do
+        get v1_rule_url(@profile.rules.first.id),
+            params: { include: 'rule_identifier' }
+        assert_response :success
+      end
+
       should 'finds a rule with similar slug within the user scope' do
         @profile.rules.first.update(
           slug: "#{@profile.rules.first.ref_id}-#{SecureRandom.uuid}"


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

Adding the `system` and `label` attributes to the rule identifier serializer so that they are available via REST API under "included" in the response. 

To test: Add `include==rule_identifier` to the end of the REST API call. Also, use the `/api/compliance/v1/rules` or `/api/compliance/v1/rules/{id}` path in the URL of the API call.

Current response: 
```
"included": [
        {
            "id": "87b9a20b-3f3b-4889-8db6-219b5e167b73",
            "type": "rule_identifier"
        }
    ]
```

Response after this update:
 ```
"included": [
        {
            "attributes": {
                "label": "CCE-27012-4",
                "system": "https://nvd.nist.gov/cce/index.cfm"
            },
            "id": "87b9a20b-3f3b-4889-8db6-219b5e167b73",
            "type": "rule_identifier"
        }
    ]
```