### PR TITLE
fix(tests): fixed deprecation for asserting nil value

### DIFF
--- a/test/services/concerns/xccdf/rule_groups_test.rb
+++ b/test/services/concerns/xccdf/rule_groups_test.rb
@@ -51,7 +51,7 @@ class RuleGroupsTest < ActiveSupport::TestCase
     rg_ancestor_ids = rg_with_ancestors.ancestors.map(&:id)
 
     assert_equal "#{root.id}/#{parent2.id}/#{parent1.id}", rg_with_ancestors.ancestry
-    assert_equal nil, root.parent
+    assert_nil root.parent
     assert_equal '', @rule_groups[0].ancestry
     assert_equal @rule_groups[2].parent.id.to_s, @rule_groups[2].ancestry
     assert_includes rg_ancestor_ids, root.id


### PR DESCRIPTION
```
DEPRECATED: Use assert_nil if expecting nil from test/services/concerns/xccdf/rule_groups_test.rb:53. This will fail in Minitest 6.
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
