### PR TITLE
fix(GraphQL): RHICOMPL-721 scope profiles instead of pre-auth

### DIFF
--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -48,11 +48,7 @@ module Types
     end
 
     def profile(id:)
-      Pundit.authorize(
-        context[:current_user],
-        ::Profile.includes(:test_results, :hosts).find(id),
-        :show?
-      )
+      Pundit.policy_scope(context[:current_user], ::Profile).includes(:test_results, :hosts).find(id)
     end
 
     def business_objectives

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -115,7 +115,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
 
     @profile.update!(account: FactoryBot.create(:account))
 
-    assert_raises(Pundit::NotAuthorizedError) do
+    assert_raises(ActiveRecord::RecordNotFound) do
       Schema.execute(
         query,
         variables: { id: @profile.id },


### PR DESCRIPTION
Instead of pre-authourizing against a specific profile, we can just scope the query against the user's account in order to get a 404 if the entity is not accessible.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
