### PR TITLE
feat(Group): RHICOMPL-2482 Add Group to DB model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'prometheus_exporter', '>= 0.5'
 gem 'manageiq-loggers', '~> 0.6.0'
 
 # Parsing OpenSCAP reports library
-gem 'openscap_parser', '~> 1.0.0'
+gem 'openscap_parser', '~> 1.1.0'
 
 # RBAC service API
 gem 'insights-rbac-api-client', '~> 1.0.0'
@@ -82,6 +82,9 @@ gem 'request_store'
 gem 'cgi', ">= 0.3.1"
 gem 'rexml'
 gem 'webrick'
+
+# Allows for tree structures in db 
+gem 'ancestry'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ancestry (4.1.0)
+      activerecord (>= 5.2.6)
     ansi (1.5.0)
     ast (2.4.2)
     bootsnap (1.9.3)
@@ -174,7 +176,7 @@ GEM
     insights-rbac-api-client (1.0.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    io-console (0.5.6)
+    io-console (0.5.7)
     io-wait (0.2.1)
     irb (1.2.4)
       reline (>= 0.0.1)
@@ -232,7 +234,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.10.6)
-    openscap_parser (1.0.1)
+    openscap_parser (1.1.0)
       nokogiri (~> 1.6)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -302,7 +304,7 @@ GEM
       rake (>= 12.3)
     redis (4.5.1)
     regexp_parser (2.2.0)
-    reline (0.1.4)
+    reline (0.2.5)
       io-console (~> 0.5)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -414,6 +416,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  ancestry
   bootsnap (>= 1.1.0)
   brakeman
   bullet
@@ -440,7 +443,7 @@ DEPENDENCIES
   minitest-stub-const
   mocha
   oj
-  openscap_parser (~> 1.0.0)
+  openscap_parser (~> 1.1.0)
   pg
   prometheus_exporter (>= 0.5)
   pry-byebug

--- a/app/models/concerns/profile_rules.rb
+++ b/app/models/concerns/profile_rules.rb
@@ -7,6 +7,8 @@ module ProfileRules
   included do
     has_many :profile_rules, dependent: :delete_all
     has_many :rules, through: :profile_rules, source: :rule
