### PR TITLE
feat(Tailoring): RHICOMPL-2947 Add groups to tailoring file

### DIFF
--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -59,7 +59,8 @@ module V1
       return unless profile.tailored?
 
       send_data XccdfTailoringFile.new(
-        profile: profile, rule_ref_ids: profile.tailored_rule_ref_ids
+        profile: profile, rule_ref_ids: profile.tailored_rule_ref_ids,
+        rule_group_ref_ids: profile.rule_group_ancestor_ref_ids
       ).to_xml, filename: tailoring_filename, type: Mime[:xml]
 
       audit_tailoring_file

--- a/app/services/xccdf_tailoring_file.rb
+++ b/app/services/xccdf_tailoring_file.rb
@@ -6,9 +6,10 @@ class XccdfTailoringFile
 
   XCCDF = 'xccdf'
 
-  def initialize(profile:, rule_ref_ids: {}, set_values: {})
+  def initialize(profile:, rule_ref_ids: {}, set_values: {}, rule_group_ref_ids: [])
     @profile = profile
     @rule_ref_ids = rule_ref_ids
+    @rule_group_ref_ids = rule_group_ref_ids
     @set_values = set_values
   end
 
@@ -41,7 +42,7 @@ class XccdfTailoringFile
       xml[XCCDF].description(@profile.description,
                              'xmlns:xhtml' => 'http://www.w3.org/1999/xhtml',
                              'xml:lang' => 'en-US', override: true)
-      rule_selections_builder(xml)
+      selections_builder(xml)
     end
   end
 
@@ -49,6 +50,17 @@ class XccdfTailoringFile
     @rule_ref_ids.each do |rule_ref_id, selected|
       xml[XCCDF].select(idref: rule_ref_id, selected: selected)
     end
+  end
+
+  def rule_group_selections_builder(xml)
+    @rule_group_ref_ids.each do |rule_group_ref_id|
+      xml[XCCDF].select(idref: rule_group_ref_id, selected: true)
+    end
+  end
+
+  def selections_builder(xml)
+    rule_selections_builder(xml)
+    rule_group_selections_builder(xml)
   end
 
   def create_builder

--- a/test/services/xccdf_tailoring_file_test.rb
+++ b/test/services/xccdf_tailoring_file_test.rb
@@ -46,13 +46,29 @@ class XccdfTailoringFileTest < ActiveSupport::TestCase
       parent_profile_id: @parent.id
     )
     rules = @parent.rules.take(2)
+
+    rule_group1 = FactoryBot.create(:rule_group)
+    rule_group2 = FactoryBot.create(:rule_group)
+    rule_group3 = FactoryBot.create(:rule_group)
+    rule_group4 = FactoryBot.create(:rule_group)
+
+    rule_group1.ancestry = "#{rule_group3.id}/#{rule_group2.id}"
+    rule_group1.save(validate: false)
+    rule_group2.ancestry = rule_group3.id.to_s
+    rule_group2.save(validate: false)
+
+    rules.first.update! rule_group: rule_group1
+    rules.last.update! rule_group: rule_group4
+
     @parent.benchmark.update!(rules: rules)
+
     tailoring_file = XccdfTailoringFile.new(
       profile: profile,
       rule_ref_ids: {
         rules.first.ref_id => false,
         rules.last.ref_id => true
-      }
+      },
+      rule_group_ref_ids: [rule_group1.ref_id, rule_group2.ref_id, rule_group3.ref_id, rule_group4.ref_id]
     )
     op_tailoring = OpenscapParser::TailoringFile.new(tailoring_file.to_xml)
                                                 .tailoring
@@ -66,6 +82,65 @@ class XccdfTailoringFileTest < ActiveSupport::TestCase
         "select[@selected='false']/@idref"
       ).text,
       rules.first.ref_id
+    )
+  end
+
+  test 'properly selects rule_group ref_ids' do
+    profile = Profile.create!(
+      ref_id: 'test',
+      name: 'test profile',
+      benchmark_id: @parent.benchmark.id,
+      parent_profile_id: @parent.id
+    )
+    rules = @parent.rules.take(2)
+
+    rule_group1 = FactoryBot.create(:rule_group)
+    rule_group2 = FactoryBot.create(:rule_group)
+    rule_group3 = FactoryBot.create(:rule_group)
+    rule_group4 = FactoryBot.create(:rule_group)
+
+    @parent.benchmark.update!(rules: rules)
+
+    tailoring_file = XccdfTailoringFile.new(
+      profile: profile,
+      rule_ref_ids: {
+        rules.first.ref_id => false,
+        rules.last.ref_id => true
+      },
+      rule_group_ref_ids: [rule_group1.ref_id, rule_group2.ref_id, rule_group3.ref_id, rule_group4.ref_id]
+    )
+    op_tailoring = OpenscapParser::TailoringFile.new(tailoring_file.to_xml)
+                                                .tailoring
+
+    assert_includes(
+      op_tailoring.profiles.first.xpath(
+        "select[@selected='true']/@idref"
+      ).text,
+      rule_group1.ref_id
+    )
+    assert_includes(
+      op_tailoring.profiles.first.xpath(
+        "select[@selected='true']/@idref"
+      ).text,
+      rule_group2.ref_id
+    )
+    assert_includes(
+      op_tailoring.profiles.first.xpath(
+        "select[@selected='true']/@idref"
+      ).text,
+      rule_group3.ref_id
+    )
+    assert_includes(
+      op_tailoring.profiles.first.xpath(
+        "select[@selected='true']/@idref"
+      ).text,
+      rule_group4.ref_id
+    )
+    assert_equal(
+      op_tailoring.profiles.first.xpath(
+        "select[@selected='true']/@idref"
+      ).length,
+      5
     )
   end
 


### PR DESCRIPTION
Test cases covered in `profile_test.rb` :
- `rule_group_ancestor_ref_ids` returns all rule group ancestors for added rules when the rule_group depth is 4
-`rule_group_ancestor_ref_ids` returns all rule group ancestors for added rules when the rule_group depth is 1
- `rule_group_ancestor_ref_ids` does not return any rule groups that are not the parent or ancestor of an added_rule

Test cases covered in `xccdf_tailoring_file.rb`:
- all rule group ref_ids in `rule_group_ref_ids` should be added to the tailoring file with `selected='true'`
- There are no rule groups added to the tailoring file that isn't included in `rule_group_ref_ids`

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
