### PR TITLE
perf(GraphQL): RHICOMPL-3025 reverse querying of Profile#test_results

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -114,10 +114,11 @@ module Types
     def latest_test_result_batch(args)
       ::RecordLoader.for(
         ::TestResult,
-        column: :profile_id,
-        where: { host_id: system_id(args) },
+        column: :host_id,
+        where: { profile_id: object.id },
+        includes: :rule_results, # TODO: check for lookaheads
         order: 'created_at DESC'
-      ).load(object.id)
+      ).load(system_id(args))
     end
   end
 end


### PR DESCRIPTION
The `where` clause in the `RecordLoader` gets called on the query every time, therefore having it more static causes more cache hits. As there are usually more hosts than profiles, it should speed up things if we swap these two.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
