### PR TITLE
chore(rails): clear compensation for missing rails bugfix

### DIFF
--- a/app/models/concerns/sortable.rb
+++ b/app/models/concerns/sortable.rb
@@ -30,15 +30,7 @@ module Sortable
         column, direction = field.underscore.split(':')
         assert_sortable_by!(column, direction)
 
-        # FIXME: Rails cannot deal with Arel nodes in order hashes.
-        # After the bug is resolved, the compensation will be no longer
-        # necessaryand the fetching can be simply done by:
-        # rule = @sortable_by[column.to_sym]
-        #
-        # BUG: https://github.com/rails/rails/issues/44282
-        # FIX: https://github.com/rails/rails/pull/44284
-        rule = fetch_rule_by_column(column.to_sym)
-
+        rule = @sortable_by[column.to_sym]
         obj[:h][rule[:statement]] = direction || 'asc'
         obj[:s] << rule[:scope] if rule[:scope]
       end
@@ -52,16 +44,6 @@ module Sortable
       return if ['asc', 'desc', nil].include?(direction)
 
       raise ::Exceptions::InvalidSortingDirection, direction
-    end
-
-    def fetch_rule_by_column(column)
-      rule = @sortable_by[column]
-      if rule[:statement].is_a?(Arel::Nodes::Node)
-        # Arel node conversion to make both Rails and Brakeman happy
-        rule[:statement] = Arel.sql(rule[:statement].to_sql)
-      end
-
-      rule
     end
   end
 end


### PR DESCRIPTION
This temporary fix I'm removing was introduced to bridge through a [bug in rails](https://github.com/rails/rails/issues/44282) that has been [fixed](https://github.com/rails/rails/pull/44284) and now the latest version contains it so we can just drop it. Tests should fail without the fix and the compensation, so if everything is green, we're good.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
