### PR TITLE
fix(rails): RHICOMPL-2569 fixed db setup in development for rails61

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ bundle exec rake ssg:import_rhel_supported
 The compliance project integrates with project cyndi. For local development, a database view is created, built from the inventory database which runs alongside the compliance database. The Cyndi hosts view exists within an inventory schema within the compliance database.
 
 ```shell
-bundle exec rails db < db/cyndi_setup_devel.sql # syndicated (cyndi) hosts from inventory
-RAILS_ENV=test bundle exec rails db < db/cyndi_setup_test.sql # cyndi for test DB
+bundle exec rails db -p < db/cyndi_setup_devel.sql # syndicated (cyndi) hosts from inventory
+RAILS_ENV=test bundle exec rails db -p < db/cyndi_setup_test.sql # cyndi for test DB
 ```
 
 You can verify everything worked as expected within psql for compliance_dev and

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,14 +142,16 @@ services:
     entrypoint: ''
     command: sh -c '
       if bundle exec rake db:version 2> /dev/null; then
-        bundle exec rake db:migrate;
+        bundle exec rake --trace db:migrate;
       else
-        bundle exec rake db:setup;
+        bundle exec rake --trace db:setup;
       fi;
-      RAILS_ENV=test bundle exec rake db:create;
-      RAILS_ENV=test bundle exec rake db:test:prepare;
-      bundle exec rails db < db/cyndi_setup_devel.sql;
-      RAILS_ENV=test bundle exec rails db < db/cyndi_setup_test.sql;
+      RAILS_ENV=test bundle exec rake --trace db:create;
+      RAILS_ENV=test bundle exec rake --trace db:test:prepare;
+      echo "Setting up Cyndi data in the development DB"
+      bundle exec rails db -p < db/cyndi_setup_devel.sql;
+      echo "Setting up Cyndi data in the test DB"
+      RAILS_ENV=test bundle exec rails db -p < db/cyndi_setup_test.sql;
       '
     volumes:
       - .:/app:z


### PR DESCRIPTION
The `bin/rails db` command now required a `-p` argument if we want to avoid interactive password input (idk why) and I also added some tracing to the rake tasks in the compose file for better debugging.