### PR TITLE
fix(codecov): RHICOMPL-2701 Disable coverage offsets

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,5 +5,3 @@ coverage:
         target: 90
 ignore:
   - "bundle"
-codecov:
-  allow_coverage_offsets: True


### PR DESCRIPTION
> We no longer need them as we always have the latest master's coverage report at hand.

https://docs.codecov.com/docs/comparing-commits#pseudo-comparison

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
