### PR TITLE
fix(ssgs): RHICOMPL-2649 only import the latest revision for OS major

### DIFF
--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -18,6 +18,12 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     Gem::Version.new(version)
   end
 
+  def version_with_revision
+    Gem::Version.new(
+      package.sub(/^scap-security-guide-(.*)\.el.*$/, '\1')
+    )
+  end
+
   class << self
     def supported?(ssg_version:, os_major_version:, os_minor_version:)
       ssg_versions_for_os(os_major_version, os_minor_version)

--- a/app/services/datastream_downloader.rb
+++ b/app/services/datastream_downloader.rb
@@ -8,8 +8,9 @@ class DatastreamDownloader
 
   def default_supported_ssgs
     ::SupportedSsg.all
-                  .sort_by(&:comparable_version)
+                  .sort_by(&:version_with_revision)
                   .reverse
+                  .uniq { |ssg| [ssg.version, ssg.os_major_version] }
   end
 
   def download_datastreams


### PR DESCRIPTION
As discussed with the OpenSCAP team, we are safe with importing only the latest revision for each benchmark version per OS major. This should prevent the pingponging of rule changes between revisions that should not happen but they actually do.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
