### PR TITLE
fix(entrypoint): RHICOMPL-2858 use the correct variable for memlimit

### DIFF
--- a/scripts/set_cgroup_limits.sh
+++ b/scripts/set_cgroup_limits.sh
@@ -26,7 +26,7 @@ else
 fi
 
 # Set NO_MEMORY_LIMIT
-if [[ "${MEMORY_LIMIT}" -ge "${MAX_MEMORY_LIMIT_IN_BYTES}" ]]; then
+if [[ "${MEMORY_LIMIT_IN_BYTES}" -ge "${MAX_MEMORY_LIMIT_IN_BYTES}" ]]; then
   export NO_MEMORY_LIMIT="true"
   echo "NO_MEMORY_LIMIT=true"
 fi


### PR DESCRIPTION
My bad, checking against the wrong var :see_no_evil: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