+    has_many :profile_rule_groups, dependent: :delete_all
+    has_many :rule_groups, through: :profile_rule_groups, source: :rule_group
 
     def update_rules(ids: nil, ref_ids: nil)
       removed = ::ProfileRule.where(

--- a/app/models/profile_rule_group.rb
+++ b/app/models/profile_rule_group.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Join table to be able to have a has-many-belongs-to-many relation between
+# Profile and RuleGroup
+class ProfileRuleGroup < ApplicationRecord
+  belongs_to :profile
+  belongs_to :rule_group
+
+  validates :profile, presence: true
+  validates :rule_group, presence: true, uniqueness: { scope: :profile }
+end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -29,10 +29,16 @@ class Rule < ApplicationRecord
 
   has_many :profile_rules, dependent: :delete_all
   has_many :profiles, through: :profile_rules, source: :profile
+  has_many :rule_group_rules, dependent: :delete_all
+  has_many :rule_groups, through: :rule_group_rules
   has_many :rule_results, dependent: :delete_all
   has_many :hosts, through: :rule_results, source: :host
   has_many :rule_references_rules, dependent: :delete_all
   has_many :rule_references, through: :rule_references_rules
+  has_many :left_rule_group_relationships, dependent: :delete_all, foreign_key: :left_id,
+                                           inverse_of: :left, class_name: 'RuleGroupRelationship'
+  has_many :right_rule_group_relationships, dependent: :delete_all, foreign_key: :right_id,
+                                            inverse_of: :right, class_name: 'RuleGroupRelationship'
   alias references rule_references
   has_one :rule_identifier, dependent: :destroy
   alias identifier rule_identifier

--- a/app/models/rule_group.rb
+++ b/app/models/rule_group.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# OpenSCAP RuleGroup
+class RuleGroup < ApplicationRecord
+  # Need to set primary key format to work with uuid primary key column
+  has_ancestry(primary_key_format: %r{\A[\w\-]+(\/[\w\-]+)*\z})
+
+  has_many :profile_rule_groups, dependent: :delete_all
+  has_many :profiles, through: :profile_rule_groups, source: :profile
+  has_many :left_rule_group_relationships, dependent: :delete_all, foreign_key: :left_id,
+                                           inverse_of: :left, class_name: 'RuleGroupRelationship'
+  has_many :right_rule_group_relationships, dependent: :delete_all, foreign_key: :right_id,
+                                            inverse_of: :right, class_name: 'RuleGroupRelationship'
+
+  belongs_to :benchmark, class_name: 'Xccdf::Benchmark'
+
+  validates :title, presence: true
+  validates :ref_id, uniqueness: { scope: %i[benchmark_id] }, presence: true
+  validates :description, presence: true
+  validates :benchmark_id, presence: true
+
+  def self.from_openscap_parser(op_rule_group, benchmark_id: nil, parent_id: nil)
+    rule_group = find_or_initialize_by(ref_id: op_rule_group.id,
+                                       benchmark_id: benchmark_id)
+
+    rule_group.assign_attributes(title: op_rule_group.title,
+                                 description: op_rule_group.description,
+                                 rationale: op_rule_group.rationale,
+                                 parent_id: parent_id)
+
+    rule_group
+  end
+end

--- a/app/models/rule_group_relationship.rb
+++ b/app/models/rule_group_relationship.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Required and conflicting relationships between rules and rule groups
+class RuleGroupRelationship < ApplicationRecord
+  belongs_to :left, polymorphic: true
+  belongs_to :right, polymorphic: true
+
+  validates :relationship, presence: true, inclusion: { in: %w[requires conflicts] }
+
+  # Need to use left_id because polymorphic assocations don't support computing the class
+  validates :left_id, presence: true, uniqueness: { scope: %i[relationship right_id right_type left_type] }
+end

--- a/app/models/rule_group_rule.rb
+++ b/app/models/rule_group_rule.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Join table with the has-many-belongs-to-many relations between RuleGroup and Rule
+class RuleGroupRule < ApplicationRecord
+  # These keep track of the parent-child relationship between rules and rule_groups
+  belongs_to :rule
+  belongs_to :rule_group
+
+  validates :rule_group, presence: true
+  validates :rule, presence: true, uniqueness: { scope: :rule_group }
+end

--- a/app/models/xccdf/benchmark.rb
+++ b/app/models/xccdf/benchmark.rb
@@ -19,6 +19,7 @@ module Xccdf
 
     has_many :profiles, dependent: :destroy
     has_many :rules, dependent: :destroy
+    has_many :rule_groups, dependent: :destroy
     validates :ref_id, uniqueness: { scope: %i[version] }, presence: true
     validates :version, presence: true
 

--- a/app/services/concerns/xccdf/profile_rule_groups.rb
+++ b/app/services/concerns/xccdf/profile_rule_groups.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Xccdf
+  # Methods related to saving rule references
+  module ProfileRuleGroups
+    extend ActiveSupport::Concern
+
+    included do
+      def save_profile_rule_groups
+        ::ProfileRuleGroup.transaction do
+          ::ProfileRuleGroup.import!(profile_rule_groups,
+                                     on_duplicate_key_update: {
+                                       conflict_target: %i[rule_group_id profile_id],
+                                       columns: %i[rule_group_id profile_id]
+                                     })
+
+          base = ::ProfileRuleGroup.joins(profile: :benchmark)
+                                   .where('profiles.parent_profile_id' => nil)
+
+          profile_rule_group_links_to_remove(base).delete_all
+        end
+      end
+
+      private
+
+      def profile_rule_groups
+        @profile_rule_groups ||= @op_profiles.flat_map do |op_profile|
+          profile_id = profile_id_for(ref_id: op_profile.id)
+          rule_group_ids_for(ref_ids: op_profile.selected_rule_ids).map do |rule_group_id|
+            ::ProfileRuleGroup.new(
+              profile_id: profile_id, rule_group_id: rule_group_id
+            )
+          end
+        end
+      end
+
+      def profile_rule_group_links_to_remove(base)
+        grouped_rules = profile_rule_groups.group_by(&:profile_id)
+        grouped_rules.reduce(ProfileRuleGroup.none) do |query, (profile_id, prs)|
+          query.or(
+            base.where(profile_id: profile_id)
+                .where.not(rule_group_id: prs.map(&:rule_group_id))
+          )
+        end
+      end
+
+      def profile_id_for(ref_id:)
+        @profiles.find { |p| p.ref_id == ref_id }.id
+      end
+
+      def rule_group_ids_for(ref_ids:)
+        @rule_groups.select { |r| ref_ids.include?(r.ref_id) }.map(&:id)
+      end
+    end
+  end
+end

--- a/app/services/concerns/xccdf/profile_rules.rb
+++ b/app/services/concerns/xccdf/profile_rules.rb
@@ -17,7 +17,7 @@ module Xccdf
           base = ::ProfileRule.joins(profile: :benchmark)
                               .where('profiles.parent_profile_id' => nil)
 
-          links_to_remove(base).delete_all
+          profile_rule_links_to_remove(base).delete_all
         end
       end
 
@@ -34,7 +34,7 @@ module Xccdf
         end
       end
 
-      def links_to_remove(base)
+      def profile_rule_links_to_remove(base)
         grouped_rules = profile_rules.group_by(&:profile_id)
         grouped_rules.reduce(ProfileRule.none) do |query, (profile_id, prs)|
           query.or(

--- a/app/services/concerns/xccdf/rule_group_relationships.rb
+++ b/app/services/concerns/xccdf/rule_group_relationships.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Xccdf
+  # Methods related to saving RuleGroupRelationships
+  module RuleGroupRelationships
+    extend ActiveSupport::Concern
+    included do
+      def save_rule_group_relationships
+        @op_rules_and_rule_groups = @op_rule_groups + @op_rules
+
+        ::RuleGroupRelationship.import!(
+          rule_group_relationships.select(&:new_record?), ignore: true
+        )
+
+        rgr_links_to_remove(::RuleGroupRelationship).delete_all
+      end
+
+      private
+
+      def rule_group_relationships
+        @rule_group_relationships ||= @op_rules_and_rule_groups.flat_map do |op_r_or_rg|
+          %i[conflicts requires].flat_map { |type| with_relationship(op_r_or_rg, type) }
+        end.compact
+      end
+
+      def with_relationship(entity, type)
+        left = rule_or_rule_group_for(ref_id: entity.id)
+        entity.send(type).map do |relationship_ref_id|
+          right = rule_or_rule_group_for(ref_id: relationship_ref_id)
+          next unless right
+
+          ::RuleGroupRelationship.find_or_initialize_by(
+            left: left, right: right, relationship: type
+          )
+        end
+      end
+
+      def rgr_links_to_remove(base)
+        grouped_by_rgr = rule_group_relationships&.group_by(&:left_id)
+        grouped_by_rgr&.reduce(RuleGroupRelationship.none) do |query, (left_id, rgr)|
+          query.or(
+            base.where(left_id: left_id)
+                .where.not(right_id: rgr.map(&:right_id))
+                .where.not(relationship: rgr.map(&:relationship))
+          )
+        end
+      end
+
+      def rule_or_rule_group_for(ref_id:)
+        rule_for(ref_id: ref_id) || rule_group_for(ref_id: ref_id)
+      end
+    end
+  end
+end

--- a/app/services/concerns/xccdf/rule_group_rules.rb
+++ b/app/services/concerns/xccdf/rule_group_rules.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Xccdf
+  # Methods related to saving RuleGroupRules
+  module RuleGroupRules
+    extend ActiveSupport::Concern
+
+    included do
+      def save_rule_group_rules
+        ::RuleGroupRule.import!(rules_with_rule_group_parent, ignore: true)
+
+        rule_parent_links_to_remove(::RuleGroupRule).delete_all
+      end
+
+      private
+
+      def rules_with_rule_group_parent
+        @op_rules.flat_map do |op_rule|
+          rule_group = rule_group_for(ref_id: op_rule.parent_id)
+          next unless rule_group
+
+          rule = rule_for(ref_id: op_rule.id)
+          ::RuleGroupRule.new(rule_group: rule_group, rule: rule)
+        end.compact
+      end
+
+      def rule_parent_links_to_remove(base)
+        grouped_by_rgr = rules_with_rule_group_parent.group_by(&:rule_id)
+        grouped_by_rgr.reduce(RuleGroupRule.none) do |query, (rule_id, rgr)|
+          query.or(
+            base.where(rule_id: rule_id)
+                .where.not(rule_group_id: rgr.map(&:rule_group_id))
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/concerns/xccdf/rule_groups.rb
+++ b/app/services/concerns/xccdf/rule_groups.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Xccdf
+  # Methods related to saving groups
+  module RuleGroups
+    extend ActiveSupport::Concern
+
+    included do
+      def save_rule_groups
+        @rule_groups ||= @op_rule_groups.map do |op_rule_group|
+          ::RuleGroup.from_openscap_parser(op_rule_group, benchmark_id: @benchmark&.id)
+        end
+
+        ::RuleGroup.import!(@rule_groups.select(&:new_record?), ignore: true)
+
+        ::RuleGroup.import!(rule_group_parents, on_duplicate_key_update: {
+                              conflict_target: %i[ref_id benchmark_id],
+                              columns: %i[ancestry]
+                            }, validate: false)
+      end
+
+      private
+
+      def rule_group_parents
+        @op_rule_groups.select(&:parent_id).map do |op_rule_group|
+          rule_group = rule_group_for(ref_id: op_rule_group.id)
+          rule_group.parent_id = rule_group_for(ref_id: op_rule_group.parent_id)&.id
+          rule_group
+        end
+      end
+
+      def rule_group_for(ref_id:)
+        @cached_rule_groups ||= @rule_groups.index_by(&:ref_id)
+        @cached_rule_groups[ref_id]
+      end
+    end
+  end
+end

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -9,25 +9,35 @@ module Xccdf
       include ::Xccdf::Benchmarks
       include ::Xccdf::Profiles
       include ::Xccdf::Rules
+      include ::Xccdf::RuleGroups
       include ::Xccdf::RuleIdentifiers
+      include ::Xccdf::ProfileRuleGroups
       include ::Xccdf::ProfileRules
       include ::Xccdf::RuleReferences
       include ::Xccdf::RuleReferencesRules
+      include ::Xccdf::RuleGroupRules
+      include ::Xccdf::RuleGroupRelationships
       include ::Xccdf::Hosts
       include ::Xccdf::RuleResults
       include ::Xccdf::TestResult
 
+      # rubocop:disable Metrics/MethodLength
       def save_all_benchmark_info
         return if benchmark_contents_equal_to_op?
 
         save_benchmark
         save_profiles
+        save_rule_groups
         save_rules
         save_rule_identifiers
+        save_rule_group_rules
+        save_rule_group_relationships
+        save_profile_rule_groups
         save_profile_rules
         save_rule_references
         save_rule_references_rules
       end
+      # rubocop:enable Metrics/MethodLength
 
       def save_all_test_result_info
         save_host_profile
@@ -39,6 +49,7 @@ module Xccdf
       def set_openscap_parser_data
         @op_benchmark = @test_result_file.benchmark
         @op_test_result = @test_result_file.test_result
+        @op_rule_groups = @op_benchmark.groups
         @op_profiles = @op_benchmark.profiles
         @op_rules = @op_benchmark.rules
         @op_rule_references =

--- a/app/services/datastream_importer.rb
+++ b/app/services/datastream_importer.rb
@@ -8,6 +8,7 @@ class DatastreamImporter
   def initialize(datastream_filename)
     @op_benchmark = op_datastream_file(datastream_filename).benchmark
     @op_profiles = @op_benchmark.profiles
+    @op_rule_groups = @op_benchmark.groups
     @op_rules = @op_benchmark.rules
     @op_rule_references =
       @op_benchmark.rule_references.reject { |rr| rr.label.empty? }

--- a/db/migrate/20200327170640_remove_empty_benchmarks.rb
+++ b/db/migrate/20200327170640_remove_empty_benchmarks.rb
@@ -17,7 +17,7 @@ class RemoveEmptyBenchmarks < ActiveRecord::Migration[5.2]
         empty_rule_references_rules.delete_all
         empty_benchmark.rules.delete_all
       end
-      empty_benchmarks.destroy_all
+      empty_benchmarks.delete_all
     end
   end
 

--- a/db/migrate/20220202002459_create_rule_groups.rb
+++ b/db/migrate/20220202002459_create_rule_groups.rb
@@ -1,0 +1,38 @@
+class CreateRuleGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rule_groups, id: :uuid do |t|
+      t.string :ref_id
+      t.string :title
+      t.text :description
+      t.text :rationale
+      t.string :ancestry
+      t.index :ancestry
+      t.references :benchmark, type: :uuid, null: false, foreign_key: true
+      t.references :rule, type: :uuid, foreign_key: true, index: {unique: true}
+      t.index [:ref_id, :benchmark_id], unique: true
+    end
+
+    create_table :rule_group_rules, id: :uuid do |t|
+      t.references :rule_group, type: :uuid, foreign_key: true
+      t.references :rule, type: :uuid, foreign_key: true
+      t.index [:rule_group_id, :rule_id], unique: true
+    end
+
+    create_table :rule_group_relationships, id: :uuid do |t|
+      t.references :left, type: :uuid, polymorphic: true
+      t.references :right, type: :uuid, polymorphic: true
+      t.string :relationship
+      t.index [:left_id, :right_id, :right_type, :left_type, :relationship],
+               name: 'index_rule_group_relationships_unique',
+               unique: true
+    end
+
+    create_table :profile_rule_groups, id: :uuid do |t|
+      t.references :profile, type: :uuid, index: true, null: false
+      t.references :rule_group, type: :uuid, index: true, null: false
+      t.index [:profile_id, :rule_group_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220323130920_clear_revisions_march_twenty_third.rb
+++ b/db/migrate/20220323130920_clear_revisions_march_twenty_third.rb
@@ -1,0 +1,9 @@
+class ClearRevisionsMarchTwentyThird < ActiveRecord::Migration[7.0]
+  def up
+    Revision.find_by(name: 'datastreams')&.delete
+  end
+
+  def down
+    # nop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_12_143550) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_23_130920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -78,6 +78,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_12_143550) do
     t.index ["policy_id"], name: "index_policy_hosts_on_policy_id"
   end
 
+  create_table "profile_rule_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "profile_id", null: false
+    t.uuid "rule_group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id", "rule_group_id"], name: "index_profile_rule_groups_on_profile_id_and_rule_group_id", unique: true
+    t.index ["profile_id"], name: "index_profile_rule_groups_on_profile_id"
+    t.index ["rule_group_id"], name: "index_profile_rule_groups_on_rule_group_id"
+  end
+
   create_table "profile_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "profile_id", null: false
     t.uuid "rule_id", null: false
@@ -119,6 +129,39 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_12_143550) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_revisions_on_name", unique: true
+  end
+
+  create_table "rule_group_relationships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "left_type"
+    t.uuid "left_id"
+    t.string "right_type"
+    t.uuid "right_id"
+    t.string "relationship"
+    t.index ["left_id", "right_id", "right_type", "left_type", "relationship"], name: "index_rule_group_relationships_unique", unique: true
+    t.index ["left_type", "left_id"], name: "index_rule_group_relationships_on_left"
+    t.index ["right_type", "right_id"], name: "index_rule_group_relationships_on_right"
+  end
+
+  create_table "rule_group_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "rule_group_id"
+    t.uuid "rule_id"
+    t.index ["rule_group_id", "rule_id"], name: "index_rule_group_rules_on_rule_group_id_and_rule_id", unique: true
+    t.index ["rule_group_id"], name: "index_rule_group_rules_on_rule_group_id"
+    t.index ["rule_id"], name: "index_rule_group_rules_on_rule_id"
+  end
+
+  create_table "rule_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "ref_id"
+    t.string "title"
+    t.text "description"
+    t.text "rationale"
+    t.string "ancestry"
+    t.uuid "benchmark_id", null: false
+    t.uuid "rule_id"
+    t.index ["ancestry"], name: "index_rule_groups_on_ancestry"
+    t.index ["benchmark_id"], name: "index_rule_groups_on_benchmark_id"
+    t.index ["ref_id", "benchmark_id"], name: "index_rule_groups_on_ref_id_and_benchmark_id", unique: true
+    t.index ["rule_id"], name: "index_rule_groups_on_rule_id", unique: true
   end
 
   create_table "rule_identifiers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -214,4 +257,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_12_143550) do
   add_foreign_key "policy_hosts", "policies"
   add_foreign_key "profiles", "policies"
   add_foreign_key "profiles", "profiles", column: "parent_profile_id"
+  add_foreign_key "rule_group_rules", "rule_groups"
+  add_foreign_key "rule_group_rules", "rules"
+  add_foreign_key "rule_groups", "benchmarks"
+  add_foreign_key "rule_groups", "rules"
 end

--- a/test/factories/rule_group.rb
+++ b/test/factories/rule_group.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rule_group do
+    title { Faker::Lorem.sentence }
+    ref_id { "foo-#{SecureRandom.uuid}" }
+    description { Faker::Lorem.paragraph }
+    rationale { Faker::Lorem.paragraph }
+    benchmark
+  end
+end

--- a/test/factories/rule_group_relationship.rb
+++ b/test/factories/rule_group_relationship.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rule_group_relationship do
+    for_rule_group_and_rule_group_requires
+    trait :for_rule_group_and_rule_group_requires do
+      association :left, factory: :rule_group
+      association :right, factory: :rule_group
+      relationship { 'requires' }
+    end
+
+    trait :for_rule_and_rule_requires do
+      association :left, factory: :rule
+      association :right, factory: :rule
+      relationship { 'requires' }
+    end
+
+    trait :for_rule_and_rule_group_requires do
+      association :left, factory: :rule
+      association :right, factory: :rule_group
+      relationship { 'requires' }
+    end
+
+    trait :for_rule_group_and_rule_requires do
+      association :left, factory: :rule_group
+      association :right, factory: :rule
+      relationship { 'requires' }
+    end
+
+    trait :for_rule_group_and_rule_group_conflicts do
+      association :left, factory: :rule_group
+      association :right, factory: :rule_group
+      relationship { 'conflicts' }
+    end
+
+    trait :for_rule_and_rule_conflicts do
+      association :left, factory: :rule
+      association :right, factory: :rule
+      relationship { 'conflicts' }
+    end
+
+    trait :for_rule_and_rule_group_conflicts do
+      association :left, factory: :rule
+      association :right, factory: :rule_group
+      relationship { 'conflicts' }
+    end
+
+    trait :for_rule_group_and_rule_conflicts do
+      association :left, factory: :rule_group
+      association :right, factory: :rule
+      relationship { 'conflicts' }
+    end
+  end
+end

--- a/test/factories/rule_group_rule.rb
+++ b/test/factories/rule_group_rule.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :rule_group_rule do
+    association :rule_group, factory: :rule_group
+    association :rule, factory: :rule
+  end
+end

--- a/test/fixtures/files/xccdf_report.xml
+++ b/test/fixtures/files/xccdf_report.xml
@@ -238,7 +238,7 @@ Regardless of your system's workload all of these checks should pass.</descripti
     <select idref="xccdf_org.ssgproject.content_group_dns_server_separate_internal_external" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_dns_server_partition_with_views" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_nfs_and_rpc" selected="false"/>
-    <select idref="xccdf_org.ssgproject.content_group_nfs_configuring_servers" selected="false"/>
+    <select idref="xccdf_org.ssgproject.content_group_nfs_configuring_servers" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_group_use_acl_enforce_auth_restrictions" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_export_filesystems_read_only" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_configure_exports_restrictively" selected="false"/>
@@ -280,10 +280,10 @@ Regardless of your system's workload all of these checks should pass.</descripti
     <select idref="xccdf_org.ssgproject.content_group_locking_out_password_attempts" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_accounts-banners" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_gui_login_banner" selected="false"/>
-    <select idref="xccdf_org.ssgproject.content_group_accounts-physical" selected="false"/>
+    <select idref="xccdf_org.ssgproject.content_group_accounts-physical" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_group_screen_locking" selected="false"/>
-    <select idref="xccdf_org.ssgproject.content_group_smart_card_login" selected="false"/>
-    <select idref="xccdf_org.ssgproject.content_group_console_screen_locking" selected="false"/>
+    <select idref="xccdf_org.ssgproject.content_group_smart_card_login" selected="true"/>
+    <select idref="xccdf_org.ssgproject.content_group_console_screen_locking" selected="true"/>
     <select idref="xccdf_org.ssgproject.content_group_user_umask" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_selinux" selected="false"/>
     <select idref="xccdf_org.ssgproject.content_group_selinux-booleans" selected="false"/>
@@ -2272,6 +2272,7 @@ be forwarded to at least one monitored email address.</rationale>
       </Group>
       <Group id="xccdf_org.ssgproject.content_group_postfix_harden_os">
         <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Configure Operating System to Protect Mail Server</title>
+        <requires idref="xccdf_org.ssgproject.content_group_postfix_configure_ssl_certs xccdf_org.ssgproject.content_group_postfix_install_ssl_cert xccdf_org.ssgproject.content_rule_sshd_disable_rhosts"/>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">The guidance in this section is appropriate for any host which is
 operating as a site MTA, whether the mail server runs using Sendmail, Postfix,
 or some other software.</description>
@@ -2619,6 +2620,8 @@ Run the following command:
         </Group>
         <Rule id="xccdf_org.ssgproject.content_rule_sshd_disable_rhosts" selected="false" severity="medium">
           <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Disable SSH Support for .rhosts Files</title>
+          <requires idref="xccdf_org.ssgproject.content_group_ssh_server"/>
+          <requires idref="xccdf_org.ssgproject.content_group_sshd_strengthen_firewall"/>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">SSH can emulate the behavior of the obsolete rsh
 command in allowing users to enable insecure access to their
 accounts via <html:code xmlns:html="http://www.w3.org/1999/xhtml">.rhosts</html:code> files.
@@ -2662,6 +2665,8 @@ replace_or_append '/etc/ssh/sshd_config' '^IgnoreRhosts' 'yes' '' '%s %s'
         </Rule>
         <Rule id="xccdf_org.ssgproject.content_rule_sshd_set_keepalive" selected="false" severity="medium">
           <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Set SSH Client Alive Count</title>
+          <conflicts idref="xccdf_org.ssgproject.content_rule_sshd_disable_rhosts"/>
+          <conflicts idref="xccdf_org.ssgproject.content_group_talk"/>
           <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">To ensure the SSH idle timeout occurs precisely when the <html:code xmlns:html="http://www.w3.org/1999/xhtml">ClientAliveInterval</html:code> is set,
 edit <html:code xmlns:html="http://www.w3.org/1999/xhtml">/etc/ssh/sshd_config</html:code> as follows:
 <html:pre xmlns:html="http://www.w3.org/1999/xhtml">ClientAliveCountMax 0</html:pre></description>
@@ -3916,6 +3921,7 @@ location. The system's default proxy server software is Squid, and
 provided in an RPM package of the same name.</description>
       <Group id="xccdf_org.ssgproject.content_group_disabling_squid">
         <title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">Disable Squid if Possible</title>
+        <conflicts idref="xccdf_org.ssgproject.content_group_openstack"/>
         <description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US">If Squid was installed and activated, but the system
 does not need to act as a proxy server, then it should be disabled
 and removed.</description>

--- a/test/models/benchmark_test.rb
+++ b/test/models/benchmark_test.rb
@@ -15,6 +15,7 @@ module Xccdf
 
     should have_many(:profiles)
     should have_many(:rules)
+    should have_many(:rule_groups)
 
     OP_BENCHMARK = OpenStruct.new(id: '1', version: 'v0.1.49',
                                   title: 'one', description: 'first')

--- a/test/models/rule_group_relationship_test.rb
+++ b/test/models/rule_group_relationship_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RuleGroupRelationshipTest < ActiveSupport::TestCase
+  should belong_to(:left)
+  should belong_to(:right)
+
+  setup do
+    fake_report = file_fixture('xccdf_report.xml').read
+    @op_benchmark = OpenscapParser::TestResultFile.new(fake_report).benchmark
+    @op_rule_groups = @op_benchmark.groups
+
+    account = FactoryBot.create(:account)
+    @profile = FactoryBot.create(
+      :profile,
+      account: account
+    )
+    @rule_group_1 = FactoryBot.create(:rule_group)
+    @rule_group_2 = FactoryBot.create(:rule_group)
+    @rule_1 = FactoryBot.create(:rule)
+    @rule_2 = FactoryBot.create(:rule)
+  end
+
+  test 'rule or rule group cannot require the same rule or rule group twice' do
+    rgr1 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_requires)
+    rgr2 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_requires)
+    rgr2.update!(left: rgr1.left)
+    exception = assert_raises(Exception) do
+      rgr2.update!(right: rgr1.right)
+    end
+    assert_equal(exception.message, 'Validation failed: Left has already been taken')
+  end
+
+  test 'rule or rule group cannot conflict with the same rule or rule group twice' do
+    rgr1 = FactoryBot.create(:rule_group_relationship, :for_rule_and_rule_group_conflicts)
+    rgr2 = FactoryBot.create(:rule_group_relationship, :for_rule_and_rule_group_conflicts)
+    rgr2.update!(left: rgr1.left)
+    exception = assert_raises(Exception) do
+      rgr2.update!(right: rgr1.right)
+    end
+    assert_equal(exception.message, 'Validation failed: Left has already been taken')
+  end
+
+  test 'rule or rule group can be required by more than one rule or rule group' do
+    rgr1 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_group_requires)
+    rgr2 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_group_requires)
+    assert_nothing_raised do
+      rgr2.update!(right: rgr1.right)
+    end
+  end
+
+  test 'rule or rule group can be conflicting with more than one rule or rule group' do
+    rgr1 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_group_conflicts)
+    rgr2 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_group_conflicts)
+    assert_nothing_raised do
+      rgr2.update!(right: rgr1.right)
+    end
+  end
+
+  test 'two left_id columns can have the same value but left_type must be different' do
+    rule = FactoryBot.create(:rule)
+    rule_group = FactoryBot.create(:rule_group)
+    rule_group.update!(id: rule.id)
+    rgr1 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_group_conflicts)
+    rgr2 = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_group_conflicts)
+    rgr1.update!(left: rule)
+    assert_nothing_raised do
+      rgr2.update!(left: rule_group)
+    end
+    assert_equal rule.id, rule_group.id
+  end
+end

