### PR TITLE
feat(tailoring): RHICOMPL-2554 Add conflict resolving for rules

### DIFF
--- a/app/models/concerns/profile_tailoring.rb
+++ b/app/models/concerns/profile_tailoring.rb
@@ -33,4 +33,13 @@ module ProfileTailoring
 
     update!(os_minor_version: version)
   end
+
+  def tailoring_valid?
+    conflicts, requires = %w[conflicts requires].map do |relationship|
+      with_relationships(relationship, rules, hierarchical_rule_groups).map(&:right)
+    end
+
+    rules_and_groups = rules | hierarchical_rule_groups
+    (requires - rules_and_groups).empty? && (conflicts & rules_and_groups).empty?
+  end
 end

--- a/app/models/concerns/rules_and_rule_groups.rb
+++ b/app/models/concerns/rules_and_rule_groups.rb
@@ -31,14 +31,19 @@ module RulesAndRuleGroups
 
     private
 
-    def with_relationships(relationship)
+    def hierarchical_rule_groups
+      RuleGroup.where(id: rules.includes(:rule_group)
+               .references(:rule_group).flat_map { |r| r.rule_group&.path_ids })
+    end
+
+    def with_relationships(relationship, rules, rule_groups)
       RuleGroupRelationship.with_relationships(rules, relationship).or(
         RuleGroupRelationship.with_relationships(rule_groups, relationship)
       )
     end
 
     def relationships_for(relationship)
-      with_relationships(relationship).each_with_object({}) do |rgr, relationships|
+      with_relationships(relationship, rules, rule_groups).each_with_object({}) do |rgr, relationships|
         relationships[rgr.left] ||= []
         relationships[rgr.left] << rgr.right
       end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -30,8 +30,8 @@ class Rule < ApplicationRecord
 
   has_many :profile_rules, dependent: :delete_all
   has_many :profiles, through: :profile_rules, source: :profile
-  has_many :rule_group_rules, dependent: :delete_all
-  has_many :rule_groups, through: :rule_group_rules
+  has_one :rule_group_rule, dependent: :delete
+  has_one :rule_group, through: :rule_group_rule
   has_many :rule_results, dependent: :delete_all
   has_many :hosts, through: :rule_results, source: :host
   has_many :rule_references_rules, dependent: :delete_all
@@ -73,9 +73,7 @@ class Rule < ApplicationRecord
     joins(:profiles).where(profiles: { id: Profile.canonical })
   }
 
-  scope :without_rule_group_parent, lambda {
-    where.missing(:rule_groups)
-  }
+  scope :without_rule_group_parent, -> { where.missing(:rule_group) }
 
   scope :joins_identifier, lambda {
     left_outer_joins(:rule_identifier).select('rules.*', RuleIdentifier::AS_JSON.as('identifier'))

--- a/app/models/rule_group_relationship.rb
+++ b/app/models/rule_group_relationship.rb
@@ -11,6 +11,6 @@ class RuleGroupRelationship < ApplicationRecord
   validates :left_id, presence: true, uniqueness: { scope: %i[relationship right_id right_type left_type] }
 
   scope :with_relationships, lambda { |rules_or_groups, relationship|
-    where(relationship: relationship).includes(:left, :right).where(left: rules_or_groups)
+    where(relationship: relationship, left: rules_or_groups).includes(:left, :right)
   }
 end


### PR DESCRIPTION
Note: The XCCDF specifications says to only deselect the item that has a conflict and to not touch any other items in the Benchmark(so don't try to resolve the conflict by selecting or deselecting other items in the Benchmark)
```
Also, <xccdf:requires> and
<xccdf:conflicts> elements SHALL only change their parent item; they SHALL NOT modify
other items in the <xccdf:Benchmark>. 
```
```
Rules and Groups may contain any number of <xccdf:requires> and <xccdf:conflicts>
elements and if any of these elements do not evaluate to true, then that item SHALL become deselected. 
```

Here is an example of how conflicts are resolved: 
<img width="491" alt="Screen Shot 2022-04-26 at 2 45 59 PM" src="https://user-images.githubusercontent.com/87209745/165380144-b8191de5-cc65-4b50-bdc6-4bb8790328ca.png">


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
