### PR TITLE
fix(SSG): RHICOMPL-3514 use the default conflict target for profiles

### DIFF
--- a/app/services/concerns/xccdf/profiles.rb
+++ b/app/services/concerns/xccdf/profiles.rb
@@ -23,11 +23,8 @@ module Xccdf
 
         # Update the fields on existing profiles, validation is not necessary
         ::Profile.import(old_profiles.values,
-                         on_duplicate_key_update: {
-                           conflict_target: %i[ref_id benchmark_id],
-                           index_predicate: 'parent_profile_id IS NULL',
-                           columns: %i[value_overrides]
-                         }, validate: false)
+                         on_duplicate_key_update: %i[value_overrides],
+                         validate: false)
       end
 
       private


### PR DESCRIPTION
The partial index on the benchmarks/ref_ids is a bit messy for the importer, so instead we can use the primary key. This should simplify the syntax according to the [docs](https://github.com/zdennis/activerecord-import/blob/master/lib/activerecord-import/import.rb#L438-L444).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
