### PR TITLE
fix(Systems): RHICOMPL-2805 return all timestamps in ISO-8601 format

### DIFF
--- a/app/graphql/types/system.rb
+++ b/app/graphql/types/system.rb
@@ -66,6 +66,22 @@ module Types
       object.last_scanned(**args)
     end
 
+    def culled_timestamp
+      object.culled_timestamp&.iso8601
+    end
+
+    def stale_warning_timestamp
+      object.stale_warning_timestamp&.iso8601
+    end
+
+    def stale_timestamp
+      object.stale_timestamp&.iso8601
+    end
+
+    def updated
+      object.updated&.iso8601
+    end
+
     private
 
     def context_parent

--- a/app/serializers/host_serializer.rb
+++ b/app/serializers/host_serializer.rb
@@ -6,8 +6,25 @@ class HostSerializer < ApplicationSerializer
   attributes :name, :os_major_version, :os_minor_version, :last_scanned,
              :rules_passed, :rules_failed, :has_policy, :culled_timestamp,
              :stale_timestamp, :stale_warning_timestamp, :updated, :insights_id
+
   attribute :compliant do |host|
     host.compliant.values.all?
+  end
+
+  attribute :culled_timestamp do |host|
+    host.culled_timestamp.iso8601
+  end
+
+  attribute :stale_timestamp do |host|
+    host.stale_timestamp.iso8601
+  end
+
+  attribute :stale_warning_timestamp do |host|
+    host.stale_warning_timestamp.iso8601
+  end
+
+  attribute :updated do |host|
+    host.updated.iso8601
   end
 
   has_many :test_results

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -147,6 +147,21 @@ module V1
         get system_path(host)
         assert_response :not_found
       end
+
+      should 'return timestamps in ISO-6801' do
+        host = FactoryBot.create(:host)
+        get system_path(host)
+
+        %w[
+          culled_timestamp
+          stale_timestamp
+          stale_warning_timestamp
+          updated
+        ].each do |ts|
+          timestamp = response.parsed_body.dig('data', 'attributes')[ts]
+          assert_equal timestamp, Time.parse(timestamp).iso8601
+        end
+      end
     end
   end
 end

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -56,6 +56,30 @@ class SystemQueryTest < ActiveSupport::TestCase
     end
   end
 
+  test 'query host returns timestamps in ISO-6801' do
+    query = <<-GRAPHQL
+      query System($inventoryId: String!){
+          system(id: $inventoryId) {
+              culledTimestamp
+              staleWarningTimestamp
+              staleTimestamp
+              updated
+          }
+      }
+    GRAPHQL
+
+    result = Schema.execute(
+      query,
+      variables: { inventoryId: @host1.id },
+      context: { current_user: @user }
+    )
+
+    assert_equal 4, result['data']['system'].count
+    result['data']['system'].each do |_, timestamp|
+      assert_equal timestamp, Time.parse(timestamp).iso8601
+    end
+  end
+
   context 'policy id querying' do
     setup do
       [@profile1, @profile2].each do |p|


### PR DESCRIPTION
Unit tests are simple, if the parsed and converted timestamps equal to the original, the timestamp is in the right format.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
