### PR TITLE
feat(Profiles): RHICOMPL-2399 Add scope returning latest profiles

### DIFF
--- a/app/models/concerns/profile_searching.rb
+++ b/app/models/concerns/profile_searching.rb
@@ -135,6 +135,18 @@ module ProfileSearching
                    ::Xccdf::Benchmark.where.not(version: value)
       { conditions: benchmark_id.in(benchmarks.pluck(:id)).to_sql }
     end
+
+    def profiles_for_os_major(major_os_version)
+      ::SupportedSsg.sorted_ssgs_for_os_major(major_os_version)
+                    .each_with_object({}) do |supported_ssg, latest_profiles|
+        supported_ssg.profiles.keys.each do |profile|
+          next if latest_profiles.values.flatten.include?(profile)
+
+          latest_profiles[supported_ssg.version] ||= []
+          latest_profiles[supported_ssg.version] << profile
+        end
+      end
+    end
   end
 
   class_methods do

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -53,6 +53,15 @@ class Profile < ApplicationRecord
 
   scope :joins_policy, -> { left_outer_joins(:policy) }
 
+  scope :supported_for_os_major, lambda { |major|
+    Profile.profiles_for_os_major(major)
+           .inject(none) do |union, (version, profs)|
+      ref_ids = profs.map { |p| "xccdf_org.ssgproject.content_profile_#{p}" }
+      union.or(where(ref_id: ref_ids).ssg_versions(version)
+                                     .os_major_version(major))
+    end
+  }
+
   delegate :account_number, to: :account, allow_nil: true
 
   class << self

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -69,6 +69,11 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
       all.group_by(&:os_major_version)
     end
 
+    def sorted_ssgs_for_os_major(os_major_version)
+      for_os_major(os_major_version).sort_by(&:comparable_version)
+                                    .reverse
+    end
+
     private
 
     def map_attributes(rhel, raw_attrs)
@@ -79,6 +84,11 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
 
     def os_version(rhel)
       rhel.scan(/(\d+)\.(\d+)$/)[0]
+    end
+
+    def for_os_major(os_major_version)
+      os_major_version = os_major_version.to_s
+      all.select { |ssg| ssg.os_major_version == os_major_version }
     end
 
     def clear


### PR DESCRIPTION
…chmark

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

Adding a method that will return all latest profiles on a benchmark. The current endpoint only gets us the profiles from the latest benchmark, but there might be missing profiles that are only available in older ones. This method returns the latest versions of all profiles for a certain benchmark, even if they are not on the latest version of the benchmark. 

Currently, there are too many lines in the ProfileSearching Module: `Metrics/ModuleLength: Module has too many lines. [111/100]`. 