### PR TITLE
cleanup(Gemfile): remove incorrect comment for activerecord-import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'faraday'
 gem 'friendly_id', '~> 5.2.4'
 gem 'scoped_search'
 gem 'will_paginate'
-gem 'activerecord-import' # Substitute on upgrade to Rails 6
+gem 'activerecord-import'
 gem 'oj'
 gem 'uuid'
 


### PR DESCRIPTION
Upsert in Rails 7 is not sufficient to stop using `activerecord-import` gem.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
