### PR TITLE
fix(ParseReportJob): RHICOMPL-1021 read reports from S3, not redis

### DIFF
--- a/app/consumers/concerns/report_parsing.rb
+++ b/app/consumers/concerns/report_parsing.rb
@@ -21,9 +21,8 @@ module ReportParsing
     end
 
     def enqueue_parse_report_job(reports)
-      reports.each do |profile_id, report|
-        job = ParseReportJob
-              .perform_async(ActiveSupport::Gzip.compress(report), metadata)
+      reports.each_with_index do |(profile_id, _report), idx|
+        job = ParseReportJob.perform_async(idx, metadata)
         notify_report_success(profile_id, job)
       end
 
@@ -84,7 +83,8 @@ module ReportParsing
     def metadata
       (@msg_value.dig('platform_metadata', 'metadata') || {}).merge(
         'id' => id,
-        'b64_identity' => b64_identity
+        'b64_identity' => b64_identity,
+        'url' => url
       )
     end
 

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class ParseReportJobTest < ActiveSupport::TestCase
   setup do
-    @msg_value = { 'id': '', 'account': '', 'request_id': '' }
+    @msg_value = { 'id' => '', 'account' => '', 'request_id' => '', 'url' => '' }
     @parse_report_job = ParseReportJob.new
     @file = file_fixture('report.tar.gz').read
     @parser = mock('XccdfReportParser')
@@ -16,7 +16,9 @@ class ParseReportJobTest < ActiveSupport::TestCase
     @logger.stubs(:error)
   end
 
-  test 'payload tracker is notified about successful processing' do
+  # TODO: delete the legacy tests after the legacy jobs are drained in production
+
+  test 'legacy - payload tracker is notified about successful processing' do
     XccdfReportParser.stubs(:new).returns(@parser)
     @parser.stubs(:save_all)
     Sidekiq.stubs(:redis).returns(false)
@@ -44,7 +46,7 @@ class ParseReportJobTest < ActiveSupport::TestCase
     assert_audited 'Successful report of profileid policy policyUUID'
   end
 
