### PR TITLE
perf(SystemProfiles): RHICOMPL-3025 cache scope_profiles per IDs

### DIFF
--- a/app/graphql/types/concerns/system_profiles.rb
+++ b/app/graphql/types/concerns/system_profiles.rb
@@ -30,7 +30,13 @@ module Types
       private
 
       def scope_profiles(profiles, policy_id)
-        policy_id ? profiles.in_policy(policy_id) : profiles
+        if policy_id
+          context[:scope_profiles] ||= {}
+          context[:scope_profiles][policy_id] ||= {}
+          context[:scope_profiles][policy_id][profiles.pluck(:id).sort] ||= profiles.in_policy(policy_id)
+        else
+          profiles
+        end
       end
     end
   end


### PR DESCRIPTION
The `scope_profiles` method keeps running the `Profile#in_policy` method that does an advanced query on a set of profiles based on a statically set `policy_id` argument. Therefore we can per-request cache the results based on the IDs of the set of profiles we're calling this against. Minor speedup when loading things... :zap: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
