### PR TITLE
RHICOMPL-3021 use same build logic for pr_check and build_deploy

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -6,6 +6,6 @@ source 'scripts/deploy/build-deploy-common.sh'
 
 IMAGE_NAME="${IMAGE_NAME:-quay.io/cloudservices/compliance-backend}"
 ADDITIONAL_TAGS="latest"
-CONTAINER_ENGINE_CMD="docker"
+#PREFER_CONTAINER_ENGINE="docker"
 
 build_deploy_main || exit 1

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,8 +4,8 @@ set -exv
 
 source 'scripts/deploy/build-deploy-common.sh'
 
-BACKWARDS_COMPATIBILITY_TAGS="latest qa"
 IMAGE_NAME="${IMAGE_NAME:-quay.io/cloudservices/compliance-backend}"
-IMAGE_TAG="${IMAGE_TAG:?}"
+ADDITIONAL_TAGS="latest"
+CONTAINER_ENGINE_CMD="docker"
 
 build_deploy_main || exit 1

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -13,9 +13,8 @@ export COMPONENT_NAME="compliance"  # name of app-sre "resourceTemplate" in depl
 export IMAGE="quay.io/cloudservices/compliance-backend"
 cat /etc/redhat-release
 
-# shellcheck source=/dev/null
 # build the PR commit image
-source "${CICD_ROOT}/build.sh"
+source "${APP_ROOT}/build_deploy.sh"
 
 # Make directory for artifacts
 mkdir -p artifacts


### PR DESCRIPTION
- Refactor build-deploy-common deployment library
- Deprecate backwards compatibility tags (qa, latest tags no longer used)
- Update naming format of temporary image tags to match bonfire's build script
- Enforce usage of `docker` where available, fallback to `podman` when it's not.
- Detect and fail if it can't build the image

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
