### PR TITLE
cleanup(env): RHICOMPL-2968 drop the JOBS_ACCOUNT_NUMBER param

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -64,8 +64,6 @@ objects:
           value: "${PATH_PREFIX}"
         - name: APP_NAME
           value: "${APP_NAME}"
-        - name: JOBS_ACCOUNT_NUMBER
-          value: ${JOBS_ACCOUNT_NUMBER}
         # Should be a secret ?
         - name: SECRET_KEY_BASE
           value: "secret_key_base"
@@ -291,8 +289,6 @@ objects:
           value: "${REDIS_SSL}"
         - name: RAILS_MAX_THREADS
           value: "${RAILS_MAX_THREADS}"
-        - name: JOBS_ACCOUNT_NUMBER
-          value: ${JOBS_ACCOUNT_NUMBER}
         # Should be a secret ?
         - name: SECRET_KEY_BASE
           value: "secret_key_base"
@@ -414,10 +410,6 @@ parameters:
   value: "5"
 - name: SIDEKIQ_CONCURRENCY
   value: "1"
-- name: JOBS_ACCOUNT_NUMBER
-  displayName: "Account number used in the import remediations job"
-  value: "6212377"
-  required: true
 - name: RAILS_MAX_THREADS
   value: "1"
 - name: DISABLE_RBAC

--- a/lib/tasks/import_remediations.rake
+++ b/lib/tasks/import_remediations.rake
@@ -8,7 +8,7 @@ desc <<-END_DESC
   API.
 
   Examples:
-    # JOBS_ACCOUNT_NUMBER=000001 rake import_remediations
+    # rake import_remediations
 END_DESC
 
 # rubocop:disable Metrics/BlockLength

--- a/test/services/datastream_importer_test.rb
+++ b/test/services/datastream_importer_test.rb
@@ -11,14 +11,12 @@ class DatastreamImporterTest < ActiveSupport::TestCase
   test 'datastream import' do
     importer = DatastreamImporter.new(@datastream_file)
     importer.expects(:save_all_benchmark_info)
-    ENV['JOBS_ACCOUNT_NUMBER'] ||= FactoryBot.create(:account).account_number
     importer.import!
   end
 
   test 'works without any accounts' do
     importer = DatastreamImporter.new(@datastream_file)
     importer.expects(:save_all_benchmark_info)
-    ENV['JOBS_ACCOUNT_NUMBER'] ||= nil
     importer.import!
   end
 end


### PR DESCRIPTION
Seems like this is not being used, so deleting.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