--- a/test/models/rule_group_rule_test.rb
+++ b/test/models/rule_group_rule_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RuleGroupRuleTest < ActiveSupport::TestCase
+  should belong_to(:rule)
+  should belong_to(:rule_group)
+
+  setup do
+    fake_report = file_fixture('xccdf_report.xml').read
+    @op_benchmark = OpenscapParser::TestResultFile.new(fake_report).benchmark
+    @op_rule_groups = @op_benchmark.groups
+
+    account = FactoryBot.create(:account)
+    @profile = FactoryBot.create(
+      :profile,
+      account: account
+    )
+    @rule_group_1 = FactoryBot.create(:rule_group)
+    @rule_group_2 = FactoryBot.create(:rule_group)
+    @rule_1 = FactoryBot.create(:rule)
+    @rule_2 = FactoryBot.create(:rule)
+  end
+
+  test 'a rule group can be a parent for more than one rule' do
+    rgr1 = FactoryBot.create(:rule_group_rule)
+    rgr2 = FactoryBot.create(:rule_group_rule)
+    assert_nothing_raised do
+      rgr2.update!(rule_group: rgr1.rule_group)
+    end
+    assert_equal rgr1.rule_group, rgr2.rule_group
+  end
+end

--- a/test/models/rule_group_test.rb
+++ b/test/models/rule_group_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RuleGroupTest < ActiveSupport::TestCase
+  should validate_uniqueness_of(:ref_id).scoped_to(:benchmark_id)
+  should validate_presence_of :ref_id
+  should validate_presence_of :title
+  should validate_presence_of :description
+  should validate_presence_of :benchmark_id
+
+  should belong_to(:benchmark)
+
+  setup do
+    fake_report = file_fixture('xccdf_report.xml').read
+    @op_benchmark = OpenscapParser::TestResultFile.new(fake_report).benchmark
+    @op_rule_groups = @op_benchmark.groups
+
+    account = FactoryBot.create(:account)
+    @profile = FactoryBot.create(
+      :profile,
+      account: account
+    )
+    @rule_group = FactoryBot.create(:rule_group)
+    @parent_rule_group = FactoryBot.create(:rule_group)
+  end
+
+  test 'creates rule_groups from openscap_parser RuleGroup object' do
+    assert RuleGroup.from_openscap_parser(@op_rule_groups.first,
+                                          benchmark_id: @profile.benchmark.id).save
+  end
+
+  test 'updates rule groups with parent to set ancestry' do
+    assert_nil @rule_group.ancestry
+
+    @rule_group.update!(parent_id: @parent_rule_group.id)
+
+    assert_not_nil @rule_group.ancestry
+    assert_equal @rule_group.parent_id, @parent_rule_group.id
+  end
+end

