### PR TITLE
cleanup(GraphQL): RHICOMPL-2895 replace the majorOsVersion

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -188,7 +188,6 @@ type Profile implements Node & RulesPreload {
     """
     systemId: String
   ): String!
-  majorOsVersion: String!
   name: String!
   osMajorVersion: String!
   osMinorVersion: String!

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -79,7 +79,6 @@ module Types
 
     field :compliant_host_count, Int, null: false
 
-    field :major_os_version, String, null: false
     field :os_major_version, String, null: false
     field :os_minor_version, String, null: false
     field :os_version, String, null: false

--- a/app/models/concerns/profile_fields.rb
+++ b/app/models/concerns/profile_fields.rb
@@ -13,10 +13,9 @@ module ProfileFields
       (parent_profile || self).name
     end
 
-    def major_os_version
+    def os_major_version
       benchmark&.inferred_os_major_version
     end
-    alias_method :os_major_version, :major_os_version
 
     def os_version
       if os_minor_version.present?


### PR DESCRIPTION
We don't need both, the `majorOsVersion` is being cleaned up in the frontend soon.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
