### PR TITLE
fix(search): RHICOMPL-3246 set implicit searchable field on RuleResult

### DIFF
--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -5,6 +5,7 @@
 # reports of compliance at any point in time
 class RuleResult < ApplicationRecord
   scoped_search on: %i[id rule_id host_id result], only_explicit: true
+  scoped_search on: :result
   belongs_to :host, optional: true
   belongs_to :rule
   belongs_to :test_result


### PR DESCRIPTION
Scoped search doesn't like if there's no implicit search field on a model.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
