### PR TITLE
chore(deps): RHICOMPL-2632 update racecar and ruby-kafka

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     crass (1.0.6)
     deep_merge (1.2.1)
     diff-lcs (1.3)
-    digest-crc (0.6.3)
+    digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.4.0)
     dotenv (2.7.6)
@@ -146,7 +146,7 @@ GEM
       i18n (>= 1.6, < 2)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.15.4)
+    ffi (1.15.5)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
     gitlab-sidekiq-fetcher (0.8.0)
@@ -230,9 +230,9 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     racc (1.6.0)
-    racecar (2.2.0)
+    racecar (2.4.0)
       king_konf (~> 1.0.0)
-      rdkafka (~> 0.8.0)
+      rdkafka (~> 0.10.0)
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -269,7 +269,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdkafka (0.8.1)
+    rdkafka (0.10.0)
       ffi (~> 1.9)
       mini_portile2 (~> 2.1)
       rake (>= 12.3)
@@ -321,7 +321,7 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
-    ruby-kafka (1.3.0)
+    ruby-kafka (1.4.0)
       digest-crc
     ruby-progressbar (1.11.0)
     safe_yaml (1.0.5)
@@ -443,4 +443,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   2.3.5
+   2.3.6


### PR DESCRIPTION
Hoping that this will fix our LeaderNotAvailable issues in development :pray: 