### PR TITLE
fix(Notifications): RHICOMPL-2798 handle missing policy for reports

### DIFF
--- a/app/jobs/concerns/notifications.rb
+++ b/app/jobs/concerns/notifications.rb
@@ -22,7 +22,7 @@ module Notifications
 
     # Notifications should be only allowed if there are no test results or the policy was previously compliant
     def build_notify_preconditions
-      parser.policy.compliant?(parser.host) || parser.policy.test_result_hosts.where(id: parser.host.id).empty?
+      parser.policy&.compliant?(parser.host) || parser.policy&.test_result_hosts&.where(id: parser.host.id)&.empty?
     end
 
     def notify_non_compliant!

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -246,4 +246,20 @@ class ParseReportJobTest < ActiveSupport::TestCase
 
     @parse_report_job.perform(0, @msg_value)
   end
+
+  test 'does not emit notification if report is external' do
+    XccdfReportParser.stubs(:new).returns(@parser)
+    Sidekiq.stubs(:redis).returns(false)
+    @parser.stubs(:policy).returns(nil)
+    @parser.stubs(:score).returns(90)
+
+    @parse_report_job.stubs(:notify_payload_tracker)
+    @parse_report_job.stubs(:notify_remediation)
+    @parse_report_job.stubs(:audit_success)
+    @parser.expects(:save_all)
+
+    SystemNonCompliant.expects(:deliver).never
+
+    @parse_report_job.perform(0, @msg_value)
+  end
 end


### PR DESCRIPTION
In case a host has ben unassigned from a policy, it should not fail when emitting notifications.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
