### PR TITLE
cleanup(stratosphere): RHICOMPL-2965 final sweep for account numbers

### DIFF
--- a/app/consumers/concerns/report_parsing.rb
+++ b/app/consumers/concerns/report_parsing.rb
@@ -50,7 +50,7 @@ module ReportParsing
     end
 
     def notify_report_failure(exc)
-      host = Host.find_by(id: id, account: account)
+      host = Host.find_by(id: id, org_id: org_id)
 
       # Do not fire a notification for a host that has been deleted
       return unless host

--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -13,7 +13,7 @@ class InventoryEventsConsumer < ApplicationConsumer
   def process(message)
     super
 
-    Insights::API::Common::AuditLog.audit_with_account(account) do
+    Insights::API::Common::AuditLog.audit_with_account(org_id) do
       dispatch
     end
   rescue PG::Error, ActiveRecord::StatementInvalid

--- a/app/jobs/delete_host.rb
+++ b/app/jobs/delete_host.rb
@@ -7,7 +7,7 @@ class DeleteHost
   MODELS = [RuleResult, TestResult, PolicyHost].freeze
 
   def perform(message)
-    Rails.logger.audit_with_account(message['account']) do
+    Rails.logger.audit_with_account(message['org_id']) do
       host_id = message['id']
       begin
         num_removed = remove_related(host_id)

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -12,13 +12,13 @@ class ParseReportJob
 
     @msg_value = message
     Sidekiq.logger.info(
-      "Parsing report for account #{@msg_value['account']}, "\
+      "Parsing report for account #{@msg_value['org_id']}, "\
       "system #{@msg_value['id']}"
     )
 
     @file = retrieve_file(idx)
 
-    Rails.logger.audit_with_account(@msg_value['account']) do
+    Rails.logger.audit_with_account(@msg_value['org_id']) do
       parse_and_save_report
     end
   end

--- a/app/models/business_objective.rb
+++ b/app/models/business_objective.rb
@@ -6,7 +6,6 @@ class BusinessObjective < ApplicationRecord
   has_many :profiles, through: :policies
   has_many :accounts, through: :policies
 
-  delegate :account_number, to: :account
   delegate :org_id, to: :account
 
   validates :title, presence: true

--- a/app/models/concerns/system_like.rb
+++ b/app/models/concerns/system_like.rb
@@ -13,10 +13,6 @@ module SystemLike
                                 inverse_of: :hosts, class_name: 'Account'
   end
 
-  def account_number
-    account
-  end
-
   def compliant
     result = {}
     test_result_profiles.map do |profile|

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -17,7 +17,6 @@ class Policy < ApplicationRecord
 
   belongs_to :business_objective, optional: true
   belongs_to :account
-  delegate :account_number, to: :account
   delegate :org_id, to: :account
 
   validates :compliance_threshold, numericality: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -54,7 +54,6 @@ class Profile < ApplicationRecord
 
   scope :joins_policy, -> { left_outer_joins(:policy) }
 
-  delegate :account_number, to: :account, allow_nil: true
   delegate :org_id, to: :account, allow_nil: true
 
   class << self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
 
   belongs_to :account
 
-  delegate :account_number, to: :account
   delegate :org_id, to: :account
 
   def authorized_to?(access_request)

--- a/app/services/dangling_account_remover.rb
+++ b/app/services/dangling_account_remover.rb
@@ -33,7 +33,7 @@ class DanglingAccountRemover
 
     def accounts_with_hosts
       if ApplicationRecord.connection.data_source_exists?(Host.table_name)
-        Host.with_policies_or_test_results.select(:account).distinct.arel
+        Host.with_policies_or_test_results.select(:org_id).distinct.arel
       else
         # When setting up initial migrations and cyndi is not yet available
         ApplicationRecord.none

--- a/db/cyndi_setup_test.sql
+++ b/db/cyndi_setup_test.sql
@@ -11,7 +11,7 @@ DROP TABLE IF EXISTS inventory.hosts_v1_1 CASCADE;
 
 CREATE TABLE inventory.hosts_v1_1 (
     id uuid PRIMARY KEY,
-    account character varying(10) NOT NULL,
+    account character varying(10),
     org_id character varying(10) NOT NULL,
     display_name character varying(200) NOT NULL,
     tags jsonb NOT NULL,

--- a/lib/audit_log/audit_log/wrapped_logger.rb
+++ b/lib/audit_log/audit_log/wrapped_logger.rb
@@ -35,8 +35,8 @@ module Insights
             audit(payload)
           end
 
-          def audit_with_account(account_number, &block)
-            AuditLog.audit_with_account(account_number, &block)
+          def audit_with_account(account_org_id, &block)
+            AuditLog.audit_with_account(account_org_id, &block)
           end
 
           def close

--- a/lib/tasks/cleanup_db.rake
+++ b/lib/tasks/cleanup_db.rake
@@ -7,7 +7,7 @@ task cleanup_db: :environment do
   puts 'Beginning cleanup_db.'
 
   num_deleted = Account.where.not(
-    account_number: Host.select(:account)
+    org_id: Host.select(:org_id)
   ).where.not(
     id: Profile.where.not(account_id: nil).select(:account_id)
   ).where.not(

--- a/test/consumers/inventory_events_consumer_test.rb
+++ b/test/consumers/inventory_events_consumer_test.rb
@@ -89,7 +89,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
       ParseReportJob.clear
       SafeDownloader.stubs(:download_reports).returns(['report'])
       IdentityHeader.stubs(:new).returns(OpenStruct.new(valid?: true))
-      @host = Host.find(FactoryBot.create(:host, id: '37f7eeff-831b-5c41-984a-254965f58c0f', account: '1234').id)
+      @host = Host.find(FactoryBot.create(:host, id: '37f7eeff-831b-5c41-984a-254965f58c0f', org_id: '1234').id)
     end
 
     should 'not leak memory to subsequent messages' do
@@ -101,7 +101,6 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
           org_id: '1111'
         }
       }.to_json)
@@ -124,7 +123,6 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
           org_id: '1111'
         }
       }.to_json)
