### PR TITLE
feat(Tailoring): RHICOMPL-3398 add set-value to tailoring file

### DIFF
--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -60,7 +60,7 @@ module V1
 
       send_data XccdfTailoringFile.new(
         profile: profile, rule_ref_ids: profile.tailored_rule_ref_ids,
-        rule_group_ref_ids: profile.rule_group_ancestor_ref_ids
+        rule_group_ref_ids: profile.rule_group_ancestor_ref_ids, set_values: profile.value_overrides
       ).to_xml, filename: tailoring_filename, type: Mime[:xml]
 
       audit_tailoring_file

--- a/app/services/xccdf_tailoring_file.rb
+++ b/app/services/xccdf_tailoring_file.rb
@@ -42,7 +42,7 @@ class XccdfTailoringFile
       xml[XCCDF].description(@profile.description,
                              'xmlns:xhtml' => 'http://www.w3.org/1999/xhtml',
                              'xml:lang' => 'en-US', override: true)
-      selections_builder(xml)
+      tailoring_builder(xml)
     end
   end
 
@@ -58,9 +58,17 @@ class XccdfTailoringFile
     end
   end
 
-  def selections_builder(xml)
+  def value_builder(xml)
+    @set_values.each do |value_ref_id, value|
+      # nokogiri maintainers recommend using send for tags with hyphens
+      xml[XCCDF].send('set-value', value, idref: value_ref_id)
+    end
+  end
+
+  def tailoring_builder(xml)
     rule_selections_builder(xml)
     rule_group_selections_builder(xml)
+    value_builder(xml)
   end
 
   def create_builder


### PR DESCRIPTION
Waiting to merge this until values are imported in the DB: https://issues.redhat.com/browse/RHICOMPL-3475

Example of what's added to the tailoring file:

`<set-value idref="foo_value_e61824be-c7a3-4701-96f6-55b21cdafd7b">testing</set-value>
<set-value idref="foo_value_62d90c6d-3cac-491d-a778-f236e7d9ddad">true</set-value>
<set-value idref="foo_value_0f821a89-4734-46d7-80d7-78dd459ad14a">3</set-value>`

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
