### PR TITLE
feat(SSG): RHICOMPL-1736 set precedence on rules upon SSG import

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -70,7 +70,7 @@ class Rule < ApplicationRecord
     (profiles & Profile.canonical).any?
   end
 
-  def self.from_openscap_parser(op_rule, benchmark_id: nil)
+  def self.from_openscap_parser(op_rule, benchmark_id: nil, precedence: nil)
     rule = find_or_initialize_by(ref_id: op_rule.id, benchmark_id: benchmark_id)
 
     rule.op_source = op_rule
@@ -79,6 +79,7 @@ class Rule < ApplicationRecord
                            description: op_rule.description,
                            rationale: op_rule.rationale,
                            severity: op_rule.severity,
+                           precedence: precedence,
                            upstream: false)
 
     rule

--- a/app/services/concerns/xccdf/rules.rb
+++ b/app/services/concerns/xccdf/rules.rb
@@ -7,13 +7,21 @@ module Xccdf
 
     included do
       def save_rules
-        @rules ||= @op_rules.map do |op_rule|
-          ::Rule.from_openscap_parser(op_rule, benchmark_id: @benchmark&.id)
+        @rules ||= @op_rules.each_with_index.map do |op_rule, idx|
+          ::Rule.from_openscap_parser(op_rule, precedence: idx, benchmark_id: @benchmark&.id)
         end
 
-        @new_rules = @rules.select(&:new_record?)
+        @new_rules, @old_rules = @rules.partition(&:new_record?)
 
+        # Import the new records first with validation
         ::Rule.import!(@new_rules, ignore: true)
+
+        # Update the precedence on existing rules, validation is not necessary
+        ::Rule.import(@old_rules,
+                      on_duplicate_key_update: {
+                        conflict_target: %i[ref_id benchmark_id],
+                        columns: %i[precedence]
+                      }, validate: false)
       end
     end
   end

--- a/db/migrate/20220310135223_reset_revisions_march_tenth.rb
+++ b/db/migrate/20220310135223_reset_revisions_march_tenth.rb
@@ -1,0 +1,9 @@
+class ResetRevisionsMarchTenth < ActiveRecord::Migration[7.0]
+  def up
+    Revision.find_by(name: 'datastreams')&.delete
+  end
+
+  def down
+    # nop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_22_190410) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_10_135223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"

--- a/test/services/concerns/xccdf/rules_test.rb
+++ b/test/services/concerns/xccdf/rules_test.rb
@@ -66,7 +66,6 @@ class RulesTest < ActiveSupport::TestCase
   end
 
   test 'reorders rules when needed' do
-    skip 'not implemented yet'
     @mock.benchmark.rules.clear
     @mock.save_rules
 


### PR DESCRIPTION
When creating AR objects, a `precedence` inferred from the order of the rules in the XML is passed. For newly created rules, this gets stored immediately, for rules that already existed the `Rule.import` call updates the `precedence` without calling any validations.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
