### PR TITLE
chore(OrphanedLinksRemover): RHICOMPL-2781 relax dependency on inventory

### DIFF
--- a/app/services/orphaned_links_remover.rb
+++ b/app/services/orphaned_links_remover.rb
@@ -5,6 +5,8 @@ class OrphanedLinksRemover
   class << self
     # rubocop:disable Metrics/AbcSize
     def run!
+      return unless Host.table_exists?
+
       ProfileRule.left_outer_joins(:profile).left_outer_joins(:rule).where(profiles: { id: nil }).or(
         ProfileRule.where(rules: { id: nil })
       ).destroy_all


### PR DESCRIPTION
When running migrations and the inventory service is not available yet, the migration fails on the `OrphanedLinksRemover` as it depends on the inventory. The only case this can happen is a deployment to ephemeral so this can cause slower CI. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