-  test 'remediation service is notified about results with failed issues' do
+  test 'legacy - remediation service is notified about results with failed issues' do
     XccdfReportParser.stubs(:new).returns(@parser)
     @parser.stubs(:save_all)
     profile_stub = OpenStruct.new(
@@ -65,7 +67,7 @@ class ParseReportJobTest < ActiveSupport::TestCase
     @parse_report_job.perform(@file, @msg_value)
   end
 
-  test 'payload tracker is notified about errored processing' do
+  test 'legacy - payload tracker is notified about errored processing' do
     XccdfReportParser.stubs(:new).returns(@parser)
     @parser.stubs(:save_all).raises(
       XccdfReportParser::WrongFormatError.new('Wrong format or benchmark')
@@ -93,7 +95,7 @@ class ParseReportJobTest < ActiveSupport::TestCase
     assert_audited 'Failed to parse report profileid'
   end
 
-  test 'no parsed data with parsing failure' do
+  test 'legacy - no parsed data with parsing failure' do
     XccdfReportParser.stubs(:new).raises(XccdfReportParser::WrongFormatError)
     Sidekiq.stubs(:redis).returns(false)
     @parse_report_job.stubs(:jid).returns('1')
@@ -101,6 +103,106 @@ class ParseReportJobTest < ActiveSupport::TestCase
       .stubs(:remediation_issue_ids)
       .returns([@issue_id])
     @parse_report_job.perform(@file, @msg_value)
+    assert_audited 'Failed to parse report'
+  end
+
+  test 'payload tracker is notified about successful processing' do
+    XccdfReportParser.stubs(:new).returns(@parser)
+    @parser.stubs(:save_all)
+    Sidekiq.stubs(:redis).returns(false)
+    @parse_report_job.stubs(:jid).returns('1')
+    @parse_report_job
+      .stubs(:remediation_issue_ids)
+      .returns([@issue_id])
+    profile_stub = OpenStruct.new(
+      test_result: OpenStruct.new(profile_id: 'profileid')
+    )
+    @parser.stubs(:test_result_file).returns(profile_stub)
+    @parser.stubs(:host_profile)
+           .returns(OpenStruct.new(policy_id: 'policyUUID'))
+    PayloadTracker.expects(:deliver).with(
+      account: @msg_value['account'], system_id: @msg_value['id'],
+      request_id: @msg_value['request_id'], status: :processing,
+      status_msg: 'Job 1 is now processing'
+    )
+    PayloadTracker.expects(:deliver).with(
+      account: @msg_value['account'], system_id: @msg_value['id'],
+      request_id: @msg_value['request_id'], status: :success,
+      status_msg: 'Job 1 has completed successfully'
+    )
+    SafeDownloader.expects(:download_reports)
+                  .with('', ssl_only: Settings.report_download_ssl_only)
+                  .returns(ActiveSupport::Gzip.decompress(@file))
+    @parse_report_job.perform(0, @msg_value)
+    assert_audited 'Successful report of profileid policy policyUUID'
+  end
+
+  test 'remediation service is notified about results with failed issues' do
+    XccdfReportParser.stubs(:new).returns(@parser)
+    @parser.stubs(:save_all)
+    profile_stub = OpenStruct.new(
+      test_result: OpenStruct.new(profile_id: 'profileid')
+    )
+    @parser.stubs(:test_result_file).returns(profile_stub)
+    @parser.stubs(:host_profile)
+           .returns(OpenStruct.new(policy_id: 'policyUUID'))
+    Sidekiq.stubs(:redis).returns(false)
+    @parse_report_job.stubs(:jid).returns('1')
+    @parse_report_job
+      .stubs(:remediation_issue_ids)
+      .returns([@issue_id])
+    RemediationUpdates.expects(:deliver).with(
+      host_id: @msg_value['id'],
+      issue_ids: [@issue_id]
+    )
+    SafeDownloader.expects(:download_reports)
+                  .with('', ssl_only: Settings.report_download_ssl_only)
+                  .returns(ActiveSupport::Gzip.decompress(@file))
+    @parse_report_job.perform(0, @msg_value)
+  end
+
+  test 'payload tracker is notified about errored processing' do
+    XccdfReportParser.stubs(:new).returns(@parser)
+    @parser.stubs(:save_all).raises(
+      XccdfReportParser::WrongFormatError.new('Wrong format or benchmark')
+    )
+    profile_stub = OpenStruct.new(
+      test_result: OpenStruct.new(profile_id: 'profileid')
+    )
+    @parser.stubs(:test_result_file).returns(profile_stub)
+    Sidekiq.stubs(:redis).returns(false)
+    @parse_report_job.stubs(:jid).returns('1')
+    PayloadTracker.expects(:deliver).with(
+      account: @msg_value['account'], system_id: @msg_value['id'],
+      request_id: @msg_value['request_id'], status: :processing,
+      status_msg: 'Job 1 is now processing'
+    )
+    error_msg = @msg_value.to_json
+    PayloadTracker.expects(:deliver).with(
+      account: @msg_value['account'], system_id: @msg_value['id'],
+      request_id: @msg_value['request_id'], status: :error,
+      status_msg:
+      'Failed to parse report profileid: XccdfReportParser::WrongFormatError:' \
+      " Wrong format or benchmark - #{error_msg}"
+    )
+    SafeDownloader.expects(:download_reports)
+                  .with('', ssl_only: Settings.report_download_ssl_only)
+                  .returns(ActiveSupport::Gzip.decompress(@file))
+    @parse_report_job.perform(0, @msg_value)
+    assert_audited 'Failed to parse report profileid'
+  end
+
+  test 'no parsed data with parsing failure' do
+    XccdfReportParser.stubs(:new).raises(XccdfReportParser::WrongFormatError)
+    Sidekiq.stubs(:redis).returns(false)
+    @parse_report_job.stubs(:jid).returns('1')
+    @parse_report_job
+      .stubs(:remediation_issue_ids)
+      .returns([@issue_id])
+    SafeDownloader.expects(:download_reports)
+                  .with('', ssl_only: Settings.report_download_ssl_only)
+                  .returns(ActiveSupport::Gzip.decompress(@file))
+    @parse_report_job.perform(0, @msg_value)
     assert_audited 'Failed to parse report'
   end
 end


### PR DESCRIPTION
This should reduce the memory footprint of Redis as we would be no longer channel the reports through it. The racecar task pushes the URL to the job and Sidekiq consumes it directly from the S3. It's a bit less efficient as it does N+1 downloads (each report once + validation in racecar) though, but it's fully compatible with the old setup, i.e. 1 job for 1 report if N reports are in an upload. Also it's capable of draining old jobs from sidekiq, so we should clean that up later...

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
