### PR TITLE
perf(GraphQL): RHICOMPL-3775 generalize the cache key for fragments

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -34,6 +34,15 @@ module Types
       def enforce_rbac(*permissions)
         @rbac_permissions = permissions
       end
+
+      # This the field to be stored in the GraphQL fragment cache with a `title/` prefix
+      # Please note that only static and context-free fields, such as SSG content can be
+      # stored in this cache and that it gets cleared upon a successful SSG import.
+      def cached_static_field(title, type, **args)
+        field(title, type, **args.merge(
+          cache_fragment: { path_cache_key: title.to_s, cache_key: :object }
+        ))
+      end
     end
 
     protected

--- a/app/graphql/types/benchmark.rb
+++ b/app/graphql/types/benchmark.rb
@@ -14,10 +14,11 @@ module Types
     field :version, String, null: false
     field :os_major_version, String, null: false
     field :latest_supported_os_minor_versions, [String], null: false
-    field :profiles, [::Types::Profile], null: true, cache_fragment: true
-    field :rules, [::Types::Rule], null: true, cache_fragment: true
-    field :value_definitions, [::Types::ValueDefinition], null: true, cache_fragment: true
-    field :rule_tree, GraphQL::Types::JSON, null: true, cache_fragment: true
+
+    cached_static_field :profiles, [::Types::Profile], null: true
+    cached_static_field :rules, [::Types::Rule], null: true
+    cached_static_field :value_definitions, [::Types::ValueDefinition], null: true
+    cached_static_field :rule_tree, GraphQL::Types::JSON, null: true
 
     enforce_rbac Rbac::COMPLIANCE_VIEWER
 


### PR DESCRIPTION
This change adjusts the cache key generation to be independent from any other top-level parents than the actual object where the cached field is specified. This means that if in a query a given benchmark is wrapped in a profile, it would still resolve to the same cache key as requesting the benchmark directly. This generalization should speed up queries even more and also reduce the load on redis as each cached field should require just one entry per benchmark.

```
query Profile($id: String!) {
  profile(id: $id) {
    benchmark {
      ruleTree
    }
  }
}
```

```
query Benchmark($id: String!) {
  benchmark(id: $id) {
    ruleTree
  }
}
```
If the profile ID queried in the first query belongs to the benchmark that is queried in the second one, the cache key would resolve in both cases to the same thing, i.e. `graphql/rule_tree/#{SCHEMA_HASH}/benchmark-#{ID}` as before this change it would contain information about the top-level object in the query, this resolving into two separate cache keys.


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
