### PR TITLE
feat(db update): RHICOMPL-2467 bump DB used in ephemeral to 13

### DIFF
--- a/clowdapp-minimal.yaml
+++ b/clowdapp-minimal.yaml
@@ -20,7 +20,7 @@ objects:
         - rbac
       database:
         name: compliance
-        version: 12
+        version: 13
       kafkaTopics:
         - topicName: platform.upload.compliance
           partitions: 1

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -21,7 +21,7 @@ objects:
     - rbac
     database:
       name: compliance
-      version: 12
+      version: 13
     kafkaTopics:
       - topicName: platform.upload.compliance
         partitions: 1


### PR DESCRIPTION
This should make the pr_check runs start using current Clowder supported PostgreSQL ver. 13 , currently 13.3 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
