### PR TITLE
feat(SSG): RHICOMPL-2767 force SSG import if datastream rev is nil

### DIFF
--- a/lib/tasks/import_datastream.rake
+++ b/lib/tasks/import_datastream.rake
@@ -21,6 +21,9 @@ namespace :ssg do
 
   desc 'Update compliance DB with the supported SCAP Security Guide versions'
   task import_rhel_supported: [:environment] do
+    # Force an SSG import if the datastream revision is unset
+    Settings.force_import_ssgs = true if Revision.datastreams.nil?
+
     if Revision.datastreams != SupportedSsg.revision
       downloader = DatastreamDownloader.new
       downloader.download_datastreams do |file|

--- a/test/tasks/import_datastream_test.rb
+++ b/test/tasks/import_datastream_test.rb
@@ -23,6 +23,7 @@ class ImportDatastreamTest < ActiveSupport::TestCase
   end
 
   test 'ssg:import_rhel_supported imports downstream datastreams' do
+    Revision.stubs(:datastreams).returns('')
     DatastreamDownloader.any_instance
                         .expects(:download_datastreams)
                         .multiple_yields(['file1'], ['file2'])


### PR DESCRIPTION
This is a comfort extra for deployments, right now we do need the environment variable AND the migration to do a forced import. With this change only the migration will be necessary, but the support for the variable will be still around if needed.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
