### PR TITLE
fix(DanglingAccountRemover): RHICOMPL-2537 do not depend on cyndi

### DIFF
--- a/app/services/dangling_account_remover.rb
+++ b/app/services/dangling_account_remover.rb
@@ -32,7 +32,12 @@ class DanglingAccountRemover
     end
 
     def accounts_with_hosts
-      Host.with_policies_or_test_results.select(:account).distinct.arel
+      if ApplicationRecord.connection.data_source_exists?(Host.table_name)
+        Host.with_policies_or_test_results.select(:account).distinct.arel
+      else
+        # When setting up initial migrations and cyndi is not yet available
+        ApplicationRecord.none
+      end
     end
   end
 end

--- a/test/services/dangling_account_remover_test.rb
+++ b/test/services/dangling_account_remover_test.rb
@@ -35,4 +35,10 @@ class DanglingAccountRemoverTest < ActiveSupport::TestCase
     assert accounts[2].reload
     assert accounts[3].reload
   end
+
+  test 'accounts_with_hosts' do
+    ApplicationRecord.connection.expects(:data_source_exists?).returns(false)
+    none = DanglingAccountRemover.send(:accounts_with_hosts)
+    assert none, ApplicationRecord.none
+  end
 end


### PR DESCRIPTION
Sometimes cyndi is not available on initial setups and in this case not even needed (ephemeral, development, ci) and it fails on this migration. I'm adding a safeguard to return with an empty relation so the migration can continue. If there are no inventory hosts, this service should not do anything anyway.