### PR TITLE
perf(API): RHICOMPL-3497 disable eager loading of large relations

### DIFF
--- a/app/controllers/concerns/rendering.rb
+++ b/app/controllers/concerns/rendering.rb
@@ -6,7 +6,7 @@ module Rendering
 
   included do
     def render_json(model, **args)
-      model = model.includes(includes).references(includes) if index? && includes
+      model = model.includes(includes) if index? && includes
       render({ json: serializer.new(model, serializer_opts) }.merge(args))
     end
 


### PR DESCRIPTION
Calling `includes` with `references` on a relation triggers `eager_load` which in case of more than 2 tables is costly. The worst performing one is the `RulesController` that works with 4 levels of joins. All the includes in other controllers are loading at least 3 tables, therefore, falling back to `preload` should improve memory usage for the price of entering multiple times into the DB instead of a single query.

The only other usage of eager loading is in the `rule_tree` where only a single table is pulled in, which is good as it is.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
