### PR TITLE
perf(Benchmarks): RHICOMPL-3176 preload rule identifiers if needed

### DIFF
--- a/app/graphql/types/benchmark.rb
+++ b/app/graphql/types/benchmark.rb
@@ -15,12 +15,18 @@ module Types
     field :osMajorVersion, String, null: false
     field :latest_supported_os_minor_versions, [String], null: false
     field :profiles, [::Types::Profile], null: true
-    field :rules, [::Types::Rule], null: true
+    field :rules, [::Types::Rule], null: true, extras: [:lookahead]
 
     enforce_rbac Rbac::COMPLIANCE_VIEWER
 
     def profiles
       object.profiles.canonical
+    end
+
+    def rules(args = {})
+      return object.rules unless args[:lookahead].selects?(:identifier)
+
+      object.rules.joins_identifier # Join and preselect an 'identifier' column
     end
   end
 end

--- a/app/graphql/types/rule.rb
+++ b/app/graphql/types/rule.rb
@@ -56,6 +56,10 @@ module Types
     end
 
     def identifier
+      # Try to return with the preloaded identifier if available
+      return object['identifier'].to_json if object.has_attribute?('identifier')
+
+      # Fall back to loading and building the identifiers
       ::CollectionLoader.for(::Rule, :rule_identifier)
                         .load(object).then do |identifier|
         { label: identifier&.label, system: identifier&.system }.to_json

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -73,6 +73,10 @@ class Rule < ApplicationRecord
     includes(:profiles).where(profiles: { id: Profile.canonical })
   }
 
+  scope :joins_identifier, lambda {
+    left_outer_joins(:rule_identifier).select('rules.*', RuleIdentifier::AS_JSON.as('identifier'))
+  }
+
   def canonical?
     (profiles & Profile.canonical).any?
   end

--- a/app/models/rule_identifier.rb
+++ b/app/models/rule_identifier.rb
@@ -8,6 +8,14 @@ class RuleIdentifier < ApplicationRecord
   validates :system, presence: true, uniqueness: { scope: %i[label rule_id] }
   validates :rule, presence: true, uniqueness: { scope: %i[label system] }
 
+  AS_JSON = Arel::Nodes::NamedFunction.new(
+    'json_build_object',
+    [
+      Arel::Nodes::Quoted.new('label'), arel_table[:label],
+      Arel::Nodes::Quoted.new('system'), arel_table[:system]
+    ]
+  )
+
   def self.from_openscap_parser(op_rule_identifier, rule_id)
     if op_rule_identifier.label # rubocop:disable Style/GuardClause
       find_or_initialize_by(label: op_rule_identifier.label,


### PR DESCRIPTION
Using GQL lookahead, we can preload the rule identifiers for rules under benchmarks which speeds up the loading significantly and also reduces the amount of allocated objects. My benchmark says that without optimization loading takes 2.5 seconds and when optimized it's around 850 milliseconds, which is more or less the same as we would not request the identifiers.

```
query benchmarkQuery($id: String!) {
  benchmark(id: $id) {
    id
    osMajorVersion
    rules {
      id
      title
      severity
      rationale
      refId
      description
      remediationAvailable
      identifier
      __typename
    }
    __typename
  }
}
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
