### PR TITLE
fix(RBAC): RHINENG-101 set the URL scheme for RBAC requests

### DIFF
--- a/config/initializers/rbac.rb
+++ b/config/initializers/rbac.rb
@@ -1,5 +1,6 @@
 RBACApiClient.configure do |config|
   config.host = Settings.rbac_url
+  config.scheme = Settings.rbac_url.split('://').first
   if Settings.platform_basic_auth_username.present?
     config.username = Settings.platform_basic_auth_username
     config.password = Settings.platform_basic_auth_password


### PR DESCRIPTION
It's a bit of hacky to get the schema from the URL, but it complies with how clowder works. Might be a future refactoring point for @RoamingNoMaD :wink: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
