### PR TITLE
feat(Import): RHICOMPL-3475 import Values into the DB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'nokogiri', force_ruby_platform: true
 gem 'manageiq-loggers', '~> 0.6.0'
 
 # Parsing OpenSCAP reports library
-gem 'openscap_parser', '~> 1.5.1'
+gem 'openscap_parser', '~> 1.6.0'
 
 # RBAC service API
 gem 'insights-rbac-api-client', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.10.6)
-    openscap_parser (1.5.1)
+    openscap_parser (1.6.0)
       nokogiri (~> 1.6)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -474,7 +474,7 @@ DEPENDENCIES
   mocha
   nokogiri
   oj
-  openscap_parser (~> 1.5.1)
+  openscap_parser (~> 1.6.0)
   pg
   pry-byebug
   pry-rails

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -57,12 +57,13 @@ class Profile < ApplicationRecord
   delegate :org_id, to: :account, allow_nil: true
 
   class << self
-    def from_openscap_parser(op_profile, existing: nil, benchmark_id: nil, account_id: nil)
+    def from_openscap_parser(op_profile, existing: nil, benchmark_id: nil, account_id: nil, value_overrides: nil)
       profile = existing || new(ref_id: op_profile.id, benchmark_id: benchmark_id, account_id: account_id)
 
       profile.assign_attributes(
         name: op_profile.title,
         description: op_profile.description,
+        value_overrides: value_overrides,
         upstream: false
       )
 

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -78,7 +78,9 @@ class Rule < ApplicationRecord
     (profiles & Profile.canonical).any?
   end
 
-  def self.from_openscap_parser(op_rule, existing: nil, rule_group_id: nil, benchmark_id: nil, precedence: nil)
+  # rubocop:disable Metrics/ParameterLists
+  def self.from_openscap_parser(op_rule, existing: nil, rule_group_id: nil,
+                                benchmark_id: nil, precedence: nil, value_checks: nil)
     rule = existing || new(ref_id: op_rule.id, benchmark_id: benchmark_id)
 
     rule.op_source = op_rule
@@ -87,10 +89,11 @@ class Rule < ApplicationRecord
                            rationale: op_rule.rationale, severity: op_rule.severity,
                            precedence: precedence, rule_group_id: rule_group_id,
                            upstream: false, slug: rule.normalize_friendly_id(op_rule.id),
-                           identifier: op_rule.identifier&.to_h)
+                           value_checks: value_checks, identifier: op_rule.identifier&.to_h)
 
     rule
   end
+  # rubocop:enable Metrics/ParameterLists
 
   def compliant?(host, profile)
     Rails.cache.fetch("#{id}/#{host.id}/compliant") do

--- a/app/models/value_definition.rb
+++ b/app/models/value_definition.rb
@@ -2,12 +2,25 @@
 
 # Stores information about value definitions. This comes from SCAP.
 class ValueDefinition < ApplicationRecord
+  include OpenscapParserDerived
+
   belongs_to :benchmark, class_name: 'Xccdf::Benchmark'
 
-  POSSIBLE_VALUE_TYPES = %w[string number bool].freeze
+  POSSIBLE_VALUE_TYPES = %w[string number boolean].freeze
 
   validates :benchmark_id, presence: true
   validates :ref_id, uniqueness: { scope: %i[benchmark_id] }, presence: true
   validates :description, presence: true
   validates :value_type, presence: true, inclusion: { in: POSSIBLE_VALUE_TYPES }
+
+  def self.from_openscap_parser(op_vd, existing: nil, benchmark_id: nil)
+    value_definition = existing || new(ref_id: op_vd.id, benchmark_id: benchmark_id)
+
+    value_definition.op_source = op_vd
+
+    value_definition.assign_attributes(title: op_vd.title, description: op_vd.description,
+                                       value_type: op_vd.type, default_value: op_vd.value)
+
+    value_definition
+  end
 end

