### PR TITLE
fix(GraphQL): RHICOMPL-2257 narrow down querying for profiles/hosts

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -11,6 +11,19 @@ module Mutations
   # Helpers for host related mutations
   module HostHelper
     include UserHelper
+
+    def find_host(host_id)
+      ::Pundit.authorize(
+        current_user,
+        ::Host.find(host_id),
+        :show?
+      )
+    end
+
+    def find_hosts(host_ids)
+      ::Pundit.policy_scope(current_user, ::Host)
+              .where(id: host_ids)
+    end
   end
 
   # Helpers for profile related mutations

--- a/app/graphql/mutations/profile/associate_systems.rb
+++ b/app/graphql/mutations/profile/associate_systems.rb
@@ -13,9 +13,10 @@ module Mutations
 
       def resolve(args = {})
         ::Profile.transaction do
+          hosts = find_hosts(args[:system_ids])
           profile = find_profile(args[:id])
           if profile&.policy
-            profile.policy.update_hosts(args[:system_ids])
+            profile.policy.update_hosts(hosts.pluck(:id))
             audit_mutation(profile)
           end
           { profile: profile, profiles: profile.policy.profiles }

--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -41,7 +41,7 @@ module Mutations
 
       def new_policy(args)
         ::Policy.new(new_policy_options(args)).fill_from(
-          profile: ::Profile.find(args[:clone_from_profile_id])
+          profile: ::Profile.canonical.find(args[:clone_from_profile_id])
         )
       end
 

--- a/app/graphql/mutations/system/associate_profiles.rb
+++ b/app/graphql/mutations/system/associate_profiles.rb
@@ -11,7 +11,7 @@ module Mutations
       field :system, ::Types::System, null: true
 
       def resolve(args = {})
-        host = Host.find(args[:id])
+        host = find_host(args[:id])
         policies = find_profiles(args[:profile_ids]).map(&:policy).uniq
         policies.map do |policy|
           policy.hosts << host


### PR DESCRIPTION
Making the host lookup in mutations analogous to profile lookups and narrowing down profile querying in policy creation for speed.