### PR TITLE
perf(REST): RHICOMPL-3531 not load rem_issue_id with benchmarks

### DIFF
--- a/app/serializers/rule_serializer.rb
+++ b/app/serializers/rule_serializer.rb
@@ -2,8 +2,9 @@
 
 # JSON API serialization for an OpenSCAP Rule
 class RuleSerializer < ApplicationSerializer
-  attributes :ref_id, :remediation_issue_id, :title, :rationale, :description,
+  attributes :ref_id, :title, :rationale, :description,
              :severity, :slug, :values, :precedence
+  attribute :remediation_issue_id, if: proc { |_, params| [Rule, Profile].include? params[:root_resource] }
   belongs_to :benchmark
 
   has_many :profiles do |rule|


### PR DESCRIPTION
The `remediation_issue_id` is a field used for applying remediations when scoped under a profile, otherwise it does not even make sense and slows down everything as it generates N+1. Scoping it down for models where it is already available without an extra query...

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
