### PR TITLE
fix(ExcNotify): RHICOMPL-3227 set the data segment as first hook

### DIFF
--- a/app/controllers/concerns/exception_notifier_custom_data.rb
+++ b/app/controllers/concerns/exception_notifier_custom_data.rb
@@ -5,15 +5,18 @@ module ExceptionNotifierCustomData
   extend ActiveSupport::Concern
 
   included do
-    before_action :prepare_exception_notifier
+    prepend_before_action :prepare_exception_notifier
+    before_action :extend_exception_notifier
   end
 
   private
 
   def prepare_exception_notifier
-    request.env[
-      'exception_notifier.exception_data'
-    ] = OpenshiftEnvironment.summary.merge(
+    request.env['exception_notifier.exception_data'] = OpenshiftEnvironment.summary
+  end
+
+  def extend_exception_notifier
+    request.env['exception_notifier.exception_data'].merge!(
       current_user: current_user&.account&.org_id
     )
   end


### PR DESCRIPTION
Sometimes if an error happens during the controller hooks (e.g. RBAC checks) the data section of the exception notification is not set properly. In some of these cases the current user is not even set up, therefore, I split it up into two hooks. One that runs as the very first in each controller, and another one that sets the current user after the user is authorized via RBAC.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
