### PR TITLE
Revert "fix(RuleGroups): RHICOMPL-2956 update ancestry for rule groups correctly"

### DIFF
--- a/app/services/concerns/xccdf/rule_groups.rb
+++ b/app/services/concerns/xccdf/rule_groups.rb
@@ -12,15 +12,20 @@ module Xccdf
         end
 
         ::RuleGroup.import!(@rule_groups.select(&:new_record?), ignore: true)
-        rule_group_parents
+
+        ::RuleGroup.import!(rule_group_parents, on_duplicate_key_update: {
+                              conflict_target: %i[ref_id benchmark_id],
+                              columns: %i[ancestry]
+                            }, validate: false)
       end
 
       private
 
       def rule_group_parents
-        @op_rule_groups.each do |op_rule_group|
+        @op_rule_groups.select(&:parent_id).map do |op_rule_group|
           rule_group = rule_group_for(ref_id: op_rule_group.id)
-          rule_group.update(parent: rule_group_for(ref_id: op_rule_group.parent_id))
+          rule_group.parent_id = rule_group_for(ref_id: op_rule_group.parent_id)&.id
+          rule_group
         end
       end
 

--- a/db/migrate/20220511212358_clear_revisions_may_eleventh.rb
+++ b/db/migrate/20220511212358_clear_revisions_may_eleventh.rb
@@ -1,9 +1,0 @@
-class ClearRevisionsMayEleventh < ActiveRecord::Migration[7.0]
-  def up
-    Revision.find_by(name: 'datastreams')&.delete
-  end
-
-  def down
-    # nop
-  end
-end

--- a/test/services/concerns/xccdf/rule_groups_test.rb
+++ b/test/services/concerns/xccdf/rule_groups_test.rb
@@ -43,32 +43,14 @@ class RuleGroupsTest < ActiveSupport::TestCase
     @rule_groups = @op_rule_groups.map do |op_rule_group|
       ::RuleGroup.from_openscap_parser(op_rule_group, benchmark_id: @benchmark&.id)
     end
-
-    ::RuleGroup.import!(@rule_groups.select(&:new_record?), ignore: true)
-
-    rule_group = @rule_groups.select { |rg| rg.ref_id == 'xccdf_org.ssgproject.content_group_remediation_functions' }
-                             .first
-    rule_group.update(ref_id: 'xccdf_org.ssgproject.content_group_remediation_functions')
-    rule_group.update(parent: RuleGroup.second)
-
-    assert_equal rule_group.parent, RuleGroup.second
-    assert_equal 1, @rule_groups.select(&:ancestry).count
-
-    send(:rule_group_parents)
-
-    assert_nil rule_group.parent
-    assert_equal rule_group.is_root?, true
+    ::RuleGroup.import!(@rule_groups, ignore: true)
+    assert_equal 0, @rule_groups.select(&:ancestry).count
+    @rule_groups_with_parents = send(:rule_group_parents)
+    ::RuleGroup.import!(@rule_groups_with_parents, on_duplicate_key_update: {
+                          conflict_target: %i[ref_id benchmark_id],
+                          columns: :all
+                        })
     assert_equal 228, @rule_groups.select(&:ancestry).count
-
-    rule_groups_by_ref_id = @rule_groups.index_by(&:ref_id)
-    rule_group = rule_groups_by_ref_id['xccdf_org.ssgproject.content_group_principle-encrypt-transmitted-data']
-
-    assert_equal rule_group.ancestors.map(&:ref_id), ['xccdf_org.ssgproject.content_group_intro',
-                                                      'xccdf_org.ssgproject.content_group_general-principles']
-
-    rg1_id = rule_groups_by_ref_id['xccdf_org.ssgproject.content_group_intro'].id
-    rg2_id = rule_groups_by_ref_id['xccdf_org.ssgproject.content_group_general-principles'].id
-    assert_equal rule_group.ancestry, "#{rg1_id}/#{rg2_id}"
   end
 
   test 'saves rule groups only once' do


### PR DESCRIPTION
Reverts RedHatInsights/compliance-backend#1286