### PR TITLE
refactor(RuleGroups): RHICOMPL-3402 make the mixin more readable

### DIFF
--- a/app/models/concerns/rules_and_rule_groups.rb
+++ b/app/models/concerns/rules_and_rule_groups.rb
@@ -5,26 +5,40 @@ module RulesAndRuleGroups
   extend ActiveSupport::Concern
 
   included do
+    # rubocop:disable Metrics/MethodLength
     def rules_and_rule_groups
       conflicts = relationships_for('conflicts')
       requires = relationships_for('requires')
       arranged_rule_groups = rule_groups.includes(:rules).arrange_serializable do |parent, children|
-        { 'rule_group' => parent, 'group_children' => children,
-          'rule_children' => parent.rules_with_relationships(requires, conflicts),
-          'requires' => requires[parent], 'conflicts' => conflicts[parent] }
+        {
+          rule_group: parent,
+          group_children: children,
+          rule_children: parent.rules_with_relationships(requires, conflicts),
+          requires: requires[parent],
+          conflicts: conflicts[parent]
+        }
       end
 
-      arranged_rule_groups.concat(rules.without_rule_group_parent.map do |pr|
-        { 'rule' => pr, 'requires' => requires[pr], 'conflicts' => conflicts[pr] }
-      end)
+      arranged_rule_groups + rules.without_rule_group_parent.map do |pr|
+        {
+          rule: pr,
+          requires: requires[pr],
+          conflicts: conflicts[pr]
+        }
+      end
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 
-    def relationships_for(relationship)
+    def with_relationships(relationship)
       RuleGroupRelationship.with_relationships(rules, relationship).or(
         RuleGroupRelationship.with_relationships(rule_groups, relationship)
-      ).each_with_object({}) do |rgr, relationships|
+      )
+    end
+
+    def relationships_for(relationship)
+      with_relationships(relationship).each_with_object({}) do |rgr, relationships|
         relationships[rgr.left] ||= []
         relationships[rgr.left] << rgr.right
       end

--- a/app/models/rule_group.rb
+++ b/app/models/rule_group.rb
@@ -35,7 +35,11 @@ class RuleGroup < ApplicationRecord
 
   def rules_with_relationships(requires, conflicts)
     rules.map do |r|
-      { 'rule' => r, 'requires' => requires[r], 'conflicts' => conflicts[r] }
+      {
+        rule: r,
+        requires: requires[r],
+        conflicts: conflicts[r]
+      }
     end
   end
 end

