### PR TITLE
fix(Notification): RHICOMPL-2563 always notify if system has no reports

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -42,8 +42,8 @@ class ParseReportJob
   end
 
   def notify_if_non_compliant
-    # Store the old score to detect if there was a drop
-    pre_compliant = parser.policy.compliant?(parser.host)
+    # Store the old score to detect if there was a drop or there are no test results
+    pre_compliant = parser.host.test_results.empty? || parser.policy.compliant?(parser.host)
 
     yield
 


### PR DESCRIPTION
Systems without results are marked as non-compliant, but we need to notify them if their first report coming in is also non-compliant.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
