### PR TITLE
fix(entrypoint): RHICOMPL-2858 source the cgroup-limits for ENV

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ if [ "$APPLICATION_TYPE" = "compliance-backend" ]; then
   fi
 
   if is_puma_installed; then
-    ./scripts/set_cgroup_limits.sh
+    source scripts/set_cgroup_limits.sh
 
     exec bundle exec "puma --config ../etc/puma.cfg -b tcp://0.0.0.0:${PORT}"
   else


### PR DESCRIPTION
Executing the script doesn't set the ENV variables, calling `source` does...

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