--- a/app/services/concerns/xccdf/profiles.rb
+++ b/app/services/concerns/xccdf/profiles.rb
@@ -11,7 +11,8 @@ module Xccdf
           ::Profile.from_openscap_parser(
             op_profile,
             existing: old_profiles[op_profile.id],
-            benchmark_id: @benchmark&.id
+            benchmark_id: @benchmark&.id,
+            value_overrides: value_overrides(op_profile)
           )
         end
 
@@ -29,6 +30,13 @@ module Xccdf
         @old_profiles ||= ::Profile.where(
           ref_id: @op_profiles.map(&:id), benchmark: @benchmark&.id
         ).index_by(&:ref_id)
+      end
+
+      def value_overrides(op_profile)
+        op_profile.refined_values.each_with_object({}) do |(value_id, selector), value_map|
+          op_value = value_definition_for(ref_id: value_id).op_source
+          value_map[value_id] = op_value.value(selector)
+        end
       end
     end
   end

--- a/app/services/concerns/xccdf/rules.rb
+++ b/app/services/concerns/xccdf/rules.rb
@@ -9,12 +9,12 @@ module Xccdf
       def rules
         @rules ||= @op_rules.each_with_index.map do |op_rule, idx|
           rule_group = rule_group_for(ref_id: op_rule.parent_id)
+          value_checks = op_rule.values.map { |value_ref_id| value_definition_for(ref_id: value_ref_id).id }
 
           ::Rule.from_openscap_parser(
             op_rule,
-            existing: old_rules[op_rule.id],
-            precedence: idx,
-            rule_group_id: rule_group&.id,
+            existing: old_rules[op_rule.id], precedence: idx,
+            rule_group_id: rule_group&.id, value_checks: value_checks,
             benchmark_id: @benchmark&.id
           )
         end
@@ -28,7 +28,7 @@ module Xccdf
         ::Rule.import(old_rules.values,
                       on_duplicate_key_update: {
                         conflict_target: %i[ref_id benchmark_id],
-                        columns: %i[identifier description precedence rationale rule_group_id severity]
+                        columns: %i[identifier description precedence rationale rule_group_id severity value_checks]
                       }, validate: false)
       end
 

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -10,6 +10,7 @@ module Xccdf
       include ::Xccdf::Profiles
       include ::Xccdf::Rules
       include ::Xccdf::RuleGroups
+      include ::Xccdf::ValueDefinitions
       include ::Xccdf::ProfileRules
       include ::Xccdf::RuleReferencesContainers
       include ::Xccdf::RuleGroupRelationships
@@ -22,6 +23,7 @@ module Xccdf
         return if benchmark_contents_equal_to_op?
 
         save_benchmark
+        save_value_definitions
         save_profiles
         save_rule_groups
         save_rules
@@ -43,6 +45,7 @@ module Xccdf
         @op_test_result = @test_result_file.test_result
         @op_rule_groups = @op_benchmark.groups
         @op_profiles = @op_benchmark.profiles
+        @op_value_definitions = @op_benchmark.values
         @op_rules = @op_benchmark.rules
         @op_rule_results = @op_test_result.rule_results
       end

--- a/app/services/concerns/xccdf/value_definitions.rb
+++ b/app/services/concerns/xccdf/value_definitions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Xccdf
+  # Methods related to saving value definitions
+  module ValueDefinitions
+    extend ActiveSupport::Concern
+
+    included do
+      def value_definitions
+        @value_definitions ||= @op_value_definitions.map do |op_value_definition|
+          ::ValueDefinition.from_openscap_parser(
+            op_value_definition,
+            existing: old_value_definitions[op_value_definition.id],
+            benchmark_id: @benchmark&.id
+          )
+        end
+      end
+
+      def save_value_definitions
+        # Import the new records first with validation
+        ::ValueDefinition.import!(new_value_definitions, ignore: true)
+
+        # Update the fields on existing value_definitions, validation is not necessary
+        ::ValueDefinition.import(old_value_definitions.values,
+                                 on_duplicate_key_update: {
+                                   conflict_target: %i[ref_id benchmark_id],
+                                   columns: %i[description default_value]
+                                 }, validate: false)
+      end
+
+      private
+
+      def new_value_definitions
+        @new_value_definitions ||= value_definitions.select(&:new_record?)
+      end
+
+      def old_value_definitions
+        @old_value_definitions ||= ::ValueDefinition.where(
+          ref_id: @op_value_definitions.map(&:id), benchmark_id: @benchmark&.id
+        ).index_by(&:ref_id)
+      end
+
+      def value_definition_for(ref_id:)
+        @cached_value_definitions ||= @value_definitions.index_by(&:ref_id)
+        @cached_value_definitions[ref_id]
+      end
+    end
+  end
+end

