### PR TITLE
feat(Profile): RHICOMPL-3278 get rules and groups of profile

### DIFF
--- a/app/models/concerns/profile_fields.rb
+++ b/app/models/concerns/profile_fields.rb
@@ -38,6 +38,20 @@ module ProfileFields
       parent_profile_id.blank?
     end
 
+    def rules_and_rule_groups
+      conflicts = relationships_for('conflicts')
+      requires = relationships_for('requires')
+      arranged_rule_groups = rule_groups.includes(:rules).arrange_serializable do |parent, children|
+        { 'rule_group' => parent, 'group_children' => children,
+          'rule_children' => parent.rules_with_relationships(requires, conflicts),
+          'requires' => requires[parent], 'conflicts' => conflicts[parent] }
+      end
+
+      arranged_rule_groups.concat(rules.without_rule_group_parent.map do |pr|
+        { 'rule' => pr, 'requires' => requires[pr], 'conflicts' => conflicts[pr] }
+      end)
+    end
+
     private
 
     def bm_versions
@@ -46,6 +60,15 @@ module ProfileFields
         ref_id: ref_id,
         upstream: false
       ).joins(:benchmark).pluck('benchmarks.version')
+    end
+
+    def relationships_for(relationship)
+      RuleGroupRelationship.with_relationships(rules, relationship).or(
+        RuleGroupRelationship.with_relationships(rule_groups, relationship)
+      ).each_with_object({}) do |rgr, relationships|
+        relationships[rgr.left] ||= []
+        relationships[rgr.left] << rgr.right
+      end
     end
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -73,6 +73,10 @@ class Rule < ApplicationRecord
     joins(:profiles).where(profiles: { id: Profile.canonical })
   }
 
+  scope :without_rule_group_parent, lambda {
+    where.missing(:rule_groups)
+  }
+
   scope :joins_identifier, lambda {
     left_outer_joins(:rule_identifier).select('rules.*', RuleIdentifier::AS_JSON.as('identifier'))
   }

--- a/app/models/rule_group.rb
+++ b/app/models/rule_group.rb
@@ -11,6 +11,8 @@ class RuleGroup < ApplicationRecord
                                            inverse_of: :left, class_name: 'RuleGroupRelationship'
   has_many :right_rule_group_relationships, dependent: :delete_all, foreign_key: :right_id,
                                             inverse_of: :right, class_name: 'RuleGroupRelationship'
+  has_many :rule_group_rules, dependent: :delete_all
+  has_many :rules, through: :rule_group_rules
 
   belongs_to :benchmark, class_name: 'Xccdf::Benchmark'
 
@@ -29,5 +31,11 @@ class RuleGroup < ApplicationRecord
                                  parent_id: parent_id)
 
     rule_group
+  end
+
+  def rules_with_relationships(requires, conflicts)
+    rules.map do |r|
+      { 'rule' => r, 'requires' => requires[r], 'conflicts' => conflicts[r] }
+    end
   end
 end

--- a/app/models/rule_group_relationship.rb
+++ b/app/models/rule_group_relationship.rb
@@ -9,4 +9,8 @@ class RuleGroupRelationship < ApplicationRecord
 
   # Need to use left_id because polymorphic assocations don't support computing the class
   validates :left_id, presence: true, uniqueness: { scope: %i[relationship right_id right_type left_type] }
+
+  scope :with_relationships, lambda { |rules_or_groups, relationship|
+    where(relationship: relationship).includes(:left, :right).where(left: rules_or_groups)
+  }
 end

--- a/test/factories/profile.rb
+++ b/test/factories/profile.rb
@@ -47,5 +47,20 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_rule_groups do
+      transient do
+        rule_group_count { 5 }
+      end
+
+      after(:create) do |profile, evaluator|
+        create_list(
+          :rule_group,
+          evaluator.rule_group_count,
+          profiles: [profile, profile&.parent_profile].compact,
+          benchmark: profile.benchmark
+        )
+      end
+    end
   end
 end

--- a/test/models/rule_group_test.rb
+++ b/test/models/rule_group_test.rb
@@ -38,4 +38,17 @@ class RuleGroupTest < ActiveSupport::TestCase
     assert_not_nil @rule_group.ancestry
     assert_equal @rule_group.parent_id, @parent_rule_group.id
   end
+
+  test 'rules_with_relationships' do
+    rule = FactoryBot.create(:rule)
+    required_rule_group = FactoryBot.create(:rule_group)
+    @rule_group.rules << rule
+
+    requires = {}
+    requires[rule] = required_rule_group
+
+    expected = [{ 'rule' => rule, 'requires' => required_rule_group, 'conflicts' => nil }]
+
+    assert_equal @rule_group.rules_with_relationships(requires, {}), expected
+  end
 end


