### PR TITLE
perf(GraphQL): RHICOMPL-3849 enable fragment caching on OS#profiles

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -247,7 +247,6 @@ type Profile implements Node & RulesPreload {
   external: Boolean!
   hosts: [System!]
   id: ID!
-  inUse: Boolean
   lastScanned(
     """
     Last time this profile was scanned for a system

--- a/app/graphql/types/os_major_version.rb
+++ b/app/graphql/types/os_major_version.rb
@@ -8,7 +8,7 @@ module Types
     description 'Major version of a supported operating system'
 
     field :os_major_version, Int, null: false
-    field :profiles, [::Types::Profile], null: true
+    cached_static_field :profiles, [::Types::Profile], null: true
 
     enforce_rbac Rbac::COMPLIANCE_VIEWER
   end

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -44,7 +44,6 @@ module Types
     field :unsupported_host_count, Int, null: false
     field :external, Boolean, null: false
     field :parent_profile_id, ID, null: true
-    field :in_use, Boolean, null: true
     field :score, Float, null: false do
       argument :system_id, String,
                'Latest TestResult score for this system and profile',
@@ -95,11 +94,6 @@ module Types
 
     def benchmark
       ::CollectionLoader.for(::Profile, :benchmark).load(object)
-    end
-
-    # When listing supportedProfiles to properly mark the profile as already in use
-    def in_use
-      object.in_use if object.has_attribute?(:in_use)
     end
 
     private

--- a/app/models/os_major_version.rb
+++ b/app/models/os_major_version.rb
@@ -62,4 +62,8 @@ class OsMajorVersion < ApplicationRecord
   def os_major_version
     attributes['os_major_version']
   end
+
+  def graphql_cache_key
+    "#{self.class.model_name.cache_key}/#{os_major_version}"
+  end
 end

--- a/app/models/os_major_version.rb
+++ b/app/models/os_major_version.rb
@@ -25,7 +25,7 @@ class OsMajorVersion < ApplicationRecord
       Arel::Nodes::NamedFunction.new(
         'REPLACE',
         [
-          arel_table[:ref_id],
+          Xccdf::Benchmark.arel_table[:ref_id],
           Arel::Nodes::Quoted.new("#{Xccdf::Benchmark::REF_PREFIX}-"),
           Arel::Nodes::Quoted.new('')
         ]
@@ -33,12 +33,8 @@ class OsMajorVersion < ApplicationRecord
     ]
   ).as('os_major_version')
 
-  PROFILE_IN_USE = Arel::Nodes::True.new.as('in_use')
   PROFILE_LAST_ID = Arel.sql("(#{aggregated_cast(Profile.arel_table[:id]).to_sql})[1] as \"id\"")
-  PROFILE_BM_VERSIONS = aggregated_cast(arel_table[:version]).as('bm_versions')
-  # Rails tries to alias the JOIN on benchmarks as it wrongly detects multiple use across subqueries, in order
-  # to prevent this from happening, we're generating the join explicitly using Arel.
-  PROFILE_BM_JOIN = Profile.arel_table.join(arel_table).on(Profile.arel_table[:benchmark_id].eq(arel_table[:id]))
+  PROFILE_BM_VERSIONS = aggregated_cast(Xccdf::Benchmark.arel_table[:version]).as('bm_versions')
 
   default_scope do
     select(OS_MAJOR_VERSION, :ref_id).distinct.order(:os_major_version)
@@ -49,25 +45,14 @@ class OsMajorVersion < ApplicationRecord
                         inverse_of: false, dependent: :restrict_with_exception
 
   has_many :profiles, lambda {
-    # List the profiles in use for the current user
-    profiles_in_use = User.current.account.profiles.joins(PROFILE_BM_JOIN.join_sources)
-                          .select(arel_table[:ref_id], OS_MAJOR_VERSION, PROFILE_IN_USE)
-
-    # Canonical profiles joined with profiles in use and grouped by supported benchmark versions
     supported_profiles = canonical.where(upstream: false)
-                                  .joins(PROFILE_BM_JOIN.join_sources)
-                                  .joins("LEFT OUTER JOIN (#{profiles_in_use.to_sql}) sq ON
-                                    sq.ref_id = profiles.ref_id AND
-                                    os_major_version = sq.os_major_version")
-                                  .select(PROFILE_LAST_ID, PROFILE_BM_VERSIONS, OS_MAJOR_VERSION, 'sq.in_use')
-                                  .group(:ref_id, Xccdf::Benchmark.arel_table[:ref_id], 'in_use')
+                                  .joins(:benchmark)
+                                  .select(PROFILE_LAST_ID, PROFILE_BM_VERSIONS, OS_MAJOR_VERSION)
+                                  .group(:ref_id, 'os_major_version')
 
-    # Rails cannot consume grouped results as proper ActiveRecord classes, it has to be joined with itself
     canonical.where(upstream: false)
              .joins("INNER JOIN (#{supported_profiles.to_sql}) t ON t.id = profiles.id")
-             .select('"profiles".*, "t"."bm_versions" AS "bm_versions"',
-                     '"t"."os_major_version" AS "os_major_version"',
-                     'COALESCE("t"."in_use", FALSE) AS "in_use"')
+             .select('"profiles".*, "t"."bm_versions" AS "bm_versions", "t"."os_major_version" AS "os_major_version"')
   }, through: :benchmarks
 
   def readonly?

--- a/test/graphql/queries/os_major_version_query_test.rb
+++ b/test/graphql/queries/os_major_version_query_test.rb
@@ -16,7 +16,6 @@ class OsMajorVersionQueryTest < ActiveSupport::TestCase
                 osMajorVersion
                 profiles {
                   id
-                  inUse
                   supportedOsVersions
                 }
               }
@@ -31,10 +30,6 @@ class OsMajorVersionQueryTest < ActiveSupport::TestCase
     p2 = FactoryBot.create(:canonical_profile, upstream: false, benchmark: bm)
     p3 = FactoryBot.create(:canonical_profile, os_major_version: '8', upstream: false)
 
-    acc = FactoryBot.create(:account)
-    p1.clone_to(account: user.account, policy: FactoryBot.create(:policy, account: user.account))
-    p2.clone_to(account: acc, policy: FactoryBot.create(:policy, account: acc))
-
     SupportedSsg.expects(:by_ssg_version).times(3).returns(
       {
         bm.version => [
@@ -48,15 +43,11 @@ class OsMajorVersionQueryTest < ActiveSupport::TestCase
       }
     )
 
-    User.current = user
-
     result = Schema.execute(
       query,
       variables: {},
       context: { current_user: user }
     )
-
-    User.current = nil
 
     edges = result['data']['osMajorVersions']['edges']
     major_versions = edges.each_with_object({}) do |g, obj|
@@ -73,16 +64,9 @@ class OsMajorVersionQueryTest < ActiveSupport::TestCase
       end
     end
 
-    in_use = edges.each_with_object([]) do |g, obj|
-      g['node']['profiles'].each do |p|
-        obj << p['id'] if p['inUse']
-      end
-    end
-
     assert_same_elements [7, 8], major_versions.keys
     assert_same_elements [p1.id, p2.id], major_versions[7]
     assert_equal [p3.id], major_versions[8]
-    assert_equal [p1.id], in_use
 
     assert_equal minor_versions[p1.id], ['7.2', '7.1']
     assert_equal minor_versions[p2.id], ['7.2', '7.1']

--- a/test/models/os_major_version_test.rb
+++ b/test/models/os_major_version_test.rb
@@ -5,8 +5,6 @@ require 'test_helper'
 class OsMajorVersionTest < ActiveSupport::TestCase
   context 'supported_profiles' do
     should 'list all supported profiles' do
-      User.current = FactoryBot.create(:user)
-
       supported_ssg1 = SupportedSsg.new(version: '0.1.50',
                                         os_major_version: '7', os_minor_version: '1')
       supported_ssg2 = SupportedSsg.new(version: '0.1.51',
@@ -41,8 +39,6 @@ class OsMajorVersionTest < ActiveSupport::TestCase
       assert_includes(result, p1)
       assert_includes(result, p2)
       assert_not_includes(result, p3)
-
-      User.current = nil
     end
   end
 


### PR DESCRIPTION
This needed to revert the `inUse` field from the schema, which was never actually consumed by the frontend.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
