### PR TITLE
fix(import): RHICOMPL-2833 - Update ProfileRuleGroups import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'prometheus_exporter', '>= 0.5'
 gem 'manageiq-loggers', '~> 0.6.0'
 
 # Parsing OpenSCAP reports library
-gem 'openscap_parser', '~> 1.1.0'
+gem 'openscap_parser', '~> 1.2.0'
 
 # RBAC service API
 gem 'insights-rbac-api-client', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.10.6)
-    openscap_parser (1.1.0)
+    openscap_parser (1.2.0)
       nokogiri (~> 1.6)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -443,7 +443,7 @@ DEPENDENCIES
   minitest-stub-const
   mocha
   oj
-  openscap_parser (~> 1.1.0)
+  openscap_parser (~> 1.2.0)
   pg
   prometheus_exporter (>= 0.5)
   pry-byebug

--- a/app/services/concerns/xccdf/profile_rule_groups.rb
+++ b/app/services/concerns/xccdf/profile_rule_groups.rb
@@ -26,7 +26,7 @@ module Xccdf
       def profile_rule_groups
         @profile_rule_groups ||= @op_profiles.flat_map do |op_profile|
           profile_id = profile_id_for(ref_id: op_profile.id)
-          rule_group_ids_for(ref_ids: op_profile.selected_rule_ids).map do |rule_group_id|
+          rule_group_ids_for(ref_ids: op_profile.selected_group_ids).map do |rule_group_id|
             ::ProfileRuleGroup.new(
               profile_id: profile_id, rule_group_id: rule_group_id
             )

--- a/test/factories/rule.rb
+++ b/test/factories/rule.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :rule do
     title { Faker::Lorem.sentence }
-    ref_id { "foo-#{SecureRandom.uuid}" }
+    ref_id { "foo_rule_#{SecureRandom.uuid}" }
     description { Faker::Lorem.paragraph }
     rationale { Faker::Lorem.paragraph }
     severity { %w[low medium high].sample }

--- a/test/factories/rule_group.rb
+++ b/test/factories/rule_group.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :rule_group do
     title { Faker::Lorem.sentence }
-    ref_id { "foo-#{SecureRandom.uuid}" }
+    ref_id { "foo_group_#{SecureRandom.uuid}" }
     description { Faker::Lorem.paragraph }
     rationale { Faker::Lorem.paragraph }
     benchmark


### PR DESCRIPTION
This is going to fail until the [openscap parser changes](https://github.com/OpenSCAP/openscap_parser/pull/37) are merged and deployed and then we can update the gem version in our Gemfile.

I tested locally with the `openscap_parser` gem pointing to the commit in the PR and everything worked correctly.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
