### PR TITLE
fix(RBAC): RHICOMPL-2955 adjust request on RBAC API

### DIFF
--- a/app/services/rbac.rb
+++ b/app/services/rbac.rb
@@ -7,6 +7,7 @@ class Rbac
   API_CLIENT = RBACApiClient::AccessApi.new
   COMPLIANCE_FULL_ACCESS = 'compliance:*:*'
   APPS = 'compliance,inventory'
+  OPTS = { limit: 1000, auth_names: '' }.freeze
   ANY = '*'
 
   class AuthorizationError < StandardError; end
@@ -16,7 +17,7 @@ class Rbac
       begin
         API_CLIENT.get_principal_access(
           self::APPS,
-          { header_params: { 'X_RH_IDENTITY': identity } }
+          self::OPTS.merge(header_params: { X_RH_IDENTITY: identity })
         ).data
       rescue RBACApiClient::ApiError => e
         Rails.logger.info(e.message)

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -388,7 +388,7 @@ class AuthenticationTest < ActionController::TestCase
     )
 
     Rbac::API_CLIENT.expects(:get_principal_access)
-                    .with(Rbac::APPS, header_params: { X_RH_IDENTITY: encoded_header })
+                    .with(Rbac::APPS, { limit: 1000, auth_names: '', header_params: { X_RH_IDENTITY: encoded_header } })
                     .returns(RBACApiClient::AccessPagination.new(data: []))
 
     process_test(headers: { 'X-RH-IDENTITY': encoded_header })


### PR DESCRIPTION
- adding limit 1000 to exclude a possibility of the limit defaulting to lower number
  - 1000 is max limit on RBAC API side: https://github.com/RedHatInsights/insights-rbac/blob/d511fffb50772489c009dcc1aa7ed00651eda256/rbac/api/common/pagination.py#L35

- setting empty auth_names to prevent setting Basic auth
  - https://github.com/RedHatInsights/insights-rbac-api-client-ruby/blob/40abb3042dd6ea79d0b4e9b035d19449ac1725eb/lib/insights-rbac-api-client/api/access_api.rb#L88

without setting `auth_names` with empty string, `Authorization` header is being set:
```
GET /api/rbac/v1/access/?application=compliance%2Cinventory HTTP/1.1
Host: rbac:8080
User-Agent: OpenAPI-Generator/1.0.0/ruby
Content-Type: application/json
X_RH_IDENTITY: ...
Accept: application/json
Authorization: Basic Og==
```

after setting `auth_names` to empty string, the authorization header is not present:
```
GET /api/rbac/v1/access/?application=compliance%2Cinventory&limit=1000 HTTP/1.1
Host: rbac:8080
User-Agent: OpenAPI-Generator/1.0.0/ruby
Content-Type: application/json
X_RH_IDENTITY: ...
Accept: application/json
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
