### PR TITLE
perf(REST): RHICOMPL-3500 always count results by a specific column

### DIFF
--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -16,7 +16,7 @@ module Metadata
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     def metadata(opts = {})
-      opts[:total] ||= resolve_collection.count
+      opts[:total] ||= count_collection
 
       {
         meta: {
@@ -74,6 +74,13 @@ module Metadata
     end
 
     private
+
+    def count_collection
+      # Count the whole collection using a single column and not the whole table. This column
+      # by default is the primary key of the table, however, in certain cases using a different
+      # indexed column might produce faster results without even accessing the table.
+      resolve_collection.except(:select).select(resolve_collection.base_class.count_by).count
+    end
 
     def base_link_url
       api_version = request.fullpath.delete_prefix("#{path_prefix}/#{Settings.app_name}")

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,4 +21,8 @@ class ApplicationRecord < ActiveRecord::Base
   def self.taggable?
     false
   end
+
+  def self.count_by
+    primary_key.to_sym
+  end
 end

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -36,6 +36,12 @@ class RuleResult < ApplicationRecord
   scope :for_policy, ->(policy_id) { joins(:profile).where(profiles: ::Profile.in_policy(policy_id)) }
   scope :latest, ->(policy_id) { for_policy(policy_id).joins(:test_result).joins(::TestResult.with_latest) }
 
+  # When requesting rule results, the DB response is scoped down by org_id numbers on the joined inventory. By
+  # using the same index to join hosts and count results, we can save a lot of time.
+  def self.count_by
+    :host_id
+  end
+
   def self.from_openscap_parser(op_rule_result, test_result_id: nil,
                                 rule_id: nil, host_id: nil)
     find_or_initialize_by(


### PR DESCRIPTION
Introducing a `count_by` method that defaults to `:id` to make counting results faster. This default value has the most significance for the `rules` (2x faster) and `systems` (15x faster) endpoint. For the `rule_results` it needed a custom column to make it even faster (~20x) as it allows PG to not enter the table at all and just use the index.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
