### PR TITLE
fix(REST): RHICOMPL-1612 fix scope_search on profile name

### DIFF
--- a/config/initializers/override_scoped_search_escaping.rb
+++ b/config/initializers/override_scoped_search_escaping.rb
@@ -5,6 +5,19 @@
 module ScopedSearch
   class QueryBuilder
     alias preprocess_parameters_old preprocess_parameters
+
+    INVERTED_OPERATORS = SQL_OPERATORS.invert.merge('ILIKE' => :like, 'NOT ILIKE' => :unlike).freeze
+
+    # scoped_search gem does not preprocess values before passing to ext_method but sometimes it is necessary
+    # This method can be called from a scoped search ext_method to preprocess parameters
+    def self.preprocess_parameters(definition, field, operator, value)
+      # Passing empty block because nothing needs to happen on yield in preprocess_parameters
+      # The correct yield is invoked in to_ext_method_sql so all notification values are updated correctly
+      # See https://github.com/wvanbergen/scoped_search/blob/master/lib/scoped_search/query_builder.rb
+      qb = ScopedSearch::QueryBuilder.new(definition, '', definition.profile)
+      qb.preprocess_parameters(field, INVERTED_OPERATORS[operator], value) { |_| }
+    end
+
     def preprocess_parameters(field, operator, value, &block)
       return preprocess_parameters_old(field, operator, value, &block) unless %i[like unlike].include?(operator)
       # Escaping the value part of the query

--- a/test/controllers/concerns/metadata_test.rb
+++ b/test/controllers/concerns/metadata_test.rb
@@ -88,13 +88,13 @@ class MetadataTest < ActionDispatch::IntegrationTest
       FactoryBot.create(:profile)
     end
 
-    search_query = 'name != ""'
+    search_query = "name != ''"
     get profiles_url, params: { search: search_query, limit: 1, offset: 2 }
     assert_response :success
-    assert_includes json_body['links']['first'], 'search=name+%21%3D+%22%22'
-    assert_includes json_body['links']['last'], 'search=name+%21%3D+%22%22'
-    assert_includes json_body['links']['next'], 'search=name+%21%3D+%22%22'
-    assert_includes json_body['links']['previous'], 'search=name+%21%3D+%22%22'
+    assert_includes json_body['links']['first'], 'search=name+%21%3D+%27%27'
+    assert_includes json_body['links']['last'], 'search=name+%21%3D+%27%27'
+    assert_includes json_body['links']['next'], 'search=name+%21%3D+%27%27'
+    assert_includes json_body['links']['previous'], 'search=name+%21%3D+%27%27'
   end
 
   test 'meta adds relationships param to JSON response' do


### PR DESCRIPTION
Used this to test the time/efficiency of the old `name` scoped_search and the new version implemented here: 
`http --meta --verify no GET http://0.0.0.0:3000/api/compliance/v1/profiles search==name~"ANSSI" X-RH-IDENTITY:$ID_HEADER`

Old version: `Completed 200 OK in 361ms (Views: 253.5ms | ActiveRecord: 91.0ms | Allocations: 83467) `
Old version timed with httpie: 0.447715618s 

New version: `Completed 200 OK in 325ms (Views: 214.0ms | ActiveRecord: 90.5ms | Allocations: 83458)`
New version timed with httpie: 0.452380513s

Efficiency is about the same and this new `name` scoped_search for profiles is searching profiles and policies. It was only searching profiles before.

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
