### PR TITLE
fix(clowder): RHICOMPL-2553 livenessProbe timeout for sidekiq

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -270,6 +270,7 @@ objects:
           httpGet:
             path: /metrics
             port: metrics
+          timeoutSeconds: 5
         readinessProbe:
           timeoutSeconds: 5
           exec:


### PR DESCRIPTION
Racecar had it, I don't see why sidekiq shouldn't. Hopefully it fixes the livenessProbe triggered restarts under heavy loads.