@@ -152,7 +150,6 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
           org_id: '1111'
         }
       }.to_json)
@@ -177,8 +174,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
-          org_id: '1111'
+          org_id: '1234'
         }
       }.to_json)
 
@@ -186,7 +182,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
 
       ReportUploadFailed.expects(:deliver).with(
         account_number: @host.account, host: @host,
-        request_id: '036738d6f4e541c4aa8cfc9f46f5a140', org_id: '1111',
+        request_id: '036738d6f4e541c4aa8cfc9f46f5a140', org_id: '1234',
         error: "Unable to locate any uploaded report from host #{@host.id}."
       )
 
@@ -213,8 +209,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
-          org_id: '1111'
+          org_id: '1234'
         }
       }.to_json)
 
@@ -245,8 +240,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
-          org_id: '1111'
+          org_id: '1234'
         }
       }.to_json)
       # Mock the actual 'sending the validation' to Kafka
@@ -254,7 +248,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
 
       ReportUploadFailed.expects(:deliver).with(
         account_number: @host.account, host: @host,
-        request_id: '036738d6f4e541c4aa8cfc9f46f5a140', org_id: '1111',
+        request_id: '036738d6f4e541c4aa8cfc9f46f5a140', org_id: '1234',
         error: "Failed to parse any uploaded report from host #{@host.id}: invalid format."
       )
 
@@ -282,14 +276,13 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: '1234',
-          org_id: '4321'
+          org_id: '1234'
         }
       }.to_json)
 
       ReportUploadFailed.expects(:deliver).with(
         account_number: @host.account, host: @host,
-        request_id: '036738d6f4e541c4aa8cfc9f46f5a140', org_id: '4321',
+        request_id: '036738d6f4e541c4aa8cfc9f46f5a140', org_id: '1234',
         error: "Failed to parse any uploaded report from host #{@host.id}: " \
                'invalid identity of missing insights entitlement.'
       )
@@ -318,8 +311,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
-          org_id: '1111'
+          org_id: '1234'
         }
       }.to_json)
       @consumer.stubs(:download_file)
@@ -351,8 +343,7 @@ class InventoryEventsConsumerTest < ActiveSupport::TestCase
           service: 'compliance',
           url: '/tmp/uploads/insights-upload-quarantine/036738d6f4e541c4aa8cf',
           request_id: '036738d6f4e541c4aa8cfc9f46f5a140',
-          account: @host.account,
-          org_id: '1111'
+          org_id: '1234'
         }
       }.to_json)
       # Mock the actual 'sending the validation' to Kafka

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -36,7 +36,7 @@ class AuthenticationTest < ActionController::TestCase
 
   teardown do
     # expected to be cleared out by the middleware
-    Thread.current[:audit_account_number] = nil
+    Thread.current[:audit_org_id] = nil
   end
 
   context 'unauthorized access' do
@@ -57,7 +57,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           }
@@ -73,7 +72,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           },
@@ -94,7 +92,6 @@ class AuthenticationTest < ActionController::TestCase
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           },
@@ -118,11 +115,10 @@ class AuthenticationTest < ActionController::TestCase
       stub_rbac_permissions(Rbac::COMPLIANCE_VIEWER, Rbac::INVENTORY_VIEWER)
     end
 
-    should 'account number not found, creates a new account' do
+    should 'account org_id not found, creates a new account' do
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': '1234',
             'org_id': '1234',
             'user': {
               'username': 'username',
@@ -154,7 +150,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           },
@@ -184,7 +179,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': {
               'username': 'username',
@@ -211,7 +205,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           },
@@ -234,7 +227,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           },
@@ -261,7 +253,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           },
@@ -284,7 +275,6 @@ class AuthenticationTest < ActionController::TestCase
         {
           'identity':
           {
-            'account_number': '1234',
             'org_id': '1234',
             'user': { 'username': 'username' }
           },
@@ -310,7 +300,6 @@ class AuthenticationTest < ActionController::TestCase
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': '1234',
               'org_id': '1234',
               'user': { 'username': 'username' }
             },
@@ -338,7 +327,6 @@ class AuthenticationTest < ActionController::TestCase
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': '1234',
             'org_id': '1234',
             'auth_type': IdentityHeader::CERT_AUTH
           },
