### PR TITLE
fix(SSG): RHICOMPL-3454 correctly set ancestry column during import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'nokogiri', force_ruby_platform: true
 gem 'manageiq-loggers', '~> 0.6.0'
 
 # Parsing OpenSCAP reports library
-gem 'openscap_parser', '~> 1.3.0'
+gem 'openscap_parser', '~> 1.4.0'
 
 # RBAC service API
 gem 'insights-rbac-api-client', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.10.6)
-    openscap_parser (1.3.0)
+    openscap_parser (1.4.0)
       nokogiri (~> 1.6)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -469,7 +469,7 @@ DEPENDENCIES
   mocha
   nokogiri
   oj
-  openscap_parser (~> 1.3.0)
+  openscap_parser (~> 1.4.0)
   pg
   pry-byebug
   pry-rails


### PR DESCRIPTION
Verified that openscap_parser returns the `parents_ids` of the groups in the correct order and the `ancestry` column on rule_groups is also set up in the correct order. Added tests to check this as well. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