--- a/test/services/concerns/xccdf/profile_rule_groups_test.rb
+++ b/test/services/concerns/xccdf/profile_rule_groups_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/profiles'
+
+module Xccdf
+  # A class to test Xccdf::Profiles
+  class ProfileRuleGroupsTest < ActiveSupport::TestCase
+    include Xccdf::ProfileRuleGroups
+
+    setup do
+      @account = FactoryBot.create(:account)
+      @host = FactoryBot.create(:host, account: @account.account_number)
+      @benchmark = FactoryBot.create(:canonical_profile).benchmark
+      parser = OpenscapParser::TestResultFile.new(
+        file_fixture('xccdf_report.xml').read
+      )
+      @op_profiles = parser.benchmark.profiles
+      @profiles = @op_profiles.map do |op_profile|
+        ::Profile.from_openscap_parser(op_profile, benchmark_id: @benchmark&.id)
+      end
+      ::Profile.import!(@profiles, ignore: true)
+      @op_rule_groups = parser.benchmark.groups
+      @rule_groups = @op_rule_groups.map do |op_rule_group|
+        ::RuleGroup.from_openscap_parser(op_rule_group, benchmark_id: @benchmark&.id)
+      end
+      ::RuleGroup.import!(@rule_groups, ignore: true)
+      @op_rules = parser.benchmark.rules
+      @rules = @op_rules.map do |op_rule|
+        ::Rule.from_openscap_parser(op_rule, benchmark_id: @benchmark&.id)
+      end
+      ::Rule.import!(@rules, ignore: true)
+    end
+
+    test 'saves profile rule groups only once' do
+      assert_difference('ProfileRuleGroup.count', 4) do
+        save_profile_rule_groups
+      end
+
+      assert_no_difference('ProfileRuleGroup.count') do
+        save_profile_rule_groups
+      end
+    end
+
+    test 'updates profile rule group connections' do
+      rule_group1 = FactoryBot.create(:rule_group, benchmark: @benchmark)
+      rule_group2 = ::RuleGroup.from_openscap_parser(
+        @op_rule_groups.find do |rule_group|
+          rule_group.id == 'xccdf_org.ssgproject.content_group_accounts-physical'
+        end,
+        benchmark_id: @benchmark&.id
+      )
+      @profiles.first.update(rule_groups: [rule_group1, rule_group2])
+
+      assert_difference('ProfileRuleGroup.count', 2) do
+        save_profile_rule_groups
+      end
+
+      assert_nil ProfileRuleGroup.find_by(rule_group: rule_group1, profile: @profiles.first)
+      assert ProfileRuleGroup.find_by(rule_group: rule_group2, profile: @profiles.first)
+    end
+  end
+end

