### PR TITLE
fix(deadlock): RHICOMPL-2694 remove downstream marking in ssg_import

### DIFF
--- a/app/services/concerns/xccdf/profiles.rb
+++ b/app/services/concerns/xccdf/profiles.rb
@@ -13,14 +13,6 @@ module Xccdf
         end
 
         ::Profile.import!(new_profiles, ignore: true)
-        # Mark already existing profiles to be imported as non-upstream
-        # rubocop:disable Rails/SkipsModelValidations
-        ::Profile.transaction do
-          ::Profile.where(id: old_profiles.pluck(:id)).update_all(
-            upstream: false
-          )
-        end
-        # rubocop:enable Rails/SkipsModelValidations
       end
       alias_method :save_profiles, :profiles
 

--- a/app/services/concerns/xccdf/rules.rb
+++ b/app/services/concerns/xccdf/rules.rb
@@ -12,12 +12,6 @@ module Xccdf
         end
 
         ::Rule.import!(new_rules, ignore: true)
-        # Mark already existing rules to be imported as non-upstream
-        # rubocop:disable Rails/SkipsModelValidations
-        ::Rule.transaction do
-          ::Rule.where(id: old_rules.pluck(:id)).update_all(upstream: false)
-        end
-        # rubocop:enable Rails/SkipsModelValidations
       end
 
       private


### PR DESCRIPTION
All the new rules and profiles are imported automatically as downstream, no need to update the existing ones over and over again. This also hopefully resolves a deadlock in prod.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