--- a/app/services/datastream_importer.rb
+++ b/app/services/datastream_importer.rb
@@ -10,6 +10,9 @@ class DatastreamImporter
     @op_profiles = @op_benchmark.profiles
     @op_rule_groups = @op_benchmark.groups
     @op_rules = @op_benchmark.rules
+    @op_value_definitions = @op_benchmark.values
+    @op_rule_references =
+      @op_benchmark.rule_references.reject { |rr| rr.label.empty? }
   end
 
   def import!

--- a/db/migrate/20221216135909_reset_revision_dec_sixteenth.rb
+++ b/db/migrate/20221216135909_reset_revision_dec_sixteenth.rb
@@ -1,0 +1,5 @@
+class ResetRevisionDecSixteenth < ActiveRecord::Migration[7.0]
+  def up
+    Revision.find_by(name: 'datastreams')&.delete
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_12_124930) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_16_135909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"

--- a/test/factories/value_definition.rb
+++ b/test/factories/value_definition.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :value_definition do
     title { Faker::Lorem.sentence }
-    value_type { 'bool' }
+    value_type { 'boolean' }
     ref_id { "foo_rule_group_#{SecureRandom.uuid}" }
     description { Faker::Lorem.paragraph }
     benchmark

--- a/test/services/concerns/xccdf/profiles_test.rb
+++ b/test/services/concerns/xccdf/profiles_test.rb
@@ -15,26 +15,52 @@ module Xccdf
     end
 
     include Xccdf::Profiles
+    include Xccdf::ValueDefinitions
 
     setup do
       @account = FactoryBot.create(:account)
       @host = FactoryBot.create(:host, org_id: @account.org_id)
       @benchmark = FactoryBot.create(:canonical_profile, :with_rules).benchmark
       parser = OpenscapParser::TestResultFile.new(
-        file_fixture('xccdf_report.xml').read
+        file_fixture('rhel-xccdf-report.xml').read
       )
       @op_profiles = parser.benchmark.profiles
+      @op_value_definitions = parser.benchmark.values
       @op_test_result = parser.test_result
+      save_value_definitions
     end
 
     test 'save_profiles' do
-      assert_difference('Profile.count', 1) do
+      assert_difference('Profile.count', 10) do
         save_profiles
       end
 
       assert_no_difference('Profile.count') do
         save_profiles
       end
+    end
+
+    test 'correctly save value_overrides' do
+      save_profiles
+
+      profile1 = Profile.find_by(ref_id: 'xccdf_org.ssgproject.content_profile_pci-dss')
+      profile2 = Profile.find_by(ref_id: 'xccdf_org.ssgproject.content_profile_standard')
+
+      expected_overrides = { 'xccdf_org.ssgproject.content_value_var_auditd_num_logs' => '5',
+                             'xccdf_org.ssgproject.content_value_sshd_idle_timeout_value' => '900',
+                             'xccdf_org.ssgproject.content_value_var_password_pam_minlen' => '7',
+                             'xccdf_org.ssgproject.content_value_var_multiple_time_servers' =>
+                             '0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org',
+                             'xccdf_org.ssgproject.content_value_var_password_pam_minclass' => '2',
+                             'xccdf_org.ssgproject.content_value_var_password_pam_unix_remember' => '4',
+                             'xccdf_org.ssgproject.content_value_var_accounts_maximum_age_login_defs' => '90',
+                             'xccdf_org.ssgproject.content_value_var_account_disable_post_pw_expiration' => '90',
+                             'xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_deny' => '6',
+                             'xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_unlock_time' =>
+                             '1800' }
+
+      assert_equal expected_overrides, profile1.value_overrides
+      assert_equal 0, profile2.value_overrides.length
     end
   end
 end