### PR DESCRIPTION
Here's an example of what the rules_and_rule_groups method returns: 
```
[
  {
    "rule_group"=>#<RuleGroup id: "29229bf4-227d-4f22-8d34-7dcd18b5dbac",ref_id: "foo_group_8b413bb7-96c3-4e74-9ea8-4b735eb74768", title: "Omnis ut ducimus vitae.", description: "Quos facilis quas. Est sequi rem. Sit veritatis id...", rationale: "Voluptas pariatur voluptate. Facilis iste rerum. M...", ancestry: nil, benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", rule_id: nil>,
    "group_children"=>[
      {
        "rule_group"=>#<RuleGroup id: "33099b35-0c74-4a1b-96bc-abbbe6e630ed", ref_id: "foo_group_47fbbe48-12ca-4da6-bbda-a7331c58b009", title: "A voluptatem eaque soluta.", description: "In optio non. Ut iusto facilis. Itaque ut soluta.", rationale: "Magnam doloribus distinctio. Et et aut. Minus quae...", ancestry: "29229bf4-227d-4f22-8d34-7dcd18b5dbac", benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", rule_id: nil>,
        "group_children"=>[
          {
            "rule_group"=>#<RuleGroup id: "e429ad05-cb4a-4669-b3c9-d38d50832389", ref_id: "foo_group_d1c8b323-e41c-410d-bed0-70004bc7a572", title: "Cumque ut adipisci omnis.", description: "Laudantium repudiandae est. Dolorum quod non. Aut ...", rationale: "Ducimus magnam praesentium. Illo qui est. Officiis...", ancestry: "29229bf4-227d-4f22-8d34-7dcd18b5dbac/33099b35-0c74...", benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", rule_id: nil>,
            "group_children"=>[],
            "rule_children"=>[
              {
                "rule"=>#<Rule id: "a73bf464-4629-45cc-a278-eba536eabf78", ref_id: "foo_rule_165804e2-c021-4d4e-be5f-5000ea4977eb", supported: nil, title: "Molestiae alias repellat ut.", severity: "high", description: "Ut aliquid quas. Nihil quibusdam dicta. Animi corp...", rationale: "Soluta sint ut. Perspiciatis dignissimos ad. Corpo...", created_at: "2022-10-19 22:36:20.597834000 +0000", updated_at: "2022-10-19 22:36:20.597834000 +0000", slug: "foo_rule_165804e2-c021-4d4e-be5f-5000ea4977eb", remediation_available: false, benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", upstream: true, precedence: nil>,
               "requires"=>[#<RuleGroup id: "935774fa-91e8-4af5-937a-8dcb74e4af30", ref_id: "foo_group_293beea2-49f8-4f45-88d6-5afeba6153b2", title: "Cupiditate magni debitis consequatur.", description: "Itaque voluptatem accusantium. Eaque blanditiis si...", rationale: "Possimus qui atque. Aliquid consequuntur voluptati...", ancestry: nil, benchmark_id: "c628131b-6d04-45ea-9677-f6f64f18c9da", rule_id: nil>, #<Rule id: "36d9d13d-db44-4179-9264-8b0f20b1b49e", ref_id: "foo_rule_5cbe4999-665c-4306-9d1c-1799bb3b5f04", supported: nil, title: "Quibusdam iste ut sit.", severity: "medium", description: "Asperiores rerum autem. Voluptates quibusdam est. ...", rationale: "Et id et. Et quibusdam vel. Sunt minus esse.", created_at: "2022-10-28 14:35:36.226845000 +0000", updated_at: "2022-10-28 14:35:36.226845000 +0000", slug: "foo_rule_5cbe4999-665c-4306-9d1c-1799bb3b5f04", remediation_available: false, benchmark_id: "f0cf146e-1686-4dd5-aff0-02d125ac92e0", upstream: true, precedence: nil>],
               "conflicts"=>nil
              },
            "requires"=>nil,
            "conflicts"=>nil
            ]
          }
        ],
        "rule_children"=>[
          {
            "rule"=>#<Rule id: "457edaa2-b560-410b-b939-d7ceed3b8249", ref_id: "foo_rule_fb464fc2-2e12-4218-b1a0-86da09d0fd0a", supported: nil, title: "Et ut asperiores non.", severity: "medium", description: "Esse saepe in. Provident voluptatum dolor. Sed ten...", rationale: "Aliquid soluta libero. Non ipsa deserunt. Eveniet ...", created_at: "2022-10-19 22:36:20.718936000 +0000", updated_at: "2022-10-19 22:36:20.718936000 +0000", slug: "foo_rule_fb464fc2-2e12-4218-b1a0-86da09d0fd0a", remediation_available: false, benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", upstream: true, precedence: nil>
          },
        "requires"=>[#<RuleGroup id: "935774fa-91e8-4af5-937a-8dcb74e4af30", ref_id: "foo_group_293beea2-49f8-4f45-88d6-5afeba6153b2", title: "Cupiditate magni debitis consequatur.", description: "Itaque voluptatem accusantium. Eaque blanditiis si...", rationale: "Possimus qui atque. Aliquid consequuntur voluptati...", ancestry: nil, benchmark_id: "c628131b-6d04-45ea-9677-f6f64f18c9da", rule_id: nil>],
        "conflicts"=>[#<Rule id: "36d9d13d-db44-4179-9264-8b0f20b1b49e", ref_id: "foo_rule_5cbe4999-665c-4306-9d1c-1799bb3b5f04", supported: nil, title: "Quibusdam iste ut sit.", severity: "medium", description: "Asperiores rerum autem. Voluptates quibusdam est. ...", rationale: "Et id et. Et quibusdam vel. Sunt minus esse.", created_at: "2022-10-28 14:35:36.226845000 +0000", updated_at: "2022-10-28 14:35:36.226845000 +0000", slug: "foo_rule_5cbe4999-665c-4306-9d1c-1799bb3b5f04", remediation_available: false, benchmark_id: "f0cf146e-1686-4dd5-aff0-02d125ac92e0", upstream: true, precedence: nil>]
        ]
      }
    ],
    "rule_children"=>[
      {
        "rule"=>#<Rule id: "326d6a92-9f0f-484e-b486-51d181563649", ref_id: "foo_rule_58b4aa08-2881-46fe-b8ec-cd40ab6e2df0", supported: nil, title: "Et rerum dolores autem.", severity: "low", description: "Aut minima optio. Nesciunt ut illum. Amet non quo.", rationale: "Excepturi nesciunt cum. Odit amet tenetur. Quo qua...", created_at: "2022-10-19 22:36:20.686546000 +0000", updated_at: "2022-10-19 22:36:20.686546000 +0000", slug: "foo_rule_58b4aa08-2881-46fe-b8ec-cd40ab6e2df0", remediation_available: false, benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", upstream: true, precedence: nil>,
     "requires"=>nil,
     "conflicts"=>nil
      },
     "requires"=>nil,
     "conflicts"=>nil
    ]
  },
  {
    "rule_group"=>#<RuleGroup id: "97a47bb3-2152-4ac4-9a0f-492f3001e502", ref_id: "foo_group_587bbb54-ecc4-44e2-b250-0f0b93ba1a0d", title: "In quisquam quae esse.", description: "Perferendis error perspiciatis. Laborum consequunt...", rationale: "Voluptatem incidunt accusantium. In repellendus qu...", ancestry: nil, benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", rule_id: nil>,
    "group_children"=>[],
    "rule_children"=>[
      {
        "rule"=>#<Rule id: "5c464aa6-8487-4c32-b933-5c99e8bd84c2", ref_id: "foo_rule_89316d83-a630-4b98-a328-7e0a9f90583e", supported: nil, title: "Recusandae omnis et modi.", severity: "high", description: "Reiciendis ut ducimus. Est iure vel. Sit expedita ...", rationale: "Odit quaerat commodi. Provident suscipit et. Enim ...", created_at: "2022-10-19 22:36:20.625251000 +0000", updated_at: "2022-10-19 22:36:20.625251000 +0000", slug: "foo_rule_89316d83-a630-4b98-a328-7e0a9f90583e", remediation_available: false, benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", upstream: true, precedence: nil>,
      "requires"=>nil,
      "conflicts"=>nil
      },
    "requires"=>nil,
    "conflicts"=>nil
    ]
  },
  {
    "rule"=>#<Rule id: "691c65f3-0ca4-44a2-a102-e6a9b7ec6f59", ref_id: "foo_rule_e0e5b732-dcbc-4901-a93b-5eced9804171", supported: nil, title: "Voluptas molestiae aut tempora.", severity: "low", description: "Temporibus et eum. Nihil quasi sint. Sunt aliquid ...", rationale: "Debitis est quia. Sed saepe quis. Perferendis repe...", created_at: "2022-10-19 22:36:20.653770000 +0000", updated_at: "2022-10-19 22:36:20.653770000 +0000", slug: "foo_rule_e0e5b732-dcbc-4901-a93b-5eced9804171", remediation_available: false, benchmark_id: "ffd5e1a1-09a8-4f83-9983-b3bf90bf726f", upstream: true, precedence: nil>,
    "requires"=>nil,
    "conflicts"=>[#<Rule id: "36d9d13d-db44-4179-9264-8b0f20b1b49e", ref_id: "foo_rule_5cbe4999-665c-4306-9d1c-1799bb3b5f04", supported: nil, title: "Quibusdam iste ut sit.", severity: "medium", description: "Asperiores rerum autem. Voluptates quibusdam est. ...", rationale: "Et id et. Et quibusdam vel. Sunt minus esse.", created_at: "2022-10-28 14:35:36.226845000 +0000", updated_at: "2022-10-28 14:35:36.226845000 +0000", slug: "foo_rule_5cbe4999-665c-4306-9d1c-1799bb3b5f04", remediation_available: false, benchmark_id: "f0cf146e-1686-4dd5-aff0-02d125ac92e0", upstream: true, precedence: nil>]
  }
]
```


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
