### PR TITLE
fix(db:setup): RHICOMPL-2645 do not convert Arel to SQL on startup

### DIFF
--- a/app/models/xccdf/benchmark.rb
+++ b/app/models/xccdf/benchmark.rb
@@ -24,7 +24,7 @@ module Xccdf
 
     sortable_by :title
     # Ordering by hash can't deal with Arel, so this juggling is necessary
-    sortable_by :version, Arel.sql(SORT_BY_VERSION.to_sql)
+    sortable_by :version, SORT_BY_VERSION
 
     include ::BenchmarkSearching
 


### PR DESCRIPTION
Apparently calling `.to_sql` on an Arel node in a model constant crashes if the database is not available, which also crashes a ` rake db:setup` call. Ideally we would not need the `to_sql` conversion, but [Rails can't deal with Arel nodes in an order hash](https://github.com/rails/rails/issues/44282) and until the [fix](https://github.com/rails/rails/pull/44284) gets in, we need to compensate somehow. So as a solution I moved the conversion from the constant to a bit deeper.

I know it's ugly, but we have to deal with it for some time :disappointed: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
