### PR TITLE
fix(ProfileSearching): RHICOMPL-3427 implicit operator for search

### DIFF
--- a/app/models/concerns/profile_searching.rb
+++ b/app/models/concerns/profile_searching.rb
@@ -151,6 +151,7 @@ module ProfileSearching
     end
 
     def filter_by_policy_and_profile_names(_filter, operator, value)
+      operator ||= '='
       field = scoped_search_definition.field_by_name('name')
       values = ScopedSearch::QueryBuilder.preprocess_parameters(scoped_search_definition, field, operator, value)
 

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -269,6 +269,21 @@ module V1
         end)
       end
 
+      test 'implicit search on profile name with escaped content' do
+        FactoryBot.create(:canonical_profile, name: '0')
+
+        get v1_profiles_url, params: { search: '&0' }
+
+        assert_response :success
+
+        profiles = response.parsed_body
+
+        assert_equal 1, profiles['data'].count
+        assert_equal(['0'], profiles['data'].map do |profile|
+          profile['attributes']['name']
+        end)
+      end
+
       test 'search canonical profile name' do
         canonical_profile = FactoryBot.create(:canonical_profile)
 


### PR DESCRIPTION
When doing implicit search with profile/policy names both, the operator is not always populated by default, which can cause errors...so setting it to `=`.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
