### PR TITLE
revert(GraphQL): RHICOMPL-3304 always list all tags from systemConnection

### DIFF
--- a/app/graphql/resolvers/concerns/collection.rb
+++ b/app/graphql/resolvers/concerns/collection.rb
@@ -36,10 +36,6 @@ module Resolvers
 
         filters << sort_filter(sort_by: sort_by) if sort_by.present?
 
-        # SystemConnection needs the scope without the tagging and pagination filters
-        # in order to return correct results.
-        filters << store_wide_scope
-
         filters << tags_filter(tags: tags) if permit_tags?(tags)
 
         if offset.present? || limit.present?
@@ -84,10 +80,6 @@ module Resolvers
           tags = parse_tags(tags)
           scope.where('tags @> ?', tags.to_json)
         end
-      end
-
-      def store_wide_scope
-        ->(scope) { context[:wide_scope] = scope }
       end
 
       def model_class

--- a/app/graphql/types/system_connection.rb
+++ b/app/graphql/types/system_connection.rb
@@ -11,7 +11,7 @@ module Types
     end
 
     def tags
-      context[:wide_scope].available_tags
+      object.items.limit(nil).available_tags
     end
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -43,17 +43,17 @@ class Host < ApplicationRecord
     )
   }
 
-  scope :available_tags, lambda {
-    where.not(Arel.sql("tags = '[]'::jsonb"))
-         .where.not(Arel.sql("tags = '{}'::jsonb")).distinct.pluck(TAGS)
-  }
-
   def self.os_minor_versions(hosts)
     distinct.where(id: hosts).pluck(OS_MINOR_VERSION)
   end
 
   def self.available_os_versions
     distinct.pluck(OS_VERSION)
+  end
+
+  def self.available_tags
+    where.not(Arel.sql("tags = '[]'::jsonb"))
+         .where.not(Arel.sql("tags = '{}'::jsonb")).distinct.pluck(TAGS)
   end
 
   def readonly?

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -639,38 +639,6 @@ class SystemQueryTest < ActiveSupport::TestCase
     assert_equal nodes.first['node']['id'], @host1.id
   end
 
-  should 'filtering by tags should not limit the available tags' do
-    query = <<-GRAPHQL
-      query getSystems($tags: [String!]) {
-        systems(tags: $tags) {
-          tags
-        }
-      }
-    GRAPHQL
-
-    WHost.find(@host1.id).update(
-      tags: [{ namespace: 'foo', key: 'bar', value: 'baz' }]
-    )
-
-    setup_two_hosts
-
-    WHost.find(@host2.id).update(
-      tags: [{ namespace: 'bar', key: 'baz', value: 'foo' }],
-      org_id: @host1.org_id
-    )
-
-    result = Schema.execute(
-      query,
-      variables: {
-        tags: ['foo/bar=baz']
-      },
-      context: { current_user: @user }
-    )
-
-    nodes = result['data']['systems']['tags']
-    assert_equal nodes.count, 2
-  end
-
   test 'query children profile only returns profiles owned by host' do
     query = <<-GRAPHQL
     query getSystems {


### PR DESCRIPTION
This is a revert of https://github.com/RedHatInsights/compliance-backend/pull/1438

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
