### PR TITLE
fix(Dockerfile): RHICOMPL-3337 drop the version lock from bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY ./Gemfile.lock ./Gemfile ./.gemrc.prod /opt/app-root/src/
 RUN ( [[ $prod == "true" ]] || rpm -e --nodeps tzdata )                         && \
     microdnf install --nodocs -y $deps $devDeps $extras                         && \
     chmod +t /tmp                                                               && \
-    gem install bundler -v 2.3.22                                               && \
+    gem install bundler                                                         && \
     mv /opt/app-root/src/.gemrc.prod /etc/gemrc                                 && \
     ( [[ $prod != "true" ]] || bundle config set --without 'development:test' ) && \
     ( [[ $prod != "true" ]] || bundle config set --local deployment 'true' )    && \
@@ -44,7 +44,7 @@ USER 0
 
 RUN rpm -e --nodeps tzdata             && \
     microdnf install --nodocs -y $deps && \
-    gem install bundler -v 2.3.22      && \
+    gem install bundler                && \
     microdnf clean all -y              && \
     chown 1001:root ./                 && \
     chmod +t /tmp                      && \


### PR DESCRIPTION
Seems like the issue has been either fixed or was never present.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
