### PR TITLE
fix(ci): RHCLOUD-25345 add no-cache to builds

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -6,5 +6,7 @@ source 'scripts/deploy/build-deploy-common.sh'
 
 IMAGE_NAME="${IMAGE_NAME:-quay.io/cloudservices/compliance-backend}"
 ADDITIONAL_TAGS="latest"
+REQUIRED_REGISTRIES_LOCAL=''
+DISABLE_BUILD_CACHE="true"
 
 build_deploy_main || exit 1

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -7,6 +7,5 @@ source 'scripts/deploy/build-deploy-common.sh'
 IMAGE_NAME="${IMAGE_NAME:-quay.io/cloudservices/compliance-backend}"
 ADDITIONAL_TAGS="latest"
 REQUIRED_REGISTRIES_LOCAL=''
-DISABLE_BUILD_CACHE="true"
 
 build_deploy_main || exit 1


### PR DESCRIPTION
- Adds the `DISABLE_BUILD_CACHE` to `build-deploy-common` 
- Sets the `DISABLE_BUILD_CACHE` to true to workaround: https://github.com/containers/buildah/issues/4632
- Disable requirement to log to registries on local build mode

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
