### PR TITLE
feat(PolicyHost): RHICOMPL-2830 Check if host is supported

### DIFF
--- a/app/models/policy_host.rb
+++ b/app/models/policy_host.rb
@@ -8,10 +8,26 @@ class PolicyHost < ApplicationRecord
   validates :policy, presence: true
   validates :host, presence: true, on: :create
   validates :host_id, presence: true, uniqueness: { scope: :policy }
+  validate :host_supported?, on: :create
+
+  scope :supported_os_versions, lambda { |policy_id, host_os_major_version|
+    profile = Profile.find_by(policy_id: policy_id)
+    if host_os_major_version.to_s == profile&.os_major_version.to_s
+      profile&.supported_minor_versions
+    end
+  }
 
   def self.import_from_policy(policy_id, host_ids)
     import(host_ids.map do |host_id|
       { host_id: host_id, policy_id: policy_id }
     end)
+  end
+
+  def host_supported?
+    if PolicyHost.supported_os_versions(policy&.id, host&.os_major_version).include?(host&.os_minor_version.to_s)
+      return
+    end
+
+    errors.add(:host, 'os version is unsupported for this policy')
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -80,6 +80,16 @@ class Profile < ApplicationRecord
     end.flatten.uniq.sort.reverse
   end
 
+  def supported_minor_versions
+    benchmark_versions = self.class.canonical.where(
+      ref_id: ref_id,
+      upstream: false
+    ).joins(:benchmark).pluck('benchmarks.version')
+    SupportedSsg.by_os_major[os_major_version]
+                .select { |ssg| benchmark_versions.include? ssg.version }
+                .map(&:os_minor_version)
+  end
+
   private
 
   def bm_versions

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -148,6 +148,7 @@ module V1
 
   class ProfilesControllerTest < ActionDispatch::IntegrationTest
     setup do
+      PolicyHost.any_instance.stubs(:host_supported?).returns(true)
       ProfilesController.any_instance.stubs(:authenticate_user).yields
       User.current = FactoryBot.create(:user)
     end

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 module V1
   class SystemsControllerTest < ActionDispatch::IntegrationTest
     setup do
+      PolicyHost.any_instance.stubs(:host_supported?).returns(true)
       SystemsController.any_instance.expects(:authenticate_user).yields
       User.current = FactoryBot.create(:user)
     end

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -15,6 +15,7 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
   GRAPHQL
 
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @profiles = FactoryBot.create_list(:profile, 2, account: @user.account)
     @host = FactoryBot.create(:host, account: @user.account.account_number)

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class AssociateSystemsMutationTest < ActiveSupport::TestCase
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @profile = FactoryBot.create(:profile, account: @user.account)
     @host = FactoryBot.create(:host, account: @user.account.account_number)

--- a/test/graphql/mutations/delete_test_result_mutation_test.rb
+++ b/test/graphql/mutations/delete_test_result_mutation_test.rb
@@ -20,6 +20,7 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
   GRAPHQL
 
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @profile = FactoryBot.create(:profile, account: @user.account)
     @host = FactoryBot.create(:host, account: @user.account.account_number)

