### PR TITLE
perf(RuleResults): RHICOMPL-3332 order rule results by host_id

### DIFF
--- a/app/models/concerns/sortable.rb
+++ b/app/models/concerns/sortable.rb
@@ -9,13 +9,21 @@ module Sortable
   class_methods do
     def build_order_by(*fields)
       order = build_fields_order_by(fields)
-      # Add id for deterministic pagination
+      # Additional sorting if @default_sort is set
+      order[:h][@default_sort] = :asc if @default_sort
+      # Add ID for deterministic pagination
       order[:h][:id] = :asc unless order.include?(:id)
 
       order.values
     end
 
     private
+
+    # Declares the field to be used for the basis of deterministic sorting
+    # when retrieving records via the REST/GQL APIs.
+    def default_sort(column)
+      @default_sort = column
+    end
 
     def sortable_by(column, statement = column, scope: nil)
       @sortable_by ||= {}

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -20,6 +20,7 @@ class RuleResult < ApplicationRecord
                    uniqueness: { scope: %i[test_result_id host_id] }
 
   sortable_by :result
+  default_sort :host_id
 
   POSSIBLE_RESULTS = %w[pass fail error unknown notapplicable notchecked
                         notselected informational fixed].freeze


### PR DESCRIPTION
When requesting a set of rule results contextualized under a specific user, the hosts table is being used in a subquery to filter them for a given user. This collides with the default sort of rule results by `id` and produces SQL queries that run for 6-10 seconds. After a few experiments we determined that sorting by `host_id` improves the performance the most. Therefore, I implemented a declarative way to prepend a default sort column for rule results before sorting by `id`. 

This is unfortunately something we cannot reproduce, but the query plans coming back from Gabi show that the changes make production 10x faster for this query

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
