### PR TITLE
perf(SSG): RHICOMPL-3458 extract model initialization when importing

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -58,10 +58,8 @@ class Profile < ApplicationRecord
   delegate :org_id, to: :account, allow_nil: true
 
   class << self
-    def from_openscap_parser(op_profile, benchmark_id: nil, account_id: nil)
-      profile = find_or_initialize_by(ref_id: op_profile.id,
-                                      benchmark_id: benchmark_id,
-                                      account_id: account_id)
+    def from_openscap_parser(op_profile, existing: nil, benchmark_id: nil, account_id: nil)
+      profile = existing || new(ref_id: op_profile.id, benchmark_id: benchmark_id, account_id: account_id)
 
       profile.assign_attributes(
         name: op_profile.title,

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -91,8 +91,8 @@ class Rule < ApplicationRecord
     (profiles & Profile.canonical).any?
   end
 
-  def self.from_openscap_parser(op_rule, rule_group_id: nil, benchmark_id: nil, precedence: nil)
-    rule = find_or_initialize_by(ref_id: op_rule.id, benchmark_id: benchmark_id)
+  def self.from_openscap_parser(op_rule, existing: nil, rule_group_id: nil, benchmark_id: nil, precedence: nil)
+    rule = existing || new(ref_id: op_rule.id, benchmark_id: benchmark_id)
 
     rule.op_source = op_rule
 

--- a/app/models/rule_group.rb
+++ b/app/models/rule_group.rb
@@ -21,9 +21,8 @@ class RuleGroup < ApplicationRecord
   validates :description, presence: true
   validates :benchmark_id, presence: true
 
-  def self.from_openscap_parser(op_rule_group, benchmark_id: nil, parent_id: nil)
-    rule_group = find_or_initialize_by(ref_id: op_rule_group.id,
-                                       benchmark_id: benchmark_id)
+  def self.from_openscap_parser(op_rule_group, existing: nil, benchmark_id: nil, parent_id: nil)
+    rule_group = existing || new(ref_id: op_rule_group.id, benchmark_id: benchmark_id)
 
     rule_group.assign_attributes(title: op_rule_group.title,
                                  description: op_rule_group.description,

--- a/app/services/concerns/xccdf/rule_references_rules.rb
+++ b/app/services/concerns/xccdf/rule_references_rules.rb
@@ -26,11 +26,6 @@ module Xccdf
           @cached_references[[rr.label, rr.href]]
         end.compact
       end
-
-      def rule_for(ref_id:)
-        @cached_rules ||= @rules.index_by(&:ref_id)
-        @cached_rules[ref_id]
-      end
     end
   end
 end

--- a/test/services/concerns/xccdf/profile_rule_groups_test.rb
+++ b/test/services/concerns/xccdf/profile_rule_groups_test.rb
@@ -44,11 +44,8 @@ module Xccdf
 
     test 'updates profile rule group connections' do
       rule_group1 = FactoryBot.create(:rule_group, benchmark: @benchmark)
-      rule_group2 = ::RuleGroup.from_openscap_parser(
-        @op_rule_groups.find do |rule_group|
-          rule_group.id == 'xccdf_org.ssgproject.content_group_accounts-physical'
-        end,
-        benchmark_id: @benchmark&.id
+      rule_group2 = ::RuleGroup.find_by(
+        ref_id: 'xccdf_org.ssgproject.content_group_accounts-physical', benchmark: @benchmark
       )
       @profiles.first.update(rule_groups: [rule_group1, rule_group2])
 

--- a/test/services/concerns/xccdf/profile_rules_test.rb
+++ b/test/services/concerns/xccdf/profile_rules_test.rb
@@ -39,12 +39,7 @@ module Xccdf
 
     test 'updates profile rule connections' do
       rule1 = FactoryBot.create(:rule, benchmark: @benchmark)
-      rule2 = ::Rule.from_openscap_parser(
-        @op_rules.find do |rule|
-          rule.id == 'xccdf_org.ssgproject.content_rule_disable_prelink'
-        end,
-        benchmark_id: @benchmark&.id
-      )
+      rule2 = ::Rule.find_by(ref_id: 'xccdf_org.ssgproject.content_rule_disable_prelink', benchmark: @benchmark)
       @profiles.first.update(rules: [rule1, rule2])
 
       assert_difference('ProfileRule.count', 72) do

--- a/test/services/concerns/xccdf/rule_references_rules_test.rb
+++ b/test/services/concerns/xccdf/rule_references_rules_test.rb
@@ -5,6 +5,7 @@ require 'xccdf/rule_references'
 
 # A class to test saving RuleReferencesRules from OpenscapParser
 class RuleReferencesRulesTest < ActiveSupport::TestCase
+  include Xccdf::Rules
   include Xccdf::RuleReferencesRules
 
   test 'only new rule references rules are saved' do

--- a/test/services/concerns/xccdf/rules_test.rb
+++ b/test/services/concerns/xccdf/rules_test.rb
@@ -76,6 +76,8 @@ class RulesTest < ActiveSupport::TestCase
     before = @mock.benchmark.rules.order(:precedence).pluck(:ref_id)
 
     @mock.instance_variable_set(:@rules, nil)
+    @mock.instance_variable_set(:@old_rules, nil)
+    @mock.instance_variable_set(:@new_rules, nil)
     @mock.instance_variable_set(:@op_rules, @mock.instance_variable_get(:@op_rules).reverse)
     @mock.save_rules
 
@@ -92,6 +94,8 @@ class RulesTest < ActiveSupport::TestCase
       rule = @mock.benchmark.rules.order(:precedence).first
 
       @mock.instance_variable_set(:@rules, nil)
+      @mock.instance_variable_set(:@old_rules, nil)
+      @mock.instance_variable_set(:@new_rules, nil)
       @mock.instance_variable_get(:@op_rules).first.instance_variable_set("@#{field}".to_sym, 'foobar')
       @mock.save_rules
 


### PR DESCRIPTION
Extracting the `find` part of `find_or_initialize_by` in the Rule/Group/Profile models to reduce the load on the database. 

**Before:**
```
bin/rake db:truncate_all # clear DB
time bin/rake ssg:import_rhel_supported

real  3m57.819s
user  3m20.576s
sys 0m4.161s

bin/rails r "Revision.find_by(name: 'datastreams').delete" # force import
time bin/rake ssg:import_rhel_supported

real  3m2.538s
user  2m40.986s
sys 0m3.074s
```
**After:**
```
bin/rake db:truncate_all # clear DB
time bin/rake ssg:import_rhel_supported

real  3m33.509s
user  2m59.564s
sys 0m3.414s

bin/rails r "Revision.find_by(name: 'datastreams').delete" # force import
time bin/rake ssg:import_rhel_supported

real  2m47.653s
user  2m28.603s
sys 0m2.402s
```

We're faster by additional 20-30 seconds :zap: :tada: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
