### PR TITLE
fix(import): RHICOMPL-3331 import selected groups correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'nokogiri', force_ruby_platform: true
 gem 'manageiq-loggers', '~> 0.6.0'
 
 # Parsing OpenSCAP reports library
-gem 'openscap_parser', '~> 1.2.0'
+gem 'openscap_parser', '~> 1.3.0'
 
 # RBAC service API
 gem 'insights-rbac-api-client', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.10.6)
-    openscap_parser (1.2.0)
+    openscap_parser (1.3.0)
       nokogiri (~> 1.6)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -468,7 +468,7 @@ DEPENDENCIES
   mocha
   nokogiri
   oj
-  openscap_parser (~> 1.2.0)
+  openscap_parser (~> 1.3.0)
   pg
   pry-byebug
   pry-rails
@@ -513,4 +513,4 @@ DEPENDENCIES
   yabeda-sidekiq
 
 BUNDLED WITH
-   2.3.20
+   2.3.22

--- a/app/services/concerns/xccdf/profile_rule_groups.rb
+++ b/app/services/concerns/xccdf/profile_rule_groups.rb
@@ -26,9 +26,10 @@ module Xccdf
       def profile_rule_groups
         @profile_rule_groups ||= @op_profiles.flat_map do |op_profile|
           profile_id = profile_id_for(ref_id: op_profile.id)
-          rule_group_ids_for(ref_ids: op_profile.selected_group_ids).map do |rule_group_id|
+          unselected_group_ids = rule_group_ids_for(ref_ids: op_profile.unselected_group_ids)
+          @rule_groups.reject { |rg| unselected_group_ids.include?(rg.id) }.map do |rg|
             ::ProfileRuleGroup.new(
-              profile_id: profile_id, rule_group_id: rule_group_id
+              profile_id: profile_id, rule_group_id: rg.id
             )
           end
         end

--- a/db/migrate/20221014125732_clear_revisions_oct_fourteenth.rb
+++ b/db/migrate/20221014125732_clear_revisions_oct_fourteenth.rb
@@ -1,0 +1,9 @@
+class ClearRevisionsOctFourteenth < ActiveRecord::Migration[7.0]
+  def up
+    Revision.find_by(name: 'datastreams')&.delete
+  end
+
+  def down
+    # nop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_15_070144) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_14_125732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"


### PR DESCRIPTION
This PR relies on this [openscap_parser PR](https://github.com/OpenSCAP/openscap_parser/pull/39) being merged and released but I tested locally with the gem updates and the import worked correctly and the tests passed. 

To get the tests to pass locally: 
Checkout this branch locally and then update the openscap_parser line in the Gemfile to:
`gem 'openscap_parser', git: 'https://github.com/OpenSCAP/openscap_parser.git', branch: 'master'`

(Tests will continue to fail with `NoMethodError: undefined method `unselected_group_ids' `until openscap_parser changes are released)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
