### PR TITLE
fix(profiles): RHICOMPL-2574 decouple validation from inventory

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -41,7 +41,7 @@ class Profile < ApplicationRecord
   }, if: -> { os_minor_version.present? }
   validates :name, presence: true
   validates :benchmark_id, presence: true
-  validates :account, presence: true, if: -> { hosts.any? }
+  validates :account, presence: true, if: -> { parent_profile_id && hosts.any? }
   validates :policy, presence: true, if: -> { policy_id }
 
   scope :canonical_for_os, lambda { |os_major_version, os_minor_version|


### PR DESCRIPTION
Non-canonical profiles should have an account assigned, however, the validation of this was tied to a profile having an assigned host instead of a parent profile, which triggered validation during SSG imports. As the SSG import in a clean DB can happen before the inventory is available, this can slow down the deployment process in ephemeral and docker-compose. The fix also addresses the wrong validation for the `policy` tied to itself.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
