### PR TITLE
fix(slack): RHICOMPL-2648 adjust the channel for error notifications

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -23,7 +23,7 @@ ExceptionNotification.configure do |config|
 
   config.add_notifier :slack, {
     webhook_url: Settings.slack_webhook[%r{^https://.*$}],
-    channel: '#forum-cloudservices-compliance',
+    channel: '#compliance-alarms',
     additional_parameters: {
       mrkdwn: true
     }


### PR DESCRIPTION
We actually don't have influence on the name of the channel, I just changed it for semantics. So if someone in the future is not falling into the same pit as I did with looking for notifications on the wrong channel :see_no_evil: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
