### PR TITLE
fix(Dockerfile): RHICOMPL-3335 lock the version of bundler to 2.3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ USER 0
 COPY ./Gemfile.lock ./Gemfile ./.gemrc.prod /opt/app-root/src/
 
 RUN microdnf install --nodocs -y $devDeps       && \
-    gem update bundler                          && \
+    gem install bundler -v 2.3.22               && \
     mv ./.gemrc.prod /etc/gemrc                 && \
     bundle config set --local without $without  && \
     bundle config set --local deployment 'true' && \
@@ -37,7 +37,7 @@ USER 0
 
 RUN rpm -e --nodeps tzdata             && \
     microdnf install --nodocs -y $deps && \
-    gem update bundler                 && \
+    gem install bundler -v 2.3.22      && \
     microdnf clean all -y              && \
     chown 1001:root ./                 && \
     install -v -d -m 1777 -o 1001 ./tmp ./log


### PR DESCRIPTION
Temporary workaround for a bug that was introduced in 2.3.23 to unblock future work on compliance.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
