### PR TITLE
perf(OsMajorVersion): RHICOMPL-3194 pass the OS version to profiles

### DIFF
--- a/app/models/concerns/profile_fields.rb
+++ b/app/models/concerns/profile_fields.rb
@@ -13,8 +13,17 @@ module ProfileFields
       (parent_profile || self).name
     end
 
+    def supported_os_versions
+      bm_versions.map do |v|
+        SupportedSsg.by_ssg_version[v].select { |ssg| ssg.os_major_version == os_major_version }.map do |ssg|
+          Gem::Version.new([ssg.os_major_version, ssg.os_minor_version].join('.'))
+        end
+      end.flatten.uniq.sort.reverse
+    end
+
     def os_major_version
-      benchmark&.inferred_os_major_version
+      # Try to reach for this in the cached attributes if possible
+      (attributes['os_major_version'] || benchmark&.inferred_os_major_version).to_s
     end
 
     def os_version
@@ -27,6 +36,16 @@ module ProfileFields
 
     def canonical?
       parent_profile_id.blank?
+    end
+
+    private
+
+    def bm_versions
+      # Try to reach for this in the cached attributes if possible
+      attributes['bm_versions'] || self.class.canonical.where(
+        ref_id: ref_id,
+        upstream: false
+      ).joins(:benchmark).pluck('benchmarks.version')
     end
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -72,27 +72,4 @@ class Profile < ApplicationRecord
       profile
     end
   end
-
-  def supported_os_versions
-    bm_versions.map do |v|
-      SupportedSsg.by_ssg_version[v].select { |ssg| ssg.os_major_version == cached_major_version }.map do |ssg|
-        Gem::Version.new([ssg.os_major_version, ssg.os_minor_version].join('.'))
-      end
-    end.flatten.uniq.sort.reverse
-  end
-
-  private
-
-  def bm_versions
-    # Try to reach for this in the cached attributes if possible
-    attributes['bm_versions'] || self.class.canonical.where(
-      ref_id: ref_id,
-      upstream: false
-    ).joins(:benchmark).pluck('benchmarks.version')
-  end
-
-  def cached_major_version
-    # Try to reach for this in the cached attributes if possible
-    (attributes['os_major_version'] || os_major_version).to_s
-  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -75,7 +75,7 @@ class Profile < ApplicationRecord
 
   def supported_os_versions
     bm_versions.map do |v|
-      SupportedSsg.by_ssg_version[v].select { |ssg| ssg.os_major_version == os_major_version }.map do |ssg|
+      SupportedSsg.by_ssg_version[v].select { |ssg| ssg.os_major_version == cached_major_version }.map do |ssg|
         Gem::Version.new([ssg.os_major_version, ssg.os_minor_version].join('.'))
       end
     end.flatten.uniq.sort.reverse
@@ -89,5 +89,10 @@ class Profile < ApplicationRecord
       ref_id: ref_id,
       upstream: false
     ).joins(:benchmark).pluck('benchmarks.version')
+  end
+
+  def cached_major_version
+    # Try to reach for this in the cached attributes if possible
+    (attributes['os_major_version'] || os_major_version).to_s
   end
 end


### PR DESCRIPTION
Should improve the performance of the GQL request on the create profile. Do more benchmarks than one as the first one can be slower due to cache setup if ran locally.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