--- a/test/services/concerns/xccdf/rule_group_relationships_test.rb
+++ b/test/services/concerns/xccdf/rule_group_relationships_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/rule_group_relationships'
+require 'xccdf/rule_groups'
+require 'xccdf/rule_references_rules'
+
+class RuleGroupRelationshipsTest < ActiveSupport::TestCase
+  include Xccdf::Profiles
+  include Xccdf::Rules
+  include Xccdf::RuleGroupRules
+  include Xccdf::RuleGroups
+  include Xccdf::ProfileRules
+  include Xccdf::RuleReferences
+  include Xccdf::RuleReferencesRules
+  include Xccdf::RuleGroupRelationships
+
+  attr_accessor :benchmark, :account, :op_profiles, :op_rules, :rules,
+                :rule_groups, :op_rule_groups, :rule_groups_with_parents,
+                :op_rules_and_rule_groups
+
+  context 'without any required or conflicting rules or rule groups' do
+    setup do
+      @account = FactoryBot.create(:account)
+      @host = FactoryBot.create(:host, account: @account.account_number)
+      @benchmark = FactoryBot.create(:canonical_profile).benchmark
+      parser = OpenscapParser::TestResultFile.new(
+        file_fixture('rhel-xccdf-report.xml').read
+      )
+      @op_rules = parser.benchmark.rules
+      @op_rule_groups = parser.benchmark.groups
+      @rule_groups = @op_rule_groups.map do |op_rule_group|
+        ::RuleGroup.from_openscap_parser(op_rule_group, benchmark_id: @benchmark&.id)
+      end
+      ::RuleGroup.import!(@rule_groups, ignore: true)
+      @rules = @op_rules.map do |op_rule|
+        ::Rule.from_openscap_parser(op_rule, benchmark_id: @benchmark&.id)
+      end
+      ::Rule.import!(@rules, ignore: true)
+      @op_rules_and_rule_groups = @op_rules + @op_rule_groups
+    end
+
+    should 'save no rule group relationships when there are no required or conflicting rules or rule groups' do
+      assert_no_difference('RuleGroupRelationship.count') do
+        save_rule_group_relationships
+      end
+    end
+
+    should 'return empty array are no required rules or rule groups' do
+      required_rule_group_relationships = send(:rule_group_relationships)
+      assert_equal [], required_rule_group_relationships
+    end
+  end
+
+  context 'with required and conflicting rules or rule groups' do
+    setup do
+      @account = FactoryBot.create(:account)
+      @host = FactoryBot.create(:host, account: @account.account_number)
+      @benchmark = FactoryBot.create(:canonical_profile).benchmark
+      parser = OpenscapParser::TestResultFile.new(
+        file_fixture('xccdf_report.xml').read
+      )
+      @op_rules = parser.benchmark.rules
+      @op_rule_groups = parser.benchmark.groups
+      @rule_groups = @op_rule_groups.map do |op_rule_group|
+        ::RuleGroup.from_openscap_parser(op_rule_group, benchmark_id: @benchmark&.id)
+      end
+      ::RuleGroup.import!(@rule_groups, ignore: true)
+      @rules = @op_rules.map do |op_rule|
+        ::Rule.from_openscap_parser(op_rule, benchmark_id: @benchmark&.id)
+      end
+      ::Rule.import!(@rules, ignore: true)
+      @op_rules_and_rule_groups = @op_rules + @op_rule_groups
+    end
+
+    should 'save rule group rules with required and conflicting rules and rule groups' do
+      assert_difference('RuleGroupRelationship.count', 8) do
+        save_rule_group_relationships
+      end
+    end
+
+    should 'save rule group rules only once' do
+      assert_difference('RuleGroupRelationship.count', 8) do
+        save_rule_group_relationships
+      end
+
+      assert_no_difference('RuleGroupRelationship.count') do
+        save_rule_group_relationships
+      end
+    end
+
+    should 'save a rule group rule for all required rules or rule groups' do
+      required_rule_group_relationships = send(:rule_group_relationships)
+      assert_equal 8, required_rule_group_relationships.count
+    end
+
+    should 'delete rule_group_relationships that are no longer relevant' do
+      rule_groups_by_ref_id = @rule_groups.index_by(&:ref_id)
+      rg = rule_groups_by_ref_id['xccdf_org.ssgproject.content_group_disabling_squid']
+      rgr = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_requires)
+      rgr.update!(left: rg, right: @rules.first)
+      assert_not_nil RuleGroupRelationship.where(id: rgr.id).first
+      save_rule_group_relationships
+      assert_nil RuleGroupRelationship.where(id: rgr.id).first
+    end
+
+    should 'not delete rule_group_relationships that are still relevant' do
+      rule_groups_by_ref_id = @rule_groups.index_by(&:ref_id)
+      rg = rule_groups_by_ref_id['xccdf_org.ssgproject.content_group_disabling_squid']
+      required_rg = rule_groups_by_ref_id['xccdf_org.ssgproject.content_group_openstack']
+      rgr = FactoryBot.create(:rule_group_relationship, :for_rule_group_and_rule_conflicts)
+      rgr.update!(left: rg, right: required_rg)
+      assert_not_nil RuleGroupRelationship.where(id: rgr.id).first
+      save_rule_group_relationships
+      assert_not_nil RuleGroupRelationship.where(id: rgr.id).first
+    end
+  end
+end

