### PR TITLE
fix(Sidekiq): RHICOMPL-3217 load the reliable-fetch only for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,7 @@ sidekiq_config = lambda do |config|
   }
   config.options[:dead_timeout_in_seconds] = 2.weeks.to_i
   config.options[:interrupted_timeout_in_seconds] = 2.weeks.to_i
-  Sidekiq::ReliableFetch.setup_reliable_fetch!(config)
+  Sidekiq::ReliableFetch.setup_reliable_fetch!(config) if $0.include?('sidekiq')
 
   config.server_middleware do |chain|
     require 'prometheus_exporter/instrumentation'


### PR DESCRIPTION
Should reduce the number of forked threads in the puma/rails container.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
