### PR TITLE
chore(rails6): RHICOMPL-2540 get rid of the remaining deprecations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       railties
       sprockets-rails
     graphql (1.10.9)
-    graphql-batch (0.4.2)
+    graphql-batch (0.4.3)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
     hashdiff (1.0.1)
@@ -323,7 +323,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
-    scoped_search (4.1.9)
+    scoped_search (4.1.10)
       activerecord (>= 4.2.0)
     shoulda-context (1.2.2)
     shoulda-matchers (4.3.0)

--- a/app/graphql/mutations/profile/associate_rules.rb
+++ b/app/graphql/mutations/profile/associate_rules.rb
@@ -18,7 +18,7 @@ module Mutations
         ::Profile.transaction do
           profile = find_profile(args[:id])
           if profile
-            rules_added, rules_removed = profile.update_rules(rules)
+            rules_added, rules_removed = profile.update_rules(**rules)
             audit_mutation(profile, rules_added, rules_removed)
           end
           { profile: profile }

--- a/app/services/safe_downloader.rb
+++ b/app/services/safe_downloader.rb
@@ -39,7 +39,7 @@ class SafeDownloader
 
     def download_reports(url, opts = {})
       begin
-        downloaded_file = download(url, opts)
+        downloaded_file = download(url, **opts)
       rescue *DOWNLOAD_ERRORS
         Rails.logger.audit_fail("Failed to download report from URL: #{url}")
         raise

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -368,6 +368,6 @@ class AuthenticationTest < ActionController::TestCase
       headers.each { |key, val| @request.headers[key] = val }
     end
 
-    process(action_name, params)
+    process(action_name, **params)
   end
 end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/