### PR TITLE
feat(ProfileTailoring): RHICOMPL-1736 order rules by precedence

### DIFF
--- a/app/models/concerns/profile_tailoring.rb
+++ b/app/models/concerns/profile_tailoring.rb
@@ -17,7 +17,7 @@ module ProfileTailoring
   end
 
   def added_rules
-    rules - parent_profile.rules
+    rules.order(:precedence) - parent_profile.rules
   end
 
   def removed_rules

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -838,21 +838,24 @@ class ProfileTest < ActiveSupport::TestCase
 
       @rule1 = @parent.rules.first
       @rule2 = FactoryBot.create(:rule, benchmark: @parent.benchmark)
+      @rule3 = FactoryBot.create(:rule, benchmark: @parent.benchmark)
 
       @profile = @parent.clone_to(
         account: @account,
         policy: @policy
       )
-      @profile.update! rules: [@rule2]
+      @profile.update! rules: [@rule2, @rule3]
+      @rule2.update(precedence: 4)
+      @rule3.update(precedence: 1)
     end
 
     should 'send the correct rule ref ids to the tailoring file service' do
-      assert_equal({ @rule1.ref_id => false, @rule2.ref_id => true },
+      assert_equal({ @rule1.ref_id => false, @rule2.ref_id => true, @rule3.ref_id => true },
                    @profile.tailored_rule_ref_ids)
     end
 
-    should 'properly detects added_rules' do
-      assert_equal [@rule2], @profile.added_rules
+    should 'properly detects added_rules in the correct order' do
+      assert_equal [@rule3, @rule2], @profile.added_rules
     end
 
     should 'properly detects removed_rules' do


### PR DESCRIPTION
Not sure if it's really needed but it was mentioned in the JIRA ticket. Also the order in a hash is only maintainable safely if we treat it as immutable, which we do. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
