### PR TITLE
perf(puma): RHICOMPL-3218 reduce the number of malloc arenas to 2

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -152,6 +152,8 @@ objects:
           value: "${PUMA_WORKERS}"
         - name: PUMA_MAX_THREADS
           value: "${PUMA_MAX_THREADS}"
+        - name: MALLOC_ARENA_MAX
+          value: '2'
         - name: OLD_PATH_PREFIX
           value: "${OLD_PATH_PREFIX}"
         - name: SECRET_KEY_BASE


### PR DESCRIPTION
Turning this on for the puma pods, leaving everything else alone for now. This is just an experiment that I hope reduces overall memory usage even more.

https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