@@ -366,7 +354,6 @@ class AuthenticationTest < ActionController::TestCase
       {
         'identity':
         {
-          'account_number': '1234',
           'org_id': '1234',
           'user': { 'username': 'username' }
         },

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -42,7 +42,6 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
       identity = Base64.encode64(
         {
           identity: {
-            account_number: account.account_number,
             org_id: account.org_id
           },
           entitlements: {
@@ -80,7 +79,6 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
       identity = Base64.encode64(
         {
           identity: {
-            account_number: account.account_number,
             org_id: account.org_id
           },
           entitlements: {

--- a/test/controllers/openapi_endopoint_test.rb
+++ b/test/controllers/openapi_endopoint_test.rb
@@ -12,7 +12,6 @@ class OpenapiEndpointTest < ActionDispatch::IntegrationTest
     encoded_header = Base64.encode64(
       {
         'identity': {
-          'account_number': account.account_number,
           'auth_type': 'basic-auth',
           'org_id': account.org_id
         },

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -10,7 +10,6 @@ module V1
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': '1234',
               'org_id': '1234',
               'auth_type': IdentityHeader::CERT_AUTH
             },
@@ -32,7 +31,6 @@ module V1
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': '1234',
               'org_id': '1234',
               'auth_type': IdentityHeader::CERT_AUTH
             },
@@ -55,7 +53,6 @@ module V1
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': '1234',
               'org_id': '1234',
               'auth_type': IdentityHeader::CERT_AUTH
             },
@@ -79,7 +76,6 @@ module V1
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': account.account_number,
               'org_id': account.org_id,
               'auth_type': IdentityHeader::CERT_AUTH
             },
@@ -107,7 +103,6 @@ module V1
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': account.account_number,
               'org_id': account.org_id,
               'auth_type': 'basic-auth'
             },
@@ -132,7 +127,6 @@ module V1
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': account.account_number,
               'org_id': account.org_id,
               'auth_type': IdentityHeader::CERT_AUTH
             },
@@ -158,7 +152,6 @@ module V1
         encoded_header = Base64.encode64(
           {
             'identity': {
-              'account_number': account.account_number,
               'org_id': account.org_id,
               'auth_type': IdentityHeader::CERT_AUTH
             },

--- a/test/controllers/v1/rules_controller_test.rb
+++ b/test/controllers/v1/rules_controller_test.rb
@@ -15,7 +15,6 @@ module V1
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': account.account_number,
             'org_id': account.org_id,
             'auth_type': IdentityHeader::CERT_AUTH
           },
@@ -41,7 +40,6 @@ module V1
       encoded_header = Base64.encode64(
         {
           'identity': {
-            'account_number': account.account_number,
             'org_id': account.org_id,
             'auth_type': IdentityHeader::CERT_AUTH
           },

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -173,7 +173,7 @@ module V1
       end
 
       should 'return 404 for hosts in other accounts' do
-        host = FactoryBot.create(:host, account: 'foo', org_id: 'foo')
+        host = FactoryBot.create(:host, org_id: 'foo')
         get system_path(host)
         assert_response :not_found
       end

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -2,13 +2,11 @@
 
 FactoryBot.define do
   factory :account do
-    sequence(:account_number) { |n| format('%05<num>d', num: n) }
     sequence(:org_id) { |n| format('%05<num>d', num: n) }
     identity_header do
       IdentityHeader.new(
         Base64.encode64({
           identity: {
-            account_number: account_number,
             org_id: org_id
           }
         }.to_json)

--- a/test/factories/host.rb
+++ b/test/factories/host.rb
@@ -32,14 +32,10 @@ FactoryBot.define do
     end
   end
 
-  sequence(:account_number) { |n| format('%05<num>d', num: n) }
   sequence(:org_id) { |n| format('%05<num>d', num: n) }
 
   factory :host, class: WHost do
     id { SecureRandom.uuid }
-    account do
-      User.current&.account&.account_number || generate(:account_number)
-    end
     org_id do
       User.current&.account&.org_id || generate(:org_id)
     end

--- a/test/graphql/mutations/associate_profiles_test.rb
+++ b/test/graphql/mutations/associate_profiles_test.rb
@@ -18,7 +18,7 @@ class AssociateProfilesMutationTest < ActiveSupport::TestCase
     PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @profiles = FactoryBot.create_list(:profile, 2, account: @user.account)
-    @host = FactoryBot.create(:host, account: @user.account.account_number, org_id: @user.account.org_id)
+    @host = FactoryBot.create(:host, org_id: @user.account.org_id)
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_VIEWER)
   end
 

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -7,7 +7,7 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
     PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @profile = FactoryBot.create(:profile, account: @user.account, upstream: false)
-    @host = FactoryBot.create(:host, account: @user.account.account_number, org_id: @user.account.org_id)
+    @host = FactoryBot.create(:host, org_id: @user.account.org_id)
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_VIEWER)
     stub_supported_ssg([@host], [@profile.benchmark.version])
   end

--- a/test/graphql/mutations/delete_test_result_mutation_test.rb
+++ b/test/graphql/mutations/delete_test_result_mutation_test.rb
@@ -23,7 +23,7 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
     PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
     @profile = FactoryBot.create(:profile, account: @user.account)
-    @host = FactoryBot.create(:host, account: @user.account.account_number)
+    @host = FactoryBot.create(:host, org_id: @user.account.org_id)
     @tr = FactoryBot.create(
       :test_result,
       profile: @profile,
@@ -63,7 +63,7 @@ class DeleteTestResultMutationTest < ActiveSupport::TestCase
       external: true
     )
 
-    host2 = FactoryBot.create(:host, account: @user.account.account_number)
+    host2 = FactoryBot.create(:host, org_id: @user.account.org_id)
     profile2.policy.update(hosts: [@host, host2])
     FactoryBot.create(:test_result, profile: profile2, host: host2)
 

--- a/test/graphql/mutations/edit_policy_mutation_test.rb
+++ b/test/graphql/mutations/edit_policy_mutation_test.rb
@@ -6,7 +6,7 @@ class EditPolicyMutationTest < ActiveSupport::TestCase
   setup do
     @user = FactoryBot.create(:user)
     @profile = FactoryBot.create(:profile, account: @user.account)
-    @host = FactoryBot.create(:host, account: @user.account.account_number)
+    @host = FactoryBot.create(:host, org_id: @user.account.org_id)
     @tr = FactoryBot.create(:test_result, host: @host, profile: @profile)
     PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @profile.policy.update(hosts: [@host])

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -132,7 +132,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
       @hosts = FactoryBot.create_list(
         :host,
         2,
-        account: @user.account.account_number
+        org_id: @user.account.org_id
       )
 
       @profile2 = FactoryBot.create(
@@ -334,7 +334,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
   end
 
   should 'query profile via a policy with failing rule stats' do
-    FactoryBot.create_list(:host, 2, account: @profile.account.account_number, org_id: @profile.account.org_id)
+    FactoryBot.create_list(:host, 2, org_id: @profile.account.org_id)
     @profile.policy.update!(hosts: Host.all)
     rules = @profile.rules.to_a
     duplicate_rule = rules.pop

--- a/test/graphql/queries/rule_query_test.rb
+++ b/test/graphql/queries/rule_query_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class RuleQueryTest < ActiveSupport::TestCase
   setup do
     @user = FactoryBot.create(:user)
-    @host = FactoryBot.create(:host, account: @user.account.account_number)
+    @host = FactoryBot.create(:host, org_id: @user.account.org_id)
     @profile = FactoryBot.create(
       :profile,
       :with_rules,

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -6,7 +6,7 @@ class SystemQueryTest < ActiveSupport::TestCase
   setup do
     PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @user = FactoryBot.create(:user)
-    @host1 = FactoryBot.create(:host, account: @user.account.account_number, org_id: @user.account.org_id)
+    @host1 = FactoryBot.create(:host, org_id: @user.account.org_id)
 
     @profile1, @profile2 = FactoryBot.create_list(
       :profile,
@@ -233,7 +233,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     should 'search systems based on stale_timestamp' do
       @host2 = FactoryBot.create(
         :host,
-        account: @host1.account,
         org_id: @host1.org_id,
         stale_timestamp: 2.days.ago(Time.zone.now)
       )
@@ -567,7 +566,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     setup_two_hosts
     @host1.update!(display_name: 'b')
-    @host2.update!(display_name: 'a', account: @user.account.account_number, org_id: @user.account.org_id)
+    @host2.update!(display_name: 'a', org_id: @user.account.org_id)
 
     result = Schema.execute(
       query,
@@ -920,7 +919,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     # setup_two_hosts
     @host2 = FactoryBot.create(
       :host,
-      account: @user.account.account_number,
       org_id: @user.account.org_id,
       os_minor_version: 7
     )
@@ -992,14 +990,12 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     @host2 = FactoryBot.create(
       :host,
-      account: @user.account.account_number,
       org_id: @user.account.org_id,
       os_minor_version: 7
     )
 
     @host3 = FactoryBot.create(
       :host,
-      account: @user.account.account_number,
       org_id: @user.account.org_id,
       os_minor_version: 7
     )
@@ -1045,7 +1041,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     # setup_two_hosts
     @host2 = FactoryBot.create(
       :host,
-      account: @user.account.account_number,
       org_id: @user.account.org_id,
       os_minor_version: 7
     )
@@ -1119,7 +1114,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     # setup_two_hosts
     @host2 = FactoryBot.create(
       :host,
-      account: @user.account.account_number,
       org_id: @user.account.org_id,
       os_minor_version: 7
     )
@@ -1249,7 +1243,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     @host2 = FactoryBot.create(
       :host,
       policies: [@profile2.policy],
-      account: acc.account_number,
       org_id: acc.org_id
     )
 

--- a/test/jobs/delete_host_test.rb
+++ b/test/jobs/delete_host_test.rb
@@ -6,7 +6,7 @@ require 'sidekiq/testing'
 class DeleteHostTest < ActiveSupport::TestCase
   setup do
     user = FactoryBot.create(:user)
-    @host = FactoryBot.create(:host, account: user.account.account_number)
+    @host = FactoryBot.create(:host, org_id: user.account.org_id)
     @profile = FactoryBot.create(:profile, :with_rules, account: user.account)
     tr = FactoryBot.create(:test_result, profile: @profile, host: @host)
     FactoryBot.create(

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -4,10 +4,9 @@ require 'test_helper'
 
 class ParseReportJobTest < ActiveSupport::TestCase
   setup do
-    @host = FactoryBot.create(:host, account: '1234')
+    @host = FactoryBot.create(:host, org_id: '1234')
     @msg_value = {
       'id' => @host.id,
-      'account' => '1234',
       'org_id' => '1111',
       'request_id' => '',
       'url' => ''

--- a/test/lib/audit_log/middleware_test.rb
+++ b/test/lib/audit_log/middleware_test.rb
@@ -135,7 +135,7 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     assert_equal 'fail', log_msg['status']
   end
 
-  test 'setting account number context' do
+  test 'setting account org_id context' do
     app = MockRackApp.new
     mw = Insights::API::Common::AuditLog::Middleware.new(app)
     mw.logger = @audit
@@ -151,7 +151,7 @@ class AuditLogMiddlewareTest < ActiveSupport::TestCase
     assert_equal 'success', log_msg['status']
 
     assert_not Thread.current[:audit_org_id],
-               'account number should be reset after request is done'
+               'account org_id should be reset after request is done'
   end
 
   test 'fallbacks to info loging' do

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -15,7 +15,6 @@ class AccountTest < ActiveSupport::TestCase
       acc = FactoryBot.create(:account, account_number: nil)
       ih = IdentityHeader.new(Base64.encode64({
         'identity' => {
-          'account_number' => acc.account_number,
           'org_id' => acc.org_id
         }
       }.to_json))
@@ -28,7 +27,6 @@ class AccountTest < ActiveSupport::TestCase
     should 'create an account if new' do
       ih = IdentityHeader.new(Base64.encode64({
         'identity' => {
-          'account_number' => '123456',
           'org_id' => '123456'
         }
       }.to_json))
@@ -41,7 +39,6 @@ class AccountTest < ActiveSupport::TestCase
     should 'update the is_internal field if set' do
       ih = IdentityHeader.new(Base64.encode64({
         'identity' => {
-          'account_number' => '123456',
           'org_id' => '123456',
           'user' => {
             'is_internal' => true
@@ -57,7 +54,6 @@ class AccountTest < ActiveSupport::TestCase
     should 'update the org_id field if set' do
       ih = IdentityHeader.new(Base64.encode64({
         'identity' => {
-          'account_number' => '123456',
           'org_id' => '654321'
         }
       }.to_json))

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -16,7 +16,7 @@ class HostTest < ActiveSupport::TestCase
     @account = FactoryBot.create(:account)
     @host1 = Host.find(FactoryBot.create(
       :host,
-      account: @account.account_number,
+      org_id: @account.org_id,
       os_major_version: 7,
       os_minor_version: 4,
       tags: [
@@ -27,7 +27,7 @@ class HostTest < ActiveSupport::TestCase
 
     @host2 = Host.find(FactoryBot.create(
       :host,
-      account: @account.account_number,
+      org_id: @account.org_id,
       os_major_version: 8,
       os_minor_version: 3
     ).id)
@@ -397,8 +397,8 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test '#available_tags' do
-    FactoryBot.create(:host, account: @account.account_number, tags: [])
-    FactoryBot.create(:host, account: @account.account_number, tags: {})
+    FactoryBot.create(:host, org_id: @account.org_id, tags: [])
+    FactoryBot.create(:host, org_id: @account.org_id, tags: {})
 
     assert_equal_sets(
       [

--- a/test/models/identity_header_test.rb
+++ b/test/models/identity_header_test.rb
@@ -12,7 +12,6 @@ class IdentityHeaderTest < ActiveSupport::TestCase
       },
       'identity': {
         'user': {},
-        'account_number': '293912',
         'auth_type': 'basic-auth'
       }
     }

--- a/test/models/policy_host_test.rb
+++ b/test/models/policy_host_test.rb
@@ -39,14 +39,14 @@ class PolicyHostTest < ActiveSupport::TestCase
 
     @host1 = Host.find(FactoryBot.create(
       :host,
-      account: account.account_number,
+      org_id: account.org_id,
       os_major_version: 7,
       os_minor_version: 1
     ).id)
 
     @host2 = Host.find(FactoryBot.create(
       :host,
-      account: account.account_number,
+      org_id: account.org_id,
       os_major_version: 8,
       os_minor_version: 3
     ).id)

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -23,7 +23,7 @@ class PolicyTest < ActiveSupport::TestCase
       @hosts = FactoryBot.create_list(
         :host,
         2,
-        account: @account.account_number
+        org_id: @account.org_id
       )
     end
 
@@ -119,7 +119,7 @@ class PolicyTest < ActiveSupport::TestCase
       @hosts = FactoryBot.create_list(
         :host,
         2,
-        account: @account.account_number
+        org_id: @account.org_id
       ).map { |wh| Host.find(wh.id) }
     end
 
@@ -221,7 +221,7 @@ class PolicyTest < ActiveSupport::TestCase
 
   context 'compliant?' do
     should 'be compliant if score is above compliance threshold' do
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
       FactoryBot.create(:profile, policy: @policy, account: @account)
       @policy.update(compliance_threshold: 90, hosts: [host])
       @policy.stubs(:score).returns(95)
@@ -244,7 +244,7 @@ class PolicyTest < ActiveSupport::TestCase
 
         host = FactoryBot.create(
           :host,
-          account: @account.account_number,
+          org_id: @account.org_id,
           policies: [@policy]
         )
 
@@ -261,7 +261,7 @@ class PolicyTest < ActiveSupport::TestCase
   context '#clone_to' do
     setup do
       @canonical = FactoryBot.create(:canonical_profile)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @policy.update(hosts: [@host])
       @os_minor_version = '3'
     end
@@ -366,7 +366,7 @@ class PolicyTest < ActiveSupport::TestCase
       @profile = FactoryBot.create(:profile, account: @account, policy: @policy)
       @host = FactoryBot.create(
         :host,
-        account: @account.account_number,
+        org_id: @account.org_id,
         os_minor_version: 4
       )
       @policy.update(hosts: [@host])
@@ -453,8 +453,8 @@ class PolicyTest < ActiveSupport::TestCase
 
   context 'cached host counts' do
     setup do
-      @host1 = FactoryBot.create(:host, account: @account.account_number)
-      @host2 = FactoryBot.create(:host, account: @account.account_number)
+      @host1 = FactoryBot.create(:host, org_id: @account.org_id)
+      @host2 = FactoryBot.create(:host, org_id: @account.org_id)
       @profile = FactoryBot.create(:profile, policy: @policy, account: @account)
     end
 

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -23,7 +23,7 @@ class ProfileTest < ActiveSupport::TestCase
 
   setup do
     @account = FactoryBot.create(:account)
-    @host = FactoryBot.create(:host, account: @account.account_number)
+    @host = FactoryBot.create(:host, org_id: @account.org_id)
     PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     @policy = FactoryBot.create(:policy, account: @account, hosts: [@host])
   end
@@ -133,7 +133,7 @@ class ProfileTest < ActiveSupport::TestCase
 
   context 'compliance' do
     setup do
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @policy.hosts << @host
       @profile = FactoryBot.create(
         :profile,
@@ -180,7 +180,7 @@ class ProfileTest < ActiveSupport::TestCase
       @tr.update(score: 0.5)
       FactoryBot.create(
         :test_result,
-        host: FactoryBot.create(:host, account: @account.account_number),
+        host: FactoryBot.create(:host, org_id: @account.org_id),
         profile: @profile,
         score: 0.2
       )
@@ -191,7 +191,7 @@ class ProfileTest < ActiveSupport::TestCase
       @tr.update(score: 1)
       FactoryBot.create(
         :test_result,
-        host: FactoryBot.create(:host, account: @account.account_number),
+        host: FactoryBot.create(:host, org_id: @account.org_id),
         profile: @profile,
         score: 0
       )
@@ -202,7 +202,7 @@ class ProfileTest < ActiveSupport::TestCase
   context 'threshold' do
     setup do
       @profile = FactoryBot.create(:profile, account: @account, policy: @policy)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       FactoryBot.create(
         :test_result,
         host: @host,
@@ -279,7 +279,7 @@ class ProfileTest < ActiveSupport::TestCase
       FactoryBot.create(
         :test_result,
         profile: @profile,
-        host: FactoryBot.create(:host, account: @account.account_number)
+        host: FactoryBot.create(:host, org_id: @account.org_id)
       )
 
       assert_equal 1, @profile.test_results.count
@@ -292,7 +292,7 @@ class ProfileTest < ActiveSupport::TestCase
       tr = FactoryBot.create(
         :test_result,
         profile: @profile,
-        host: FactoryBot.create(:host, account: @account.account_number)
+        host: FactoryBot.create(:host, org_id: @account.org_id)
       )
 
       FactoryBot.create(
@@ -418,7 +418,7 @@ class ProfileTest < ActiveSupport::TestCase
   end
 
   test 'has_test_results filters by test results available' do
-    host = FactoryBot.create(:host, account: @account.account_number)
+    host = FactoryBot.create(:host, org_id: @account.org_id)
     profile1 = FactoryBot.create(:profile, account: @account)
     profile2 = FactoryBot.create(:profile, account: @account)
     FactoryBot.create(:test_result, profile: profile1, host: host)
@@ -438,7 +438,7 @@ class ProfileTest < ActiveSupport::TestCase
                                                     account: @account,
                                                     policy: @policy)
 
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
       FactoryBot.create_list(:test_result, 2, profile: @profile1, host: host)
     end
 
@@ -467,7 +467,7 @@ class ProfileTest < ActiveSupport::TestCase
     setup do
       @profile1 = FactoryBot.create(:profile, account: @account)
       @profile2 = FactoryBot.create(:profile, account: @account)
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
       FactoryBot.create(:test_result, profile: @profile1, host: host)
     end
 
@@ -720,7 +720,7 @@ class ProfileTest < ActiveSupport::TestCase
     end
 
     should 'use the same profile when the host is assinged' do
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
       @policy.hosts << host
 
       FactoryBot.create(
@@ -753,7 +753,7 @@ class ProfileTest < ActiveSupport::TestCase
     end
 
     should 'assign different SSG profile to a policy the host is part of' do
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
       @policy.hosts << host
 
       second_benchmark = @profile.benchmark.dup
@@ -776,7 +776,7 @@ class ProfileTest < ActiveSupport::TestCase
     end
 
     should 'set the parent profile ID to the original profile' do
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
 
       assert @profile.canonical?
       assert_difference('Profile.count', 1) do
@@ -791,7 +791,7 @@ class ProfileTest < ActiveSupport::TestCase
     end
 
     should 'clone profiles as external by default' do
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
       assert_difference('PolicyHost.count' => 0, 'Profile.count' => 1) do
         cloned_profile = @profile.clone_to(
           account: @account,
@@ -805,7 +805,7 @@ class ProfileTest < ActiveSupport::TestCase
 
     should 'not add rules to existing profiles' do
       assert_not_empty(@profile.rules)
-      host = FactoryBot.create(:host, account: @account.account_number)
+      host = FactoryBot.create(:host, org_id: @account.org_id)
       @policy.hosts << host
 
       existing_profile = @profile.clone_to(

--- a/test/models/rule_test.rb
+++ b/test/models/rule_test.rb
@@ -20,7 +20,7 @@ class RuleTest < ActiveSupport::TestCase
 
     @rule = @profile.rules.first
 
-    @host = FactoryBot.create(:host, account: account.account_number)
+    @host = FactoryBot.create(:host, org_id: account.org_id)
   end
 
   test 'creates rules from openscap_parser Rule object' do

--- a/test/policies/host_policy_test.rb
+++ b/test/policies/host_policy_test.rb
@@ -6,12 +6,11 @@ class HostPolicyTest < ActiveSupport::TestCase
   test 'only hosts matching the account are accessible' do
     user = FactoryBot.create(:user)
     h1 = Host.find(
-      FactoryBot.create(:host, account: user.account.account_number, org_id: user.account.org_id).id
+      FactoryBot.create(:host, org_id: user.account.org_id).id
     )
     a = FactoryBot.create(:account)
     h2 = Host.find(FactoryBot.create(
       :host,
-      account: a.account_number,
       org_id: a.org_id
     ).id)
 

--- a/test/policies/profile_policy_test.rb
+++ b/test/policies/profile_policy_test.rb
@@ -17,7 +17,7 @@ class ProfilePolicyTest < ActiveSupport::TestCase
     user.account = account
 
     profile2 = FactoryBot.create(:profile, account: account)
-    host = FactoryBot.create(:host, account: account.account_number)
+    host = FactoryBot.create(:host, org_id: account.org_id)
     profile2.policy.update!(hosts: [host])
 
     assert_includes Pundit.policy_scope(user, Profile), profile2

--- a/test/policies/rule_policy_test.rb
+++ b/test/policies/rule_policy_test.rb
@@ -34,7 +34,7 @@ class RulePolicyTest < ActiveSupport::TestCase
     assert_empty Pundit.policy_scope(@user, Rule)
 
     profile = FactoryBot.create(:profile, :with_rules, account: @user.account)
-    host = FactoryBot.create(:host, account: @user.account.account_number)
+    host = FactoryBot.create(:host, org_id: @user.account.org_id)
     FactoryBot.create(:test_result, host: host, profile: profile)
 
     assert_includes Pundit.policy_scope(@user, Rule), profile.rules.sample

--- a/test/policies/rule_result_policy_test.rb
+++ b/test/policies/rule_result_policy_test.rb
@@ -6,7 +6,7 @@ class RuleResultPolicyTest < ActiveSupport::TestCase
   test 'only rules within visible hosts are accessible' do
     user = FactoryBot.create(:user)
     host1 = Host.find(
-      FactoryBot.create(:host, account: user.account.account_number, org_id: user.account.org_id).id
+      FactoryBot.create(:host, org_id: user.account.org_id).id
     )
     assert_includes Pundit.policy_scope(user, Host), host1
 
@@ -27,7 +27,7 @@ class RuleResultPolicyTest < ActiveSupport::TestCase
     )
 
     account2 = FactoryBot.create(:account)
-    host2 = FactoryBot.create(:host, account: account2.account_number, org_id: account2.org_id)
+    host2 = FactoryBot.create(:host, org_id: account2.org_id)
     profile2 = FactoryBot.create(
       :profile,
       :with_rules,

--- a/test/policies/test_result_policy_test.rb
+++ b/test/policies/test_result_policy_test.rb
@@ -11,10 +11,10 @@ class TestResultPolicyTest < ActiveSupport::TestCase
     @profile2 = FactoryBot.create(:profile, :with_rules, account: account2)
 
     @host1 = Host.find(
-      FactoryBot.create(:host, account: @user.account.account_number, org_id: @user.account.org_id).id
+      FactoryBot.create(:host, org_id: @user.account.org_id).id
     )
     @host2 = Host.find(
-      FactoryBot.create(:host, account: account2.account_number, org_id: account2.org_id).id
+      FactoryBot.create(:host, org_id: account2.org_id).id
     )
 
     @tr1 = FactoryBot.create(

--- a/test/producers/report_upload_failed_test.rb
+++ b/test/producers/report_upload_failed_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class ReportUploadFailedTest < ActiveSupport::TestCase
   setup do
     @acc = FactoryBot.create(:account)
-    @host = FactoryBot.create(:host, account: @acc.account_number)
+    @host = FactoryBot.create(:host, org_id: @acc.org_id)
   end
 
   test 'delivers messages to the notifications topic' do

--- a/test/producers/system_non_compliant_test.rb
+++ b/test/producers/system_non_compliant_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class SystemNonCompliantTest < ActiveSupport::TestCase
   setup do
     @acc = FactoryBot.create(:account)
-    @host = FactoryBot.create(:host, account: @acc.account_number)
+    @host = FactoryBot.create(:host, org_id: @acc.org_id)
     @policy = FactoryBot.create(:policy, account: @acc)
   end
 

--- a/test/services/concerns/xccdf/profile_rule_groups_test.rb
+++ b/test/services/concerns/xccdf/profile_rule_groups_test.rb
@@ -10,7 +10,7 @@ module Xccdf
 
     setup do
       @account = FactoryBot.create(:account)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @benchmark = FactoryBot.create(:canonical_profile).benchmark
       parser = OpenscapParser::TestResultFile.new(
         file_fixture('xccdf_report.xml').read

--- a/test/services/concerns/xccdf/profile_rules_test.rb
+++ b/test/services/concerns/xccdf/profile_rules_test.rb
@@ -10,7 +10,7 @@ module Xccdf
 
     setup do
       @account = FactoryBot.create(:account)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @benchmark = FactoryBot.create(:canonical_profile).benchmark
       parser = OpenscapParser::TestResultFile.new(
         file_fixture('xccdf_report.xml').read

--- a/test/services/concerns/xccdf/profiles_test.rb
+++ b/test/services/concerns/xccdf/profiles_test.rb
@@ -18,7 +18,7 @@ module Xccdf
 
     setup do
       @account = FactoryBot.create(:account)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @benchmark = FactoryBot.create(:canonical_profile, :with_rules).benchmark
       parser = OpenscapParser::TestResultFile.new(
         file_fixture('xccdf_report.xml').read

--- a/test/services/concerns/xccdf/rule_group_relationships_test.rb
+++ b/test/services/concerns/xccdf/rule_group_relationships_test.rb
@@ -22,7 +22,7 @@ class RuleGroupRelationshipsTest < ActiveSupport::TestCase
   context 'without any required or conflicting rules or rule groups' do
     setup do
       @account = FactoryBot.create(:account)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @benchmark = FactoryBot.create(:canonical_profile).benchmark
       parser = OpenscapParser::TestResultFile.new(
         file_fixture('rhel-xccdf-report.xml').read
@@ -55,7 +55,7 @@ class RuleGroupRelationshipsTest < ActiveSupport::TestCase
   context 'with required and conflicting rules or rule groups' do
     setup do
       @account = FactoryBot.create(:account)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @benchmark = FactoryBot.create(:canonical_profile).benchmark
       parser = OpenscapParser::TestResultFile.new(
         file_fixture('xccdf_report.xml').read

--- a/test/services/concerns/xccdf/rule_group_rules_test.rb
+++ b/test/services/concerns/xccdf/rule_group_rules_test.rb
@@ -21,7 +21,7 @@ class RuleGroupRulesTest < ActiveSupport::TestCase
   context 'parent-child relationship between rule group and rule' do
     setup do
       @account = FactoryBot.create(:account)
-      @host = FactoryBot.create(:host, account: @account.account_number)
+      @host = FactoryBot.create(:host, org_id: @account.org_id)
       @benchmark = FactoryBot.create(:canonical_profile).benchmark
       parser = OpenscapParser::TestResultFile.new(
         file_fixture('xccdf_report.xml').read

--- a/test/services/concerns/xccdf/rule_groups_test.rb
+++ b/test/services/concerns/xccdf/rule_groups_test.rb
@@ -16,7 +16,7 @@ class RuleGroupsTest < ActiveSupport::TestCase
 
   setup do
     @account = FactoryBot.create(:account)
-    @host = FactoryBot.create(:host, account: @account.account_number)
+    @host = FactoryBot.create(:host, org_id: @account.org_id)
     @benchmark = FactoryBot.create(:canonical_profile).benchmark
     parser = OpenscapParser::TestResultFile.new(
       file_fixture('rhel-xccdf-report.xml').read

--- a/test/services/concerns/xccdf/test_result_test.rb
+++ b/test/services/concerns/xccdf/test_result_test.rb
@@ -15,7 +15,7 @@ class TestResultTest < ActiveSupport::TestCase
     @end_time = DateTime.now
     @mock = Mock.new
     @mock.host_profile = FactoryBot.create(:profile, account: @account)
-    @mock.host = FactoryBot.create(:host, account: @account.account_number)
+    @mock.host = FactoryBot.create(:host, org_id: @account.org_id)
     @mock.op_test_result = OpenStruct.new(score: 30,
                                           start_time: @end_time - 2.minutes,
                                           end_time: @end_time)

--- a/test/services/duplicate_rule_resolver_test.rb
+++ b/test/services/duplicate_rule_resolver_test.rb
@@ -58,10 +58,10 @@ class DuplicateRuleResolverTest < ActiveSupport::TestCase
 
   test 'resolves rule_results from a duplicate rule' do
     account = FactoryBot.create(:account)
-    host1 = FactoryBot.create(:host, account: account.account_number)
+    host1 = FactoryBot.create(:host, org_id: account.org_id)
     host2 = FactoryBot.create(
       :host,
-      account: FactoryBot.create(:account).account_number
+      org_id: FactoryBot.create(:account).org_id
     )
     profile = FactoryBot.create(
       :profile,

--- a/test/services/host_inventory_api_test.rb
+++ b/test/services/host_inventory_api_test.rb
@@ -8,13 +8,12 @@ class HostInventoryApiTest < ActiveSupport::TestCase
     account = FactoryBot.create(:account)
     @host = FactoryBot.create(
       :host,
-      account: account.account_number,
       org_id: account.org_id
     )
 
     @inventory_host = { 'id' => @host.id,
                         'display_name' => @host.name,
-                        'account' => @host.account_number }
+                        'org_id' => @host.org_id }
     @account = @host.account_object
     @b64_identity = '1234abcd'
     @api = HostInventoryApi.new(b64_identity: @b64_identity)

--- a/test/services/orphaned_profiles_cleaner_test.rb
+++ b/test/services/orphaned_profiles_cleaner_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class OrphanedProfilesCleanerTest < ActiveSupport::TestCase
   setup do
     account = FactoryBot.create(:account)
-    host = FactoryBot.create(:host, account: account.account_number)
+    host = FactoryBot.create(:host, org_id: account.org_id)
     @profile = FactoryBot.create(:profile, account: account)
     @tr = FactoryBot.create(:test_result, profile: @profile, host: host)
   end

--- a/test/services/reports_tar_reader_test.rb
+++ b/test/services/reports_tar_reader_test.rb
@@ -7,13 +7,13 @@ class ReportsTarReaderTest < ActiveSupport::TestCase
     assert_nothing_raised do
       file = File.new(file_fixture('insights-archive.tar.gz'))
       account = FactoryBot.create(:account)
-      host = FactoryBot.create(:host, account: account.account_number)
+      host = FactoryBot.create(:host, org_id: account.org_id)
       reports = ReportsTarReader.new(file).reports
       assert_equal 3, reports.length
       reports.each do |report|
         XccdfReportParser.new(
           report,
-          'account' => account.account_number,
+          'org_id' => account.org_id,
           'id' => host.id,
           'b64_identity' => account.b64_identity,
           'metadata' => {
@@ -28,13 +28,13 @@ class ReportsTarReaderTest < ActiveSupport::TestCase
     assert_nothing_raised do
       file = File.new(file_fixture('insights-archive-long.tar.gz'))
       account = FactoryBot.create(:account)
-      host = FactoryBot.create(:host, account: account.account_number)
+      host = FactoryBot.create(:host, org_id: account.org_id)
       reports = ReportsTarReader.new(file).reports
       assert_equal 1, reports.length
       reports.each do |report|
         XccdfReportParser.new(
           report,
-          'account' => account.account_number,
+          'org_id' => account.org_id,
           'id' => host.id,
           'b64_identity' => account.b64_identity,
           'metadata' => {

--- a/test/services/upstream_profile_remover_test.rb
+++ b/test/services/upstream_profile_remover_test.rb
@@ -15,7 +15,7 @@ class UpstreamProfileRemoverTest < ActiveSupport::TestCase
   end
 
   test 'removes upstream non-canonical profiles' do
-    host = FactoryBot.create(:host, account: @account.account_number)
+    host = FactoryBot.create(:host, org_id: @account.org_id)
     FactoryBot.create(:test_result, profile: @upstream, host: host)
     FactoryBot.create(:test_result, profile: @downstream, host: host)
 

--- a/test/services/upstream_rule_bindings_remover_test.rb
+++ b/test/services/upstream_rule_bindings_remover_test.rb
@@ -6,7 +6,7 @@ class UpstreamRuleBindingsRemoverTest < ActiveSupport::TestCase
   setup do
     PolicyHost.any_instance.stubs(:host_supported?).returns(true)
     account = FactoryBot.create(:account)
-    host = FactoryBot.create(:host, account: account.account_number)
+    host = FactoryBot.create(:host, org_id: account.org_id)
     @profile = FactoryBot.create(
       :profile,
       :with_rules,

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -23,13 +23,13 @@ class XccdfReportParserTest < ActiveSupport::TestCase
     @account = FactoryBot.create(:account)
     @host = FactoryBot.create(
       :host,
-      account: @account.account_number,
+      org_id: @account.org_id,
       display_name: 'MyStringone'
     )
 
     @report_parser = TestParser
                      .new(fake_report,
-                          'account' => @account.account_number,
+                          'org_id' => @account.org_id,
                           'b64_identity' => @account.b64_identity,
                           'id' => @host.id,
                           'metadata' => {
@@ -186,7 +186,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       assert_raises(XccdfReportParser::MissingIdError) do
         TestParser.new(
           'fakereport',
-          'account' => @account.account_number,
+          'org_id' => @account.org_id,
           'b64_identity' => @account.b64_identity,
           'metadata' => { 'display_name': '123' }
         )
@@ -197,7 +197,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       assert_raises(XccdfReportParser::MissingIdError) do
         TestParser.new(
           'fakereport',
-          'account' => @account.account_number,
+          'org_id' => @account.org_id,
           'id' => @host.id,
           'metadata' => { 'display_name': '123' }
         )
@@ -324,7 +324,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
       assert_raises(XccdfReportParser::WrongFormatError) do
         TestParser.new(
           fake_report,
-          'account' => @account.account_number,
+          'org_id' => @account.org_id,
           'id' => @host.id,
           'b64_identity' => @account.b64_identity,
           'metadata' => {

--- a/test/tasks/cleanup_db_test.rb
+++ b/test/tasks/cleanup_db_test.rb
@@ -10,9 +10,9 @@ class CleanupDbTest < ActiveSupport::TestCase
 
   test 'cleanup_db removes dangling records' do
     account = FactoryBot.create(:account)
-    FactoryBot.create(:host, account: account.account_number, org_id: account.org_id)
+    FactoryBot.create(:host, org_id: account.org_id)
     policy = FactoryBot.create(:policy, account: account)
-    account.dup.update!(account_number: '8675309', org_id: '8675309')
+    account.dup.update!(org_id: '8675309')
 
     TestResult.new(host_id: UUID.generate).save(validate: false)
     RuleResult.new(host_id: UUID.generate).save(validate: false)
@@ -32,10 +32,10 @@ class CleanupDbTest < ActiveSupport::TestCase
 
   test 'cleanup_db does not remove accounts on a profile, policy, or host' do
     aorig = FactoryBot.create(:account)
-    FactoryBot.create(:host, account: aorig.account_number)
-    (account = aorig.dup).update!(account_number: '9797979', org_id: '9797979')
+    FactoryBot.create(:host, org_id: aorig.org_id)
+    (account = aorig.dup).update!(org_id: '9797979')
     FactoryBot.create(:profile, account: account)
-    (account = aorig.dup).update!(account_number: '3213213', org_id: '3213213')
+    (account = aorig.dup).update!(org_id: '3213213')
     FactoryBot.create(:policy, account: account)
     assert_difference('Account.count' => 0) do
       capture_io do


### PR DESCRIPTION
The only place I'm keeping account numbers is in our DB + kafka-messages that we emit further for backwards-compatibility.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
