### PR TITLE
Fix unbuffered logging when importing SSG content in production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,8 +57,11 @@ Rails.application.configure do
   # Whitelist hosts
   config.hosts.clear
 
-  # File size limit for logging
-  config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 64.megabytes)
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    config.logger = ActiveSupport::Logger.new(STDOUT)
+  else # Impose a 64MB limit for the logfile
+    config.logger = ActiveSupport::Logger.new(config.paths['log'].first, 1, 64.megabytes)
+  end
 
   # Enable sessions in development for Sidekiq WebUI access
   config.session_store :cookie_store, key: '_compliance_session'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,7 @@ services:
       - compliance-ssg
     environment:
       - POSTGRESQL_TEST_DATABASE=compliance_test
+      - RAILS_LOG_TO_STDOUT=true
       - ACG_CONFIG=/app/devel.json
   rails:
     env_file: .env

--- a/lib/tasks/import_remediations.rake
+++ b/lib/tasks/import_remediations.rake
@@ -15,7 +15,7 @@ END_DESC
 task import_remediations: :environment do
   begin
     start_time = Time.now.utc
-    puts "Starting import_remediations job at #{start_time}"
+    Rails.logger.info "Starting import_remediations job at #{start_time}"
 
     SsgConfigDownloader.update_ssg_ansible_tasks
     ansible_tasks_revision = YAML.safe_load(
@@ -42,18 +42,18 @@ task import_remediations: :environment do
       Rule.where(id: ids_with_playbooks).update_all(remediation_available: true)
       # rubocop:enable Rails/SkipsModelValidations
 
-      puts "Updated #{ids_with_playbooks.count} rules with remediations"
-      puts "Updated #{ids_sans_playbooks.count} rules without remediations"
+      Rails.logger.info "Updated #{ids_with_playbooks.count} rules with remediations"
+      Rails.logger.info "Updated #{ids_sans_playbooks.count} rules without remediations"
       Revision.remediations = ansible_tasks_revision
     end
 
     end_time = Time.now.utc
     duration = end_time - start_time
-    puts "Remediations synced to revision: #{Revision.remediations}"
-    puts "Finishing import_remediations job at #{end_time} "\
+    Rails.logger.info "Remediations synced to revision: #{Revision.remediations}"
+    Rails.logger.info "Finishing import_remediations job at #{end_time} "\
          "and last #{duration} seconds "
   rescue StandardError => e
-    puts "import_remediations job failed at #{end_time} "\
+    Rails.logger.error "import_remediations job failed at #{end_time} "\
          "and lasted #{duration} seconds "
     ExceptionNotifier.notify_exception(
       e,

--- a/test/tasks/import_datastream_test.rb
+++ b/test/tasks/import_datastream_test.rb
@@ -42,6 +42,32 @@ class ImportDatastreamTest < ActiveSupport::TestCase
     end
   end
 
+  test 'ssg:sync_supported calls the SupportedSsgUpdater' do
+    SupportedSsgUpdater.expects(:run!)
+    capture_io do
+      Rake::Task['ssg:sync_supported'].execute
+    end
+  end
+
+  test 'ssg:import imports the file' do
+    ENV['DATASTREAM_FILE'] = 'test/fixtures/files/xccdf_report.xml'
+    DatastreamImporter.any_instance.expects(:import!)
+
+    capture_io do
+      Rake::Task['ssg:import'].execute
+    end
+  end
+
+  test 'ssg:import propagates errors further' do
+    ENV['DATASTREAM_FILE'] = 'foo'
+
+    assert_raises(StandardError) do
+      capture_io do
+        Rake::Task['ssg:import'].execute
+      end
+    end
+  end
+
   test 'ssg:check_synced fails if datastreams are not synced' do
     SupportedSsg.expects(:revision).at_least_once.returns('2021-07-15')
     SupportedRemediations.expects(:revision).at_least_once.returns('2021-07-15')


### PR DESCRIPTION
https://issues.redhat.com/browse/RHICOMPL-2808

Replacing the `puts` calls in the rake tasks with logging pushes these messages into the logfile in development. By extending the `RAILS_LOG_TO_STDOUT` to development and imposing it on the `import-ssg` container, this can be fixed. As a side-effect we will have much more logging info during the SSG import process with the default loglevel, i.e. DB queries that should motivate us to optimize even more :wink: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