--- a/test/services/concerns/xccdf/rule_references_containers_test.rb
+++ b/test/services/concerns/xccdf/rule_references_containers_test.rb
@@ -9,6 +9,7 @@ class RuleReferencesContainersTest < ActiveSupport::TestCase
     include Xccdf::Profiles
     include Xccdf::Rules
     include Xccdf::RuleGroups
+    include Xccdf::ValueDefinitions
     include Xccdf::RuleReferencesContainers
 
     attr_accessor :benchmark, :account, :op_profiles, :op_rules
@@ -20,6 +21,7 @@ class RuleReferencesContainersTest < ActiveSupport::TestCase
       @op_rules = @op_benchmark.rules
       @op_profiles = @op_benchmark.profiles
       @op_rule_groups = @op_benchmark.groups
+      @op_value_definitions = @op_benchmark.values
     end
   end
 
@@ -30,6 +32,7 @@ class RuleReferencesContainersTest < ActiveSupport::TestCase
     ).benchmark
     @mock.account = FactoryBot.create(:account)
     @mock.save_rule_groups
+    @mock.save_value_definitions
     @mock.save_rules
   end
 

--- a/test/services/concerns/xccdf/rules_test.rb
+++ b/test/services/concerns/xccdf/rules_test.rb
@@ -8,6 +8,7 @@ class RulesTest < ActiveSupport::TestCase
     include Xccdf::Profiles
     include Xccdf::Rules
     include Xccdf::RuleGroups
+    include Xccdf::ValueDefinitions
     include Xccdf::ProfileRules
 
     attr_accessor :benchmark, :account, :op_profiles, :op_rules
@@ -17,6 +18,7 @@ class RulesTest < ActiveSupport::TestCase
       @op_benchmark = test_result_file.benchmark
       @op_test_result = test_result_file.test_result
       @op_rules = @op_benchmark.rules
+      @op_value_definitions = @op_benchmark.values
       @op_profiles = @op_benchmark.profiles
       @op_rule_groups = @op_benchmark.groups
     end
@@ -30,6 +32,7 @@ class RulesTest < ActiveSupport::TestCase
     RuleReferencesContainer.delete_all
     @mock.account = FactoryBot.create(:account)
     @mock.save_rule_groups
+    @mock.save_value_definitions
   end
 
   test 'save all rules as new' do
@@ -45,6 +48,19 @@ class RulesTest < ActiveSupport::TestCase
     assert rule.save
     @mock.save_rules
     assert_includes @mock.rules, rule
+  end
+
+  test 'correctly saves value_checks' do
+    @mock.save_rules
+    rule1 = Rule.find_by(ref_id: 'xccdf_org.ssgproject.content_rule_network_ipv6_disable_interfaces')
+    rule2 = Rule.find_by(ref_id: 'xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout')
+    value1 = ValueDefinition.find_by(ref_id: 'xccdf_org.ssgproject.content_value_sshd_required')
+    value2 = ValueDefinition.find_by(ref_id: 'xccdf_org.ssgproject.content_value_sshd_idle_timeout_value')
+
+    assert_includes rule2.value_checks, value1.id
+    assert_includes rule2.value_checks, value2.id
+    assert_equal 2, rule2.value_checks.length
+    assert_equal [], rule1.value_checks
   end
 
   test 'save all rules and add profiles to pre existing one' do
@@ -101,5 +117,26 @@ class RulesTest < ActiveSupport::TestCase
 
       assert_equal rule.reload[field], 'foobar'
     end
+  end
+
+  test 'updates value_checks field when needed' do
+    @mock.benchmark.rules.clear
+    @mock.save_rules
+
+    rule = @mock.benchmark.rules.order(:precedence).first
+
+    assert_equal [], rule.value_checks
+
+    value_ref_id = @mock.benchmark.value_definitions.first.ref_id
+    value_id = @mock.benchmark.value_definitions.first.id
+
+    @mock.instance_variable_set(:@rules, nil)
+    @mock.instance_variable_set(:@old_rules, nil)
+    @mock.instance_variable_set(:@new_rules, nil)
+    @mock.instance_variable_get(:@op_rules).first.stubs(:values).returns([value_ref_id])
+
+    @mock.save_rules
+
+    assert_equal [value_id], rule.reload[:value_checks]
   end
 end