--- a/test/graphql/mutations/edit_policy_mutation_test.rb
+++ b/test/graphql/mutations/edit_policy_mutation_test.rb
@@ -8,6 +8,7 @@ class EditPolicyMutationTest < ActiveSupport::TestCase
     @profile = FactoryBot.create(:profile, account: @user.account)
     @host = FactoryBot.create(:host, account: @user.account.account_number)
     @tr = FactoryBot.create(:test_result, host: @host, profile: @profile)
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @profile.policy.update(hosts: [@host])
     @bo = FactoryBot.create(:business_objective)
   end

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class ProfileQueryTest < ActiveSupport::TestCase
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @profile = FactoryBot.create(
       :profile,

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class SystemQueryTest < ActiveSupport::TestCase
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @host1 = FactoryBot.create(:host, account: @user.account.account_number)
 

--- a/test/lib/prometheus/business_collector_test.rb
+++ b/test/lib/prometheus/business_collector_test.rb
@@ -6,6 +6,7 @@ require 'prometheus/business_collector'
 
 class BusinessCollectorTest < ActiveSupport::TestCase
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @collector = BusinessCollector.new
   end
 

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -12,6 +12,7 @@ class HostTest < ActiveSupport::TestCase
   should have_many(:test_result_profiles).through(:test_results)
 
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @account = FactoryBot.create(:account)
     @host1 = Host.find(FactoryBot.create(
       :host,

--- a/test/models/policy_host_test.rb
+++ b/test/models/policy_host_test.rb
@@ -5,4 +5,59 @@ require 'test_helper'
 class PolicyHostTest < ActiveSupport::TestCase
   should belong_to(:policy)
   should validate_presence_of(:host)
+
+  setup do
+    @account = FactoryBot.create(:user).account
+    v1 = SupportedSsg.by_os_major['7'].first
+    bm1 = FactoryBot.create(
+      :benchmark,
+      version: v1.version,
+      os_major_version: '7'
+    )
+
+    v2 = SupportedSsg.by_os_major['7'].last
+    bm2 = FactoryBot.create(
+      :benchmark,
+      version: v2.version,
+      os_major_version: '7'
+    )
+
+    @policy1 = FactoryBot.create(:policy, account: @account)
+    @policy2 = FactoryBot.create(:policy, account: @account)
+    @p1 = FactoryBot.create(:canonical_profile, upstream: false, policy: @policy1, benchmark: bm1)
+    @p2 = FactoryBot.create(:canonical_profile, upstream: false, policy: @policy2, benchmark: bm2)
+    @host1 = Host.find(FactoryBot.create(
+      :host,
+      account: @account.account_number,
+      os_major_version: 7,
+      os_minor_version: 1
+    ).id)
+
+    @host2 = Host.find(FactoryBot.create(
+      :host,
+      account: @account.account_number,
+      os_major_version: 8,
+      os_minor_version: 3
+    ).id)
+  end
+
+  test 'an unsupported host based on minor version cannot be assigned to a policy' do
+    exception = assert_raises(Exception) do
+      @policy2.hosts << @host1
+    end
+    assert_equal(exception.message, 'Validation failed: Host os version is unsupported for this policy')
+  end
+
+  test 'an unsupported host based on major version cannot be assigned to a policy' do
+    exception = assert_raises(Exception) do
+      @policy1.hosts << @host2
+    end
+    assert_equal(exception.message, 'Validation failed: Host os version is unsupported for this policy')
+  end
+
+  test 'a supported host can be assigned to a policy' do
+    assert_nothing_raised do
+      @policy1.hosts << @host1
+    end
+  end
 end

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -15,6 +15,7 @@ class PolicyTest < ActiveSupport::TestCase
   setup do
     @account = FactoryBot.create(:user).account
     @policy = FactoryBot.create(:policy, account: @account)
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
   end
 
   context 'scopes' do

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -24,6 +24,7 @@ class ProfileTest < ActiveSupport::TestCase
   setup do
     @account = FactoryBot.create(:account)
     @host = FactoryBot.create(:host, account: @account.account_number)
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @policy = FactoryBot.create(:policy, account: @account, hosts: [@host])
   end
 

--- a/test/policies/profile_policy_test.rb
+++ b/test/policies/profile_policy_test.rb
@@ -3,6 +3,9 @@
 require 'test_helper'
 
 class ProfilePolicyTest < ActiveSupport::TestCase
+  setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
+  end
   test 'only noncanonical profiles within the account and '\
        'canonical profiles are accessible' do
     user = FactoryBot.create(:user)

--- a/test/services/concerns/xccdf/benchmarks_test.rb
+++ b/test/services/concerns/xccdf/benchmarks_test.rb
@@ -23,6 +23,10 @@ module Xccdf
       end
     end
 
+    setup do
+      PolicyHost.any_instance.stubs(:host_supported?).returns(true)
+    end
+
     test 'save_benchmark' do
       mock = Mock.new(OP_BENCHMARK)
       ::Xccdf::Benchmark.any_instance.expects(:rules)

--- a/test/services/dangling_account_remover_test.rb
+++ b/test/services/dangling_account_remover_test.rb
@@ -12,6 +12,7 @@ class DanglingAccountRemoverTest < ActiveSupport::TestCase
   end
 
   test 'keeps accounts that have relationships' do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     accounts = FactoryBot.create_list(:account, 5)
     FactoryBot.create(:user, account: accounts[4])
     host1 = FactoryBot.create(:host, account: accounts[0].account_number)

--- a/test/services/upstream_rule_bindings_remover_test.rb
+++ b/test/services/upstream_rule_bindings_remover_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class UpstreamRuleBindingsRemoverTest < ActiveSupport::TestCase
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     account = FactoryBot.create(:account)
     host = FactoryBot.create(:host, account: account.account_number)
     @profile = FactoryBot.create(

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -14,6 +14,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
   end
 
   setup do
+    PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     fake_report = file_fixture('xccdf_report.xml').read
     @profile = {
       'xccdf_org.ssgproject.content_profile_standard' =>


### PR DESCRIPTION
Still working on this and testing so leaving it as a draft for now. 
The purpose of these changes is to check that the host version is included in the list of supported os versions for the profile associated with the policy that it's being assigned to. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
