### PR TITLE
fix(ValueEditing): RHICOMPL-3687 look up values based on benchmark

### DIFF
--- a/app/graphql/mutations/profile/create.rb
+++ b/app/graphql/mutations/profile/create.rb
@@ -64,7 +64,7 @@ module Mutations
         {
           account_id: context[:current_user].account_id,
           parent_profile_id: args[:clone_from_profile_id],
-          values: ::Profile.prepare_values(args[:values])
+          values: ::Profile.prepare_values(args[:values], args[:benchmark_id])
         }.compact
       end
 

--- a/app/graphql/mutations/profile/edit.rb
+++ b/app/graphql/mutations/profile/edit.rb
@@ -20,7 +20,7 @@ module Mutations
 
       def resolve(args = {})
         profile = authorized_profile(args)
-        profile.update(values: ::Profile.prepare_values(args[:values])) if args[:values]
+        profile.update(values: ::Profile.prepare_values(args[:values], profile.benchmark_id)) if args[:values]
         profile.policy.update(args.slice(*POLICY_ATTRIBUTES))
         audit_mutation(profile)
         { profile: profile }

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -77,10 +77,10 @@ class Profile < ApplicationRecord
     end
 
     # Transforming value keys from ref_id to uuid
-    def prepare_values(values)
+    def prepare_values(values, benchmark_id)
       return nil unless values
 
-      value_definitions = ValueDefinition.where(ref_id: values.keys).index_by(&:ref_id)
+      value_definitions = ValueDefinition.where(ref_id: values.keys, benchmark_id: benchmark_id).index_by(&:ref_id)
 
       raise ActiveRecord::RecordNotFound unless value_definitions.count == values.keys.count
 

--- a/test/graphql/mutations/create_profile_mutation_test.rb
+++ b/test/graphql/mutations/create_profile_mutation_test.rb
@@ -40,7 +40,7 @@ class CreateProfileMutationTest < ActiveSupport::TestCase
   end
 
   test 'provide all required arguments and values' do
-    vd = FactoryBot.create(:value_definition)
+    vd = FactoryBot.create(:value_definition, benchmark: @parent.benchmark)
     result = Schema.execute(
       QUERY,
       variables: { input: {

--- a/test/graphql/mutations/edit_policy_mutation_test.rb
+++ b/test/graphql/mutations/edit_policy_mutation_test.rb
@@ -72,7 +72,7 @@ class EditPolicyMutationTest < ActiveSupport::TestCase
   end
 
   test 'set the value overrides' do
-    vd = FactoryBot.create(:value_definition)
+    vd = FactoryBot.create(:value_definition, benchmark: @profile.benchmark)
     query = <<-GRAPHQL
         mutation updateProfile($input: UpdateProfileInput!) {
             updateProfile(input: $input) {


### PR DESCRIPTION
Multiple value definitions can have the same `ref_id`, but they are scoped uniqueness across each benchmark. By translating `ref_id` to `id` without scoping down to the `benchmark_id` the selection was non-deterministic. I tried to write tests for this case, but the tests would have been non-deterministic as well, so they won't make much sense. By passing the `benchmark_id` to the query the issue is gone.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
