### PR TITLE
perf(GraphQL): RHICOMPL-3770 do not request rules twice in benchmarks

### DIFF
--- a/app/models/concerns/rule_tree.rb
+++ b/app/models/concerns/rule_tree.rb
@@ -10,7 +10,7 @@ module RuleTree
 
   included do
     def rule_tree(graphql = false)
-      cached_rules = rules.select(*RULE_ATTRIBUTES, :rule_group_id).group_by(&:rule_group_id)
+      cached_rules = rules.group_by(&:rule_group_id)
 
       rule_groups.arrange_serializable do |group, children|
         serialize(group, RULE_GROUP_ATTRIBUTES, graphql).merge(


### PR DESCRIPTION
When requesting both `rules` and `ruleTree` in a `benchmarkQuery`, we fired 2 SQL queries for the same things as one of them contained specific fields. With this change the first query will produce a cache hit for the second one.

```
query benchmarkQuery($id: String!) {
  benchmark(id: $id) {
    id
    osMajorVersion
    rules {
      id
      title
      severity
      rationale
      refId
      description
      remediationAvailable
      identifier
      values
      __typename
    }
    __typename
  }
}
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
