### PR TITLE
dev(Dockerfile): move the prometheus mmap folder under the tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN microdnf install --nodocs -y $deps $devDeps $extras                         
     bundle install                                                              && \
     ( [[ $prod != "true" ]] || bundle clean -V )
 
+ENV prometheus_multiproc_dir=/opt/app-root/tmp
+
 #############################################################
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal


### PR DESCRIPTION
This is an annoying problem that only affects development, the prometheus-mmap folders start showing up when running with compose up. The fix is trivial, just moving them under [tmp](https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap#memory-mapped-files-storage-location)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