--- a/test/services/concerns/xccdf/rule_group_rules_test.rb
+++ b/test/services/concerns/xccdf/rule_group_rules_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/rule_group_rules'
+require 'xccdf/rule_groups'
+require 'xccdf/rule_references_rules'
+
+class RuleGroupRulesTest < ActiveSupport::TestCase
+  include Xccdf::Profiles
+  include Xccdf::Rules
+  include Xccdf::RuleGroupRules
+  include Xccdf::RuleGroups
+  include Xccdf::ProfileRules
+  include Xccdf::RuleReferences
+  include Xccdf::RuleReferencesRules
+
+  attr_accessor :benchmark, :account, :op_profiles, :op_rules, :rules,
+                :rule_groups, :op_rule_groups, :rule_groups_with_parents,
+                :op_rules_and_rule_groups, :rule_group_rules
+
+  context 'parent-child relationship between rule group and rule' do
+    setup do
+      @account = FactoryBot.create(:account)
+      @host = FactoryBot.create(:host, account: @account.account_number)
+      @benchmark = FactoryBot.create(:canonical_profile).benchmark
+      parser = OpenscapParser::TestResultFile.new(
+        file_fixture('xccdf_report.xml').read
+      )
+      @op_rules = parser.benchmark.rules
+      @op_rule_groups = parser.benchmark.groups
+      @rule_groups = @op_rule_groups.map do |op_rule_group|
+        ::RuleGroup.from_openscap_parser(op_rule_group, benchmark_id: @benchmark&.id)
+      end
+      ::RuleGroup.import!(@rule_groups, ignore: true)
+      @rules = @op_rules.map do |op_rule|
+        ::Rule.from_openscap_parser(op_rule, benchmark_id: @benchmark&.id)
+      end
+      ::Rule.import!(@rules, ignore: true)
+      @op_rules_and_rule_groups = @op_rules + @op_rule_groups
+    end
+
+    should 'save rule group rules for parent-child relationship between rule group and rule' do
+      assert_difference('RuleGroupRule.count', 367) do
+        save_rule_group_rules
+      end
+    end
+
+    should 'save rule group rules for parent-child relationship between rule group and rule only once' do
+      assert_difference('RuleGroupRule.count', 367) do
+        save_rule_group_rules
+      end
+
+      assert_no_difference('RuleGroupRule.count') do
+        save_rule_group_rules
+      end
+    end
+
+    should 'remove rule_group_rules that are no longer relevent' do
+      rules_by_ref_id = @rules.index_by(&:ref_id)
+      rule = rules_by_ref_id['xccdf_org.ssgproject.content_rule_install_PAE_kernel_on_x86-32']
+      rule_group_rule = RuleGroupRule.create!(rule_id: rule.id,
+                                              rule_group_id: @rule_groups.first.id)
+      assert_not_nil RuleGroupRule.where(id: rule_group_rule.id).first
+
+      save_rule_group_rules
+
+      assert_not_nil RuleGroupRule.where(rule_id: rule.id).first
+      assert_nil RuleGroupRule.where(id: rule_group_rule.id).first
+    end
+  end
+end

