### PR TITLE
fix(ActiveRecord): RHICOMPL-2718 weaken links with host validation

### DIFF
--- a/app/models/policy_host.rb
+++ b/app/models/policy_host.rb
@@ -3,10 +3,11 @@
 # Join table between Policy and Host
 class PolicyHost < ApplicationRecord
   belongs_to :policy
-  belongs_to :host
+  belongs_to :host, optional: true
 
   validates :policy, presence: true
-  validates :host, presence: true, uniqueness: { scope: :policy }
+  validates :host, presence: true, on: :create
+  validates :host_id, presence: true, uniqueness: { scope: :policy }
 
   def self.import_from_policy(policy_id, host_ids)
     import(host_ids.map do |host_id|

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -5,15 +5,16 @@
 # reports of compliance at any point in time
 class RuleResult < ApplicationRecord
   scoped_search on: %i[id rule_id host_id result]
-  belongs_to :host
+  belongs_to :host, optional: true
   belongs_to :rule
   belongs_to :test_result
   has_one :profile, through: :test_result
 
   validates :test_result, presence: true,
                           uniqueness: { scope: %i[host_id rule_id] }
-  validates :host, presence: true,
-                   uniqueness: { scope: %i[test_result_id rule_id] }
+  validates :host, presence: true, on: :create
+  validates :host_id, presence: true,
+                      uniqueness: { scope: %i[test_result_id rule_id] }
   validates :rule, presence: true,
                    uniqueness: { scope: %i[test_result_id host_id] }
 

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -4,13 +4,14 @@
 # basic report properties, such as dates, host, and results.
 class TestResult < ApplicationRecord
   belongs_to :profile
-  belongs_to :host
+  belongs_to :host, optional: true
   has_one :benchmark, through: :profile
   has_many :rule_results, dependent: :delete_all
   has_many :rules, through: :rule_results
 
-  validates :host, presence: true,
-                   uniqueness: { scope: %i[profile_id end_time] }
+  validates :host, presence: true, on: :create
+  validates :host_id, presence: true,
+                      uniqueness: { scope: %i[profile_id end_time] }
   validates :profile, presence: true,
                       uniqueness: { scope: %i[host_id end_time] }
   validates :end_time, presence: true,

--- a/test/models/policy_host_test.rb
+++ b/test/models/policy_host_test.rb
@@ -4,5 +4,5 @@ require 'test_helper'
 
 class PolicyHostTest < ActiveSupport::TestCase
   should belong_to(:policy)
-  should belong_to(:host)
+  should validate_presence_of(:host)
 end

--- a/test/models/rule_result_test.rb
+++ b/test/models/rule_result_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class RuleResultTest < ActiveSupport::TestCase
   should validate_presence_of :rule
-  should validate_presence_of :host
+  should validate_presence_of :host_id
   should validate_presence_of :test_result
 
   should have_one(:profile).through(:test_result)

--- a/test/models/test_result_test.rb
+++ b/test/models/test_result_test.rb
@@ -6,7 +6,6 @@ class TestResultTest < ActiveSupport::TestCase
   should have_one(:benchmark).through(:profile)
   should have_many(:rule_results).dependent(:delete_all)
   should belong_to(:profile)
-  should belong_to(:host)
   should validate_presence_of(:host)
   should validate_presence_of(:profile)
   should validate_presence_of(:end_time)


### PR DESCRIPTION
Host links can be sometimes orphaned and transitive validation coming from SSG import might crash on this. As a solution I am proposing to limit the validation to the `host_id` and keep the stricter one when creating records only.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
