### PR TITLE
hack(Remediations): RHICOMPL-2385 never import rsyslog_remote_loghost

### DIFF
--- a/db/migrate/20220312143550_reset_remediations_syslog.rb
+++ b/db/migrate/20220312143550_reset_remediations_syslog.rb
@@ -1,0 +1,9 @@
+class ResetRemediationsSyslog < ActiveRecord::Migration[7.0]
+  def up
+    Revision.find_by(name: 'remediations')&.delete
+  end
+
+  def down
+    # nop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_11_152114) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_12_143550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"

--- a/lib/tasks/import_remediations.rake
+++ b/lib/tasks/import_remediations.rake
@@ -26,6 +26,13 @@ task import_remediations: :environment do
       playbook_status_by_rule_id = PlaybookDownloader.playbooks_exist?(
         Rule.with_profiles.includes(:benchmark)
       )
+
+      # Exclude the remediation for rsyslog_remote_loghost
+      EXCLUDE = 'xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost'
+      Rule.where(ref_id: EXCLUDE).pluck(:id).each do |id|
+        playbook_status_by_rule_id[id] = false
+      end
+
       ids_with_playbooks = playbook_status_by_rule_id.filter { |_, v| v }.keys
       ids_sans_playbooks = playbook_status_by_rule_id.filter { |_, v| !v }.keys
 


### PR DESCRIPTION
This is a very ugly hack and it should be refactored, but IMO we should not even have this complex logic in rake tasks. Therefore, we should first move logic from the rake tasks to classes and just invoke those. I'll create a ticket for this...

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
