### PR TITLE
revert(metrics): RHICOMPL-3232 re-enable puma metrics collection

### DIFF
--- a/config/puma.cfg
+++ b/config/puma.cfg
@@ -12,7 +12,9 @@ end
 
 preload_app!
 nakayoshi_fork
+activate_control_app("unix://#{File.expand_path(File.join(File.dirname(__FILE__), '../tmp/puma.sock'))}")
 
+plugin :yabeda
 plugin :yabeda_prometheus
 
 environment ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'production'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -44,4 +44,6 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 plugin :tmp_restart
 
 # Metrics
+activate_control_app("unix://#{File.expand_path(File.join(File.dirname(__FILE__), '../tmp/puma.sock'))}")
+plugin :yabeda
 plugin :yabeda_prometheus


### PR DESCRIPTION
Yabeda doesn't collect any rails/gql metrics after [disabling the puma collector](https://github.com/RedHatInsights/compliance-backend/pull/1426). 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
