### PR TITLE
feat(Benchmark): RHICOMPL-1896 allow reimports for backport versions

### DIFF
--- a/db/migrate/20211203100649_add_package_name_to_benchmarks.rb
+++ b/db/migrate/20211203100649_add_package_name_to_benchmarks.rb
@@ -1,0 +1,9 @@
+class AddPackageNameToBenchmarks < ActiveRecord::Migration[5.2]
+  def up
+    add_column :benchmarks, :package_name, :string
+  end
+
+  def down
+    remove_column :benchmarks, :package_name
+  end
+end

--- a/db/migrate/20211211074855_clear_revisions.rb
+++ b/db/migrate/20211211074855_clear_revisions.rb
@@ -1,0 +1,9 @@
+class ClearRevisions < ActiveRecord::Migration[5.2]
+  def up
+    Revision.find_by(name: 'datastreams')&.delete
+  end
+
+  def down
+    #nop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_131735) do
+ActiveRecord::Schema.define(version: 2021_12_11_074855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_131735) do
     t.string "version", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "package_name"
     t.index ["ref_id", "version"], name: "index_benchmarks_on_ref_id_and_version", unique: true
   end
 

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -30,6 +30,16 @@ module Xccdf
       ::Xccdf::Benchmark.any_instance.expects(:profiles)
                         .returns(stub(canonical: ['profile-mock1']))
                         .at_least_once
+
+      SupportedSsg.expects(:by_os_major).returns(
+        nil => [
+          OpenStruct.new(
+            version: 'v0.1.49',
+            package: 'foo'
+          )
+        ]
+      ).at_least_once
+
       assert_difference('Xccdf::Benchmark.count', 1) do
         mock.save_benchmark
       end
@@ -43,6 +53,16 @@ module Xccdf
       ::Xccdf::Benchmark.any_instance.expects(:profiles)
                         .returns(stub(canonical: ['profile-mock1']))
                         .at_least_once
+
+      SupportedSsg.expects(:by_os_major).returns(
+        nil => [
+          OpenStruct.new(
+            version: 'v0.1.49',
+            package: nil
+          )
+        ]
+      ).at_least_once
+
       mock.save_benchmark
       assert mock.benchmark_contents_equal_to_op?
 
@@ -56,6 +76,41 @@ module Xccdf
     test 'benchmark is not saved if rules count differ' do
       mock = Mock.new(OP_BENCHMARK)
       assert_not_equal mock.benchmark.rules.count, OP_BENCHMARK.rules.count
+
+      SupportedSsg.expects(:by_os_major).returns(
+        nil => [
+          OpenStruct.new(
+            version: 'v0.1.49',
+            package: nil
+          )
+        ]
+      )
+
+      assert_not mock.benchmark_contents_equal_to_op?
+    end
+
+    test 'benchmark is not saved if package_name differs' do
+      mock = Mock.new(OP_BENCHMARK)
+      ::Xccdf::Benchmark.any_instance.expects(:rules)
+                        .returns(['rule-mock1']).at_least_once
+      ::Xccdf::Benchmark.any_instance.expects(:profiles)
+                        .returns(stub(canonical: ['profile-mock1']))
+                        .at_least_once
+
+      SupportedSsg.expects(:by_os_major).returns(
+        nil => [
+          OpenStruct.new(
+            version: 'v0.1.49',
+            package: 'foo'
+          )
+        ]
+      ).at_least_once
+
+      mock.save_benchmark
+      assert mock.benchmark_contents_equal_to_op?
+
+      mock.instance_variable_get(:@benchmark).update(package_name: 'bar')
+
       assert_not mock.benchmark_contents_equal_to_op?
     end
 
@@ -63,6 +118,16 @@ module Xccdf
       mock = Mock.new(OP_BENCHMARK)
       ::Xccdf::Benchmark.any_instance.expects(:profiles)
                         .returns(%w[profiles-mock1 mock2]).at_least_once
+
+      SupportedSsg.expects(:by_os_major).returns(
+        nil => [
+          OpenStruct.new(
+            version: 'v0.1.49',
+            package: nil
+          )
+        ]
+      ).at_least_once
+
       assert_not_equal mock.benchmark.profiles.count,
                        OP_BENCHMARK.profiles.count
       assert_not mock.benchmark_contents_equal_to_op?

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -7,6 +7,10 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     attr_accessor :op_benchmark, :op_test_result, :op_profiles, :op_rules,
                   :op_rule_results, :rules
     attr_reader :test_result_file, :host, :profiles
+
+    def package_name
+      nil
+    end
   end
 
   setup do
@@ -21,6 +25,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       account: @account.account_number,
       display_name: 'MyStringone'
     )
+
     @report_parser = TestParser
                      .new(fake_report,
                           'account' => @account.account_number,


### PR DESCRIPTION
I'm adding a new column for benchmarks that stores the SSG package name, if there's a difference between the imported vs current, the benchmark should be reimported on its own.