### PR TITLE
perf(GraphQL): RHICOMPL-3846 suspend yabeda gql metrics collection

### DIFF
--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -8,7 +8,7 @@ require_relative 'types/mutation'
 # GraphQL-ruby documentation to find out what to add or
 # remove here.
 class Schema < GraphQL::Schema
-  use Yabeda::GraphQL
+  use Yabeda::GraphQL if Settings.yabeda_graphql_enable
   use GraphQL::FragmentCache
   use ComplianceTimeout, max_seconds: 20
   query Types::Query

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -198,6 +198,8 @@ objects:
               name: compliance-rails-cache
               key: db.auth_token
               optional: true
+        - name: SETTINGS__YABEDA_GRAPHQL_ENABLE
+          value: ${SETTINGS__YABEDA_GRAPHQL_ENABLE}
         - name: IMAGE_TAG
           value: "${IMAGE}:${IMAGE_TAG}"
         - name: QE_ACCOUNTS
@@ -535,6 +537,8 @@ parameters:
   value: "false"
 - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
   value: "true"
+- name: SETTINGS__YABEDA_GRAPHQL_ENABLE
+  value: "false"
 - name: FLOORIST_SUSPEND
   description: Disable Floorist cronjob execution
   required: true


### PR DESCRIPTION
It is allocating 50% of the memory and uses around the same CPU time based on my profiling results. Until we find a better alternative, we should suspent it.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
