### PR TITLE
fix(Clowder): RHICOMPL-3068 optional fallback to primary redis

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -176,6 +176,8 @@ objects:
           value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
         - name: MAX_INIT_TIMEOUT_SECONDS
           value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: PRIMARY_REDIS_AS_CACHE
+          value: "${PRIMARY_REDIS_AS_CACHE}"
         - name: SETTINGS__REDIS_CACHE_HOSTNAME
           valueFrom:
             secretKeyRef:
@@ -474,3 +476,6 @@ parameters:
 - name: MAX_INIT_TIMEOUT_SECONDS
   description: Number of seconds for timeout init container operation
   value: "120"
+- name: PRIMARY_REDIS_AS_CACHE
+  description: Whether to use the clowder-provided Redis as cache or not
+  value: 'false'


### PR DESCRIPTION
Should allow us to use a different secret (primary redis) in ephemeral environments. The default value would be the current secret.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
