### PR TITLE
ci(commitlint): RHICOMPL-2850 define parser options

### DIFF
--- a/.commitlint.yml
+++ b/.commitlint.yml
@@ -1,0 +1,11 @@
+---
+extends:
+  - '@commitlint/config-conventional'
+parserPreset:
+  parserOpts:
+    headerPattern: '^(\w*)\((\w*)\):\s(\w+-[0-9]+)\s(.*)$'
+    headerCorrespondence:
+      - 'type'
+      - 'scope'
+      - 'ticket'
+      - 'subject'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         fetch-depth: 0
     - name: Validate commit message format
       uses: wagoid/commitlint-github-action@v4
+      with:
+        configFile: './.commitlint.yml'
     - name: Setup Ruby and install gems
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Since we're using ticket ID where subject is expected in default configuration, our commits seem to fail on commitlint rule by being upper-case.

```
Error: You have commit messages with errors

⧗   input: feat(PolicyHost): RHICOMPL-2830 Check if host is supported
✖   subject must not be sentence-case, start-case, pascal-case, upper-case [subject-case]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

```

_(see https://commitlint.js.org/#/reference-rules?id=subject-case)_

By using the regex it is defined where does the subject start.

_(see https://commitlint.js.org/#/reference-configuration?id=parser-presets)_

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
