### PR TITLE
fix(racecar): RHICOMPL-2496 explicit symbolization for config

### DIFF
--- a/config/racecar.rb
+++ b/config/racecar.rb
@@ -3,9 +3,9 @@ Racecar.configure do |config|
   config.group_id_prefix = 'compliance'
 
   if Settings.kafka.security_protocol
-    config.security_protocol = Settings.kafka.security_protocol
+    config.security_protocol = Settings.kafka.security_protocol.try(:to_sym)
 
-    if config.security_protocol == 'sasl_ssl'
+    if config.security_protocol == :sasl_ssl
       config.ssl_ca_location = Settings.kafka.ssl_ca_location
       config.sasl_username = Settings.kafka.sasl_username
       config.sasl_password = Settings.kafka.sasl_password


### PR DESCRIPTION
The `config.security_protocol` should and will be a symbol...