### PR TITLE
fix(racecar): RHICOMPL-2801 retrieve account from the right location

### DIFF
--- a/app/consumers/concerns/report_parsing.rb
+++ b/app/consumers/concerns/report_parsing.rb
@@ -48,8 +48,8 @@ module ReportParsing
       logger.error error_message
       logger.audit_fail error_message
       notify_payload_tracker(:error, error_message)
-      ReportUploadFailed.deliver(host: Host.find_by(id: id, account: @msg_value['account']),
-                                 account_number: @msg_value['account'], error: msg_for_notification(exc))
+      ReportUploadFailed.deliver(host: Host.find_by(id: id, account: account),
+                                 account_number: account, error: msg_for_notification(exc))
 
       validation_payload(request_id, valid: false)
     end

--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -13,9 +13,7 @@ class InventoryEventsConsumer < ApplicationConsumer
   def process(message)
     super
 
-    Insights::API::Common::AuditLog.audit_with_account(
-      @msg_value['account']
-    ) do
+    Insights::API::Common::AuditLog.audit_with_account(account) do
       dispatch
     end
   rescue PG::Error, ActiveRecord::StatementInvalid
@@ -64,5 +62,11 @@ class InventoryEventsConsumer < ApplicationConsumer
   # NB: This consumer object stays around between messages
   def clear!
     @report_contents, @msg_value = nil
+  end
+
+  private
+
+  def account
+    @msg_value.dig('platform_metadata', 'account')
   end
 end

--- a/test/consumers/inventory_events_consumer_test.rb
+++ b/test/consumers/inventory_events_consumer_test.rb
@@ -84,9 +84,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: @host.account
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: @host.account
+        }
       }.to_json)
       @consumer.stubs(:validated_reports).returns([%w[profile report]])
       @consumer.stubs(:produce)
@@ -106,9 +106,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: @host.account
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: @host.account
+        }
       }.to_json)
       @consumer.stubs(:validated_reports).returns([%w[profileid report]])
       @consumer.expects(:produce).with(
@@ -133,9 +133,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: @host.account
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: @host.account
+        }
       }.to_json)
       @consumer.stubs(:validated_reports).returns([%w[profileid report]])
       @consumer.expects(:produce)
@@ -157,9 +157,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: @host.account
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: @host.account
+        }
       }.to_json)
 
       SafeDownloader.stubs(:download_reports).raises(SafeDownloader::DownloadError)
@@ -191,9 +191,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: @host.account
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: @host.account
+        }
       }.to_json)
       # Mock the actual 'sending the validation' to Kafka
       XccdfReportParser.stubs(:new).raises(StandardError.new)
@@ -226,9 +226,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: '1234'
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: '1234'
+        }
       }.to_json)
 
       ReportUploadFailed.expects(:deliver).with(
@@ -260,9 +260,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: @host.account
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: @host.account
+        }
       }.to_json)
       @consumer.stubs(:download_file)
       parsed_stub = OpenStruct.new(
@@ -292,9 +292,9 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
         platform_metadata: {
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
-          request_id: '036738d6f4e541c4aa8cfc9f46f5a140'
-        },
-        account: @host.account
+          request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
+          account: @host.account
+        }
       }.to_json)
       # Mock the actual 'sending the validation' to Kafka
       XccdfReportParser.stubs(:new).raises(ActiveRecord::StatementInvalid)


### PR DESCRIPTION
The `@msg_value['account']` is being used in our jobs, but it is not consistent with what we have in the kafka consumer. The correct location for the account is under `@msg_value['platform_metadata']['account']` that can be deducted from the fact that the inventory consumer passes the [`metadata`](https://github.com/RedHatInsights/compliance-backend/blob/4061c4a56ffdf43160d76e74c6dc2e69a307565b/app/consumers/concerns/report_parsing.rb#L96-L102) object that lives in Sidekiq as `@msg_value` further (different from the same variable name in the consumer). 

This caused our audit logging to omit the account information in inventory-consumer messages and that the account and host information in notifications was incorrect. Our tests of course were also incorrectly setting the account number at the wrong location, so there everything was passing.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
