### PR TITLE
fix(GQL): RHICOMPL-3225 provide the totalCount using #count

### DIFF
--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -9,7 +9,7 @@ module Types
     field :total_count, Integer, null: false
 
     def total_count
-      object.items.size
+      object.items.count
     end
   end
 end

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -890,6 +890,8 @@ class SystemQueryTest < ActiveSupport::TestCase
     GRAPHQL
 
     setup_two_hosts
+    @host2.update!(policies: [@profile1.policy], org_id: @host1.org_id)
+
     result = Schema.execute(
       query,
       variables: { perPage: 1, page: 1 },


### PR DESCRIPTION
When having 2 systems, this query before the change returns just 1 in totalCount. Using `#size` on a relation just counts the already loaded entities, scoped to the pagination.

```bash
time curl -k -H "Content-Type: application/json" -H "X-RH-IDENTITY: $RHI" -XPOST -d '{
  "operationName": "getSystems",
  "variables": {},
  "query": "query getSystems {
  systems(limit: 1) { 
    edges {
      node {
        id
      }
    }
    totalCount
  }
}"
}' "http://localhost:3000/api/compliance/graphql" | jq
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
