### PR TITLE
Adjustments to the first build stage in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,9 @@ WORKDIR /opt/app-root/src
 
 COPY ./Gemfile.lock ./Gemfile ./.gemrc.prod /opt/app-root/src/
 
-RUN microdnf install --nodocs -y $deps $devDeps $extras                         && \
+RUN ( [[ $prod == "true" ]] || rpm -e --nodeps tzdata )                         && \
+    microdnf install --nodocs -y $deps $devDeps $extras                         && \
     chmod +t /tmp                                                               && \
-    ( [[ $prod == "true" ]] || rpm -e --nodeps tzdata )                         && \
-    ( [[ $prod == "true" ]] || microdnf install --nodocs -y $deps )             && \
     gem install bundler -v 2.3.22                                               && \
     mv /opt/app-root/src/.gemrc.prod /etc/gemrc                                 && \
     ( [[ $prod != "true" ]] || bundle config set --without 'development:test' ) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /opt/app-root/src
 COPY ./Gemfile.lock ./Gemfile ./.gemrc.prod /opt/app-root/src/
 
 RUN microdnf install --nodocs -y $deps $devDeps $extras                         && \
+    chmod +t /tmp                                                               && \
     ( [[ $prod == "true" ]] || rpm -e --nodeps tzdata )                         && \
     ( [[ $prod == "true" ]] || microdnf install --nodocs -y $deps )             && \
     gem install bundler -v 2.3.22                                               && \


### PR DESCRIPTION
There were some warnings about the `/tmp` folder being world-writable when running `bundle install` + I found an obsolete command of installing non-development dependencies twice in production.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
