### PR TITLE
perf(SupportedSsg): RHICOMPL-3200 drop Revision from cache key

### DIFF
--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -80,9 +80,7 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def clear
-      %i[raw map by-ssg].each do |target|
-        Rails.cache.delete("SupportedSsg/datastreams/#{target}")
-      end
+      Rails.cache.delete_matched('SupportedSsg/datastreams/*')
     end
 
     private

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -9,6 +9,8 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
   OS_NAME = 'RHEL'
   self::OS_NAME = OS_NAME
 
+  CACHE_PREFIX = 'SupportedSsg/datastreams'
+
   def ref_id
     'xccdf_org.ssgproject' \
     ".content_benchmark_#{OS_NAME}-#{os_major_version}"
@@ -80,7 +82,7 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def clear
-      Rails.cache.delete_matched('SupportedSsg/datastreams/*')
+      Rails.cache.delete_matched("#{CACHE_PREFIX}/*")
     end
 
     private
@@ -111,7 +113,7 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def cache(key, &block)
-      Rails.cache.fetch("SupportedSsg/datastreams/#{key}", expires_on: 1.day, &block)
+      Rails.cache.fetch("#{CACHE_PREFIX}/#{key}", expires_on: 1.day, &block)
     end
   end
 end

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -79,9 +79,9 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
       cache(:'by-ssg') { all.group_by(&:version) }
     end
 
-    def clear(to_clear = revision)
+    def clear
       %i[raw map by-ssg].each do |target|
-        Rails.cache.delete("SupportedSsg/datastreams/#{to_clear}/#{target}")
+        Rails.cache.delete("SupportedSsg/datastreams/#{target}")
       end
     end
 
@@ -113,7 +113,7 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def cache(key, &block)
-      Rails.cache.fetch("SupportedSsg/datastreams/#{Revision.datastreams}/#{key}", expires_on: 1.day, &block)
+      Rails.cache.fetch("SupportedSsg/datastreams/#{key}", expires_on: 1.day, &block)
     end
   end
 end


### PR DESCRIPTION
Dropping the revision from the cache key reduces the number of allocations by ~100k and the latency by 200ms for this query:
```
time curl -k -H "Content-Type: application/json" -H "X-RH-IDENTITY: $RHI" -XPOST -d '{
  "operationName": "supportedProfilesByOSMajor",
  "variables": {},
  "query": "query supportedProfilesByOSMajor {
      osMajorVersions {
          edges {
              node {
                  osMajorVersion
                  profiles {
                      id
                      name
                      refId
                      description
                      complianceThreshold
                      supportedOsVersions
                      benchmark {
                          id
                          refId
                          osMajorVersion
                      }
                  }
              }
          }
      }
      profiles(search: \"external = false and canonical = false\") {
          edges {
              node {
                  id
                  refId
                  benchmark {
                      refId
                  }
              }
          }
      }
  }"
}' "http://localhost:3000/api/compliance/graphql" | jq

```

@vkrizan any objections? 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
