### PR TITLE
perf(DatastreamImporter) RHICOMPL-2539 less array operations in import

### DIFF
--- a/app/services/concerns/xccdf/rule_references.rb
+++ b/app/services/concerns/xccdf/rule_references.rb
@@ -25,13 +25,11 @@ module Xccdf
                                       .find_unique(@op_rule_references)
       end
 
-      def existing_href_labels
-        existing_rule_references.pluck(:href, :label)
-      end
-
       def new_op_rule_references
+        @existing_href_labels = existing_rule_references.pluck(:href, :label)
+
         @op_rule_references.reject do |op_reference|
-          existing_href_labels.include? [op_reference.href, op_reference.label]
+          @existing_href_labels.include? [op_reference.href, op_reference.label]
         end
       end
     end

--- a/app/services/concerns/xccdf/rule_references_rules.rb
+++ b/app/services/concerns/xccdf/rule_references_rules.rb
@@ -54,17 +54,16 @@ module Xccdf
       end
 
       def rule_references_for(op_rule: nil)
-        label_hrefs = op_rule.rule_references.map do |rr|
-          [rr.label, rr.href]
-        end
+        @cached_references ||= @rule_references.index_by { |rr| [rr.label, rr.href] }
 
-        @rule_references.select do |reference|
-          label_hrefs.include?([reference.label, reference.href])
-        end
+        op_rule.rule_references.map do |rr|
+          @cached_references[[rr.label, rr.href]]
+        end.compact
       end
 
       def rule_for(ref_id:)
-        @rules.find { |r| r.ref_id == ref_id }
+        @cached_rules ||= @rules.index_by(&:ref_id)
+        @cached_rules[ref_id]
       end
     end
   end


### PR DESCRIPTION
There were a lot of unnecessary `Array#[]` calls in the SSG importing process. The `RuleReferences#existing_href_labels` method was being called multiple times and even though the ActiveRecord result was cached there, the `pluck` operation was repetitive. In the `RuleReferencesRules` module the `rule_references_for` and `rule_for` modules were having slow and repetitive `select` and `find` calls which I replaced with a lookup hash generated by `index_by`.

Based on my benchmarks on an empty DB, the original code did the SSG import process in 17:46 and with my changes this went down to 3:33 so we're 5 times faster. This should significantly speed up the deployment process in ephemeral environments and the results should be also visible on the CI below.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