--- a/test/services/concerns/xccdf/rule_groups_test.rb
+++ b/test/services/concerns/xccdf/rule_groups_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/rule_groups'
+
+class RuleGroupsTest < ActiveSupport::TestCase
+  include Xccdf::Profiles
+  include Xccdf::Rules
+  include Xccdf::RuleGroupRules
+  include Xccdf::RuleGroups
+  include Xccdf::ProfileRules
+  include Xccdf::RuleReferences
+
+  attr_accessor :benchmark, :account, :op_profiles, :op_rules, :rules,
+                :rule_groups, :op_rule_groups, :rule_groups_with_parents
+
+  setup do
+    @account = FactoryBot.create(:account)
+    @host = FactoryBot.create(:host, account: @account.account_number)
+    @benchmark = FactoryBot.create(:canonical_profile).benchmark
+    parser = OpenscapParser::TestResultFile.new(
+      file_fixture('rhel-xccdf-report.xml').read
+    )
+    @op_rules = parser.benchmark.rules
+    @op_rule_groups = parser.benchmark.groups
+  end
+
+  test 'save all rule groups as new' do
+    assert_difference('RuleGroup.count', 232) do
+      save_rule_groups
+    end
+  end
+
+  test 'returns rule groups saved in the report' do
+    rule_group = RuleGroup.from_openscap_parser(@op_rule_groups.sample,
+                                                benchmark_id: @benchmark.id)
+    assert rule_group.save
+    save_rule_groups
+    assert_includes @rule_groups, rule_group
+  end
+
+  test 'update ancestry column for rule group with parents' do
+    @rule_groups = @op_rule_groups.map do |op_rule_group|
+      ::RuleGroup.from_openscap_parser(op_rule_group, benchmark_id: @benchmark&.id)
+    end
+    ::RuleGroup.import!(@rule_groups, ignore: true)
+    assert_equal 0, @rule_groups.select(&:ancestry).count
+    @rule_groups_with_parents = send(:rule_group_parents)
+    ::RuleGroup.import!(@rule_groups_with_parents, on_duplicate_key_update: {
+                          conflict_target: %i[ref_id benchmark_id],
+                          columns: :all
+                        })
+    assert_equal 228, @rule_groups.select(&:ancestry).count
+  end
+
+  test 'saves rule groups only once' do
+    assert_difference('RuleGroup.count', 232) do
+      save_rule_groups
+    end
+
+    assert_no_difference('RuleGroup.count') do
+      save_rule_groups
+    end
+  end
+end