--- a/test/models/benchmark_test.rb
+++ b/test/models/benchmark_test.rb
@@ -530,79 +530,79 @@ module Xccdf
         rules_and_rule_groups_json = @bm1.rules_and_rule_groups
 
         expected_response1 = {
-          'rule_group' => @rule_group_1,
-          'group_children' => [
+          rule_group: @rule_group_1,
+          group_children: [
             {
-              'rule_group' => @rule_group_2,
-              'group_children' => [
+              rule_group: @rule_group_2,
+              group_children: [
                 {
-                  'rule_group' => @rule_group_4,
-                  'group_children' => [],
-                  'rule_children' => [
+                  rule_group: @rule_group_4,
+                  group_children: [],
+                  rule_children: [
                     {
-                      'rule' => @rule5,
-                      'requires' => [@rule_group_6],
-                      'conflicts' => [@rule6]
+                      rule: @rule5,
+                      requires: [@rule_group_6],
+                      conflicts: [@rule6]
                     }
                   ],
-                  'requires' => nil,
-                  'conflicts' => [@rule_group_6]
+                  requires: nil,
+                  conflicts: [@rule_group_6]
                 }
               ],
-              'rule_children' => [
+              rule_children: [
                 {
-                  'rule' => @rule2,
-                  'requires' => nil,
-                  'conflicts' => nil
+                  rule: @rule2,
+                  requires: nil,
+                  conflicts: nil
                 }
               ],
-              'requires' => nil,
-              'conflicts' => nil
+              requires: nil,
+              conflicts: nil
             }
           ],
-          'rule_children' => [
+          rule_children: [
             {
-              'rule' => @rule1,
-              'requires' => [@rule6],
-              'conflicts' => [@rule_group_5]
+              rule: @rule1,
+              requires: [@rule6],
+              conflicts: [@rule_group_5]
             }
           ],
-          'requires' => nil,
-          'conflicts' => nil
+          requires: nil,
+          conflicts: nil
         }
 
         expected_response2 = {
-          'rule' => @rule4,
-          'requires' => [@rule6],
-          'conflicts' => nil
+          rule: @rule4,
+          requires: [@rule6],
+          conflicts: nil
         }
 
         expected_response3 = {
-          'rule_group' => @rule_group_3,
-          'group_children' => [],
-          'rule_children' => [
+          rule_group: @rule_group_3,
+          group_children: [],
+          rule_children: [
             {
-              'rule' => @rule3,
-              'requires' => nil,
-              'conflicts' => nil
+              rule: @rule3,
+              requires: nil,
+              conflicts: nil
             }
           ],
-          'requires' => nil,
-          'conflicts' => [@rule_group_6, @rule6]
+          requires: nil,
+          conflicts: [@rule_group_6, @rule6]
         }
 
         expected_response4 = {
-          'rule_group' => @rule_group_3,
-          'group_children' => [],
-          'rule_children' => [
+          rule_group: @rule_group_3,
+          group_children: [],
+          rule_children: [
             {
-              'rule' => @rule3,
-              'requires' => nil,
-              'conflicts' => nil
+              rule: @rule3,
+              requires: nil,
+              conflicts: nil
             }
           ],
-          'requires' => nil,
-          'conflicts' => [@rule6, @rule_group_6]
+          requires: nil,
+          conflicts: [@rule6, @rule_group_6]
         }
 
         assert_includes rules_and_rule_groups_json, expected_response1

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -929,79 +929,79 @@ class ProfileTest < ActiveSupport::TestCase
       rules_and_rule_groups_json = @parent1.rules_and_rule_groups
 
       expected_response1 = {
-        'rule_group' => @rule_group_1,
-        'group_children' => [
+        rule_group: @rule_group_1,
+        group_children: [
           {
-            'rule_group' => @rule_group_2,
-            'group_children' => [
+            rule_group: @rule_group_2,
+            group_children: [
               {
-                'rule_group' => @rule_group_4,
-                'group_children' => [],
-                'rule_children' => [
+                rule_group: @rule_group_4,
+                group_children: [],
+                rule_children: [
                   {
-                    'rule' => @rule5,
-                    'requires' => [@rule_group_6],
-                    'conflicts' => [@rule6]
+                    rule: @rule5,
+                    requires: [@rule_group_6],
+                    conflicts: [@rule6]
                   }
                 ],
-                'requires' => nil,
-                'conflicts' => [@rule_group_6]
+                requires: nil,
+                conflicts: [@rule_group_6]
               }
             ],
-            'rule_children' => [
+            rule_children: [
               {
-                'rule' => @rule2,
-                'requires' => nil,
-                'conflicts' => nil
+                rule: @rule2,
+                requires: nil,
+                conflicts: nil
               }
             ],
-            'requires' => nil,
-            'conflicts' => nil
+            requires: nil,
+            conflicts: nil
           }
         ],
-        'rule_children' => [
+        rule_children: [
           {
-            'rule' => @rule1,
-            'requires' => [@rule6],
-            'conflicts' => [@rule_group_5]
+            rule: @rule1,
+            requires: [@rule6],
+            conflicts: [@rule_group_5]
           }
         ],
-        'requires' => nil,
-        'conflicts' => nil
+        requires: nil,
+        conflicts: nil
       }
 
       expected_response2 = {
-        'rule' => @rule4,
-        'requires' => [@rule6],
-        'conflicts' => nil
+        rule: @rule4,
+        requires: [@rule6],
+        conflicts: nil
       }
 
       expected_response3 = {
-        'rule_group' => @rule_group_3,
-        'group_children' => [],
-        'rule_children' => [
+        rule_group: @rule_group_3,
+        group_children: [],
+        rule_children: [
           {
-            'rule' => @rule3,
-            'requires' => nil,
-            'conflicts' => nil
+            rule: @rule3,
+            requires: nil,
+            conflicts: nil
           }
         ],
-        'requires' => nil,
-        'conflicts' => [@rule_group_6, @rule6]
+        requires: nil,
+        conflicts: [@rule_group_6, @rule6]
       }
 
       expected_response4 = {
-        'rule_group' => @rule_group_3,
-        'group_children' => [],
-        'rule_children' => [
+        rule_group: @rule_group_3,
+        group_children: [],
+        rule_children: [
           {
-            'rule' => @rule3,
-            'requires' => nil,
-            'conflicts' => nil
+            rule: @rule3,
+            requires: nil,
+            conflicts: nil
           }
         ],
-        'requires' => nil,
-        'conflicts' => [@rule6, @rule_group_6]
+        requires: nil,
+        conflicts: [@rule6, @rule_group_6]
       }
 
       assert_includes rules_and_rule_groups_json, expected_response1

--- a/test/models/rule_group_test.rb
+++ b/test/models/rule_group_test.rb
@@ -47,7 +47,7 @@ class RuleGroupTest < ActiveSupport::TestCase
     requires = {}
     requires[rule] = required_rule_group
 
-    expected = [{ 'rule' => rule, 'requires' => required_rule_group, 'conflicts' => nil }]
+    expected = [{ rule: rule, requires: required_rule_group, conflicts: nil }]
 
     assert_equal @rule_group.rules_with_relationships(requires, {}), expected
   end


### PR DESCRIPTION
@marleystipich2 please go through this, even if it's merged by the time you check it. Took your extraction from #1273 and moved it here + renamed it to `with_relationships` as it calls the same scope on the `RuleGroupRelationship` model. You don't need the `rules` and `rule_groups` as an argument as they are available in the scope of the `Benchmark` and the `Profile`. The usage of symbols and the `x: y` (seattle-style) syntax in hashes is preferred over the hash rockets and the strings `'x' => y` when possible. Also when a method is about building a hash (or hashes) with a lot of keys, it is allowed to disable the linelength cop and move them on separate lines as it is more readable. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
