### PR TITLE
perf(clowder): RHICOMPL-3220 re-enable MALLOC_ARENA_MAX for racecar

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -247,6 +247,8 @@ objects:
           value: "${REDIS_SSL}"
         - name: SETTINGS__REDIS_CACHE_SSL
           value: "${REDIS_SSL}"
+        - name: MALLOC_ARENA_MAX
+          value: '2'
         - name: SECRET_KEY_BASE
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This was done by mistake as we thought that the report upload performance was dropped, but actually the REST API was not responsive.

This reverts commit 7a74942ee5c07e251415e8d9574a45251064fea6.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