--- a/test/services/concerns/xccdf/rules_test.rb
+++ b/test/services/concerns/xccdf/rules_test.rb
@@ -7,6 +7,8 @@ class RulesTest < ActiveSupport::TestCase
   class Mock
     include Xccdf::Profiles
     include Xccdf::Rules
+    include Xccdf::RuleGroupRules
+    include Xccdf::RuleGroups
     include Xccdf::ProfileRules
     include Xccdf::RuleReferences
 
@@ -18,6 +20,7 @@ class RulesTest < ActiveSupport::TestCase
       @op_test_result = test_result_file.test_result
       @op_rules = @op_benchmark.rules
       @op_profiles = @op_benchmark.profiles
+      @op_rule_groups = @op_benchmark.groups
     end
   end
 
@@ -27,6 +30,7 @@ class RulesTest < ActiveSupport::TestCase
       :canonical_profile, :with_rules
     ).benchmark
     @mock.account = FactoryBot.create(:account)
+    @mock.save_rule_groups
   end
 
   test 'save all rules as new' do

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class XccdfReportParserTest < ActiveSupport::TestCase
   class TestParser < ::XccdfReportParser
     attr_accessor :op_benchmark, :op_test_result, :op_profiles, :op_rules,
-                  :op_rule_results, :rules
+                  :op_rule_results, :rules, :op_rule_groups, :rule_groups
     attr_reader :test_result_file, :host, :profiles
 
     def package_name
@@ -84,6 +84,13 @@ class XccdfReportParserTest < ActiveSupport::TestCase
           @report_parser.save_all
         end
       end
+    end
+  end
+
+  context 'rule_group' do
+    setup do
+      @report_parser.save_benchmark
+      @report_parser.save_profiles
     end
   end
 
@@ -200,11 +207,13 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       ]
       @report_parser.save_benchmark
       @report_parser.save_profiles
+      @report_parser.save_rule_groups
     end
 
     should 'link the rules with the profile' do
       @report_parser.save_rules
       @report_parser.save_profile_rules
+      @report_parser.save_profile_rule_groups
       rule_ref_id = @report_parser.op_profiles
                                   .find { |p| p.id == @profile.keys.first }
                                   .selected_rule_ids.sample
@@ -249,6 +258,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         assert_difference('rule.profiles.count', 0) do
           @report_parser.save_rules
           @report_parser.save_profile_rules
+          @report_parser.save_profile_rule_groups
         end
       end
       assert_includes rule.profiles, profile
@@ -262,6 +272,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
 
       @report_parser.save_rules
       @report_parser.save_profile_rules
+      @report_parser.save_profile_rule_groups
       assert_empty(Profile.where(parent_profile: parent_profile))
       assert_difference(
         -> { Profile.count } => 1,
@@ -291,6 +302,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       ) do
         @report_parser.save_rules
         @report_parser.save_profile_rules
+        @report_parser.save_profile_rule_groups
         @report_parser.save_host_profile
       end
     end


### PR DESCRIPTION
`requires` or `conflicts` can show up as an element under a Group or a Rule. `conflicts` will only have one `idref` of a certain Rule or Group that needs to be **unselected** because it conflicts with the current Group/Rule. `requires` can be a list of one or more ids that need to be **selected** in order for the current Group/Rule to be evaluated correctly. 

<img width="639" alt="152354480-3528a19a-e670-48c9-9037-5590e0799a26" src="https://user-images.githubusercontent.com/7695766/152366936-8262823f-0f2f-4a49-b4e2-6bc7eea743ba.png">

Depends on https://github.com/OpenSCAP/openscap_parser/pull/34

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [x] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
