### PR TITLE
perf(SSG): RHICOMPL-2793 determine playbook existence from autoindex

### DIFF
--- a/app/services/playbook_downloader.rb
+++ b/app/services/playbook_downloader.rb
@@ -3,35 +3,35 @@
 # Service for dowloading SSG remediation playbooks
 class PlaybookDownloader
   class << self
-    def playbook_exists?(rule, profile = nil)
-      download(playbook_url(rule, profile&.short_ref_id)).present?
+    def playbooks_exist?(rules)
+      rules.inject({}) do |obj, rule|
+        obj.merge(rule.id => playbook_exists?(rule))
+      end
     end
 
-    def playbooks_exist?(rules)
-      rules.map do |rule|
-        [rule.id, playbook_exists?(rule)]
-      end.to_h
+    def playbook_exists?(rule)
+      playbook_list(rule.benchmark.os_major_version).include?(rule.short_ref_id)
     end
 
     private
 
-    def playbook_url(rule, profile_short_ref_id = nil)
+    def playbook_list(os_major_version)
+      @cache ||= {}
+      @cache[os_major_version] ||= begin
+        file = SafeDownloader.download(playbook_list_url(os_major_version))
+        JSON.parse(file.read).map do |row|
+          row['name'].sub(/\.yml$/, '')
+        end
+      end
+    end
+
+    def playbook_list_url(os_major_version)
       [
         Settings.compliance_ssg_url,
         'playbooks',
-        "rhel#{rule.benchmark.os_major_version}",
-        profile_short_ref_id || 'all',
-        "#{rule.short_ref_id}.yml"
+        "rhel#{os_major_version}",
+        'all'
       ].join('/')
-    end
-
-    def download(url)
-      file = SafeDownloader.download(url)
-      Rails.logger.audit_success("Downloaded playbook from #{url}")
-      file
-    rescue StandardError => e
-      Rails.logger.audit_fail("Failed to download playbook from #{url}: #{e}")
-      nil
     end
   end
 end

--- a/test/services/playbook_downloader_test.rb
+++ b/test/services/playbook_downloader_test.rb
@@ -8,27 +8,15 @@ class PlaybookDownloaderTest < ActiveSupport::TestCase
     @profile = FactoryBot.create(:canonical_profile)
     @rule = FactoryBot.create(:rule)
     @rules = FactoryBot.create_list(:rule, 2)
+    SafeDownloader.stubs(:download).returns(StringIO.new([{ name: @rule.short_ref_id }].to_json))
   end
 
   test 'playbook_exists? when it exists' do
-    SafeDownloader.expects(:download).returns(:playbook)
     assert PlaybookDownloader.playbook_exists?(@rule)
-    assert_audited 'Downloaded playbook'
   end
 
-  test 'playbook_exists? specifying a profile_short_ref_id' do
-    SafeDownloader.expects(:download).returns(:playbook)
-    assert PlaybookDownloader.playbook_exists?(@rule, @profile)
-    assert_audited 'Downloaded playbook'
-  end
-
-  test 'playbook_exists? handles download errors' do
-    SafeDownloader.expects(:download).raises(StandardError)
-
-    assert_nothing_raised do
-      assert_not PlaybookDownloader.playbook_exists?(@rule)
-    end
-    assert_audited 'Failed to download playbook'
+  test 'playbook_exists? when not exists' do
+    assert_not PlaybookDownloader.playbook_exists?(@rules.sample)
   end
 
   test 'playbooks_exist?' do


### PR DESCRIPTION
Instead of downloading each playbook one-by-one, we can simply download the newly provided JSON autoindex from the right folder and match against the existing files. The performance increase is significant, the original import takes :sloth: ~70 seconds :sloth: on my local machine and the new one requires :drum: :drum:  only :zap: 2-3 seconds :zap: 

Note that for testing this you'd need to pull the latest SSG container from quay.
1. Clear the revisions from rails console
```ruby
Revision.find_by(name: 'remediations')&.delete
```
2. Import the remediations
```bash
time bin/rake import_remediations
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
