### PR TITLE
feat(metrics): RHICOMPL-3501 pass the gql_op with metrics/alerts

### DIFF
--- a/app/controllers/concerns/exception_notifier_custom_data.rb
+++ b/app/controllers/concerns/exception_notifier_custom_data.rb
@@ -17,7 +17,8 @@ module ExceptionNotifierCustomData
 
   def extend_exception_notifier
     request.env['exception_notifier.exception_data'].merge!(
-      current_user: current_user&.account&.org_id
+      current_user: current_user&.account&.org_id,
+      gql_op: respond_to?(:parse_gql_op, true) ? parse_gql_op : nil
     )
   end
 end

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -2,6 +2,7 @@
 Yabeda.configure do
   default_tag :application, 'compliance'
   default_tag :qe, 0
+  default_tag :gql_op, nil
 end
 
 # Start the metrics server for sidekiq and racecar


### PR DESCRIPTION
I created a primitive regex that can parse a single operation+name from the GQL params. I intentionally made it restricted to chars+numbers up to 32 characters to avoid the injection of weird or long stuff into prometheus. This information is then being passed to the exception notifications and to Yabeda as a tag for alerting and metrics.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
