### PR TITLE
fix(GQL): RHICOMPL-3408 fall back to default groups if not passing any

### DIFF
--- a/app/graphql/mutations/profile/tailor_profile.rb
+++ b/app/graphql/mutations/profile/tailor_profile.rb
@@ -50,6 +50,8 @@ module Mutations
         elsif args[:"#{type}_ref_ids"]
           { ref_ids: args[:"#{type}_ref_ids"] }
         else
+          return { ids: nil } if type == :rule_group # FIXME: final cleanup of RHICOMPL-2124
+
           raise(ActionController::ParameterMissing, "Missing argument identifying #{type.to_s.pluralize}")
         end
       end


### PR DESCRIPTION
This should be reverted after the frontend starts sending group tailoring information via the new endpoint.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
