### PR TITLE
fix(ssg): RHICOMPL-2627 adjusted cache expiry and forced download

### DIFF
--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -102,7 +102,7 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def raw_supported
-      SsgConfigDownloader.update_ssg_ds if SsgConfigDownloader.exists?
+      SsgConfigDownloader.update_ssg_ds unless SsgConfigDownloader.exists?
       Rails.cache.fetch("SupportedSsg/datastreams/#{Revision.datastreams}/raw") do
         YAML.safe_load(SsgConfigDownloader.ssg_ds)
       end

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -113,7 +113,7 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def cache(key, &block)
-      Rails.cache.fetch("SupportedSsg/datastreams/#{Revision.datastreams}/#{key}", &block)
+      Rails.cache.fetch("SupportedSsg/datastreams/#{Revision.datastreams}/#{key}", expires_on: 1.day, &block)
     end
   end
 end


### PR DESCRIPTION
Refactored the cache fetching part and added some expiry, which is just for safety. Also fixed the condition for forcing the download of the content to `tmp`. It doesn't fix the bug as the cache is still storing the bad values, but it is necessary.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