--- a/test/services/concerns/xccdf/value_definitions_test.rb
+++ b/test/services/concerns/xccdf/value_definitions_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'xccdf/value_definitions'
+
+class ValueDefinitionsTest < ActiveSupport::TestCase
+  include Xccdf::Profiles
+  include Xccdf::ValueDefinitions
+  include Xccdf::Rules
+  include Xccdf::RuleGroups
+  include Xccdf::ProfileRules
+  include Xccdf::RuleReferencesContainers
+
+  attr_accessor :benchmark, :account, :op_profiles, :op_value_definitions
+
+  setup do
+    account = FactoryBot.create(:account)
+    FactoryBot.create(:host, org_id: account.org_id)
+    @benchmark = FactoryBot.create(:canonical_profile).benchmark
+    parser = OpenscapParser::TestResultFile.new(
+      file_fixture('rhel-xccdf-report.xml').read
+    )
+    @op_rules = parser.benchmark.rules
+    @op_rule_groups = parser.benchmark.groups
+    @op_value_definitions = parser.benchmark.values
+  end
+
+  test 'save all value_definitions as new' do
+    assert_difference('ValueDefinition.count', 408) do
+      save_value_definitions
+    end
+
+    assert_no_difference('ValueDefinition.count') do
+      save_value_definitions
+    end
+  end
+
+  test 'updates value field when needed' do
+    save_value_definitions
+
+    value_def = @benchmark.value_definitions.find_by(ref_id: 'xccdf_org.ssgproject.content_value_var_mcelog_server')
+
+    assert_equal value_def.default_value, 'false'
+
+    @value_definitions = nil
+    @old_value_definitions = nil
+    @new_value_definitions = nil
+    op_vd = @op_value_definitions.find { |t| t.id == 'xccdf_org.ssgproject.content_value_var_mcelog_server' }
+    op_vd.stubs(:value).returns('true')
+
+    save_value_definitions
+
+    assert_equal value_def.reload[:default_value], 'true'
+  end
+
+  test 'updates description field when needed' do
+    save_value_definitions
+
+    @value_definitions = nil
+    @old_value_definitions = nil
+    @new_value_definitions = nil
+    op_vd = @op_value_definitions.find { |t| t.id == 'xccdf_org.ssgproject.content_value_var_mcelog_server' }
+    op_vd.instance_variable_set('@description'.to_sym, 'foobar')
+
+    save_value_definitions
+
+    after = @benchmark.value_definitions.find_by(ref_id: 'xccdf_org.ssgproject.content_value_var_mcelog_server')
+
+    assert_equal after.description, 'foobar'
+  end
+
+  test 'correctly assigns all attributes' do
+    save_value_definitions
+
+    val = @value_definitions.find { |vd| vd.ref_id == 'xccdf_org.ssgproject.content_value_var_accounts_tmout' }
+
+    assert_equal '600', val.default_value
+    assert_equal 'number', val.value_type
+  end
+end

--- a/test/services/xccdf_report_parser_test.rb
+++ b/test/services/xccdf_report_parser_test.rb
@@ -216,6 +216,7 @@ class XccdfReportParserTest < ActiveSupport::TestCase
         # rubocop:enable Layout/LineLength
       ]
       @report_parser.save_benchmark
+      @report_parser.save_value_definitions
       @report_parser.save_profiles
       @report_parser.save_rule_groups
     end


### PR DESCRIPTION
Purpose of this PR:
- Update openscap_parser gem to version 1.6.0
- Import Values into the `value_definitions` table
- Import `value_overrides` that holds value refinements for a Profile
- Import `value_checks` for a Rule (these are the values that are used by the Rule)

Note: I imported the `lower_bound`s and `upper_bound`s of a ValueDefinition since we are parsing the info in openscap_parser but they are not used at all in our datastreams and the openscap team said they have no plans to use them in the future.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
