### PR TITLE
fix(Grafana): RHICOMPL-3847 measure GQL operation durations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ gem 'yabeda'
 gem 'yabeda-puma-plugin'
 gem 'yabeda-rails'
 gem 'yabeda-sidekiq'
-gem 'yabeda-graphql'
 gem 'yabeda-prometheus-mmap'
 
 # Nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,9 +440,6 @@ GEM
       anyway_config (>= 1.0, < 3)
       concurrent-ruby
       dry-initializer
-    yabeda-graphql (0.2.3)
-      graphql (>= 1.9, < 3)
-      yabeda (~> 0.2)
     yabeda-prometheus-mmap (0.3.0)
       prometheus-client-mmap
       yabeda (~> 0.10)
@@ -534,7 +531,6 @@ DEPENDENCIES
   webrick
   will_paginate
   yabeda
-  yabeda-graphql
   yabeda-prometheus-mmap
   yabeda-puma-plugin
   yabeda-rails

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -25,7 +25,7 @@ class GraphqlController < ApplicationController
 
   # Very primitive way to determine the first occurence of an operation name after
   # a query or a mutation. This does not work with multiplex queries, but as long
-  # as we don't use them in our codebase, it is fine.
+  # as the first operation names describe the rest, it should be fine.
   def parse_gql_op
     params[:query]&.match(QUERY_RE).try(:[], 1)
   end

--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -8,7 +8,6 @@ require_relative 'types/mutation'
 # GraphQL-ruby documentation to find out what to add or
 # remove here.
 class Schema < GraphQL::Schema
-  use Yabeda::GraphQL if Settings.yabeda_graphql_enable
   use GraphQL::FragmentCache
   use ComplianceTimeout, max_seconds: 20
   query Types::Query

--- a/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
+++ b/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
@@ -1491,22 +1491,22 @@ objects:
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "histogram_quantile(0.5, sum(rate(graphql_field_resolve_runtime_seconds_bucket{application=\"compliance\"}[$interval])) by (type,field,le))/$qe",
+                "expr": "histogram_quantile(0.5, sum(rate(rails_request_duration_seconds_bucket{application=\"compliance\",gql_op!=\"\"}[$interval])) by (gql_op,le))/$qe",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 10,
-                "legendFormat": "{{type}}.{{field}}",
+                "legendFormat": "{{gql_op}}",
                 "refId": "Total"
               },
               {
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "histogram_quantile(0.5, sum(rate(graphql_field_resolve_runtime_seconds_bucket{application=\"compliance\",qe!=\"1\"}[$interval])) by (type,field,le))/(-($qe - 1))",
+                "expr": "histogram_quantile(0.5, sum(rate(rails_request_duration_seconds_bucket{application=\"compliance\",gql_op!=\"\",qe!=\"1\"}[$interval])) by (gql_op,le))/(-($qe - 1))",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 10,
-                "legendFormat": "{{type}}.{{field}}",
+                "legendFormat": "{{gql_op}}",
                 "refId": "Excluding QE"
               }
             ],
@@ -1597,22 +1597,22 @@ objects:
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "histogram_quantile(0.99, sum(rate(graphql_field_resolve_runtime_seconds_bucket{application=\"compliance\"}[$interval])) by (type,field,le))/$qe",
+                "expr": "histogram_quantile(0.99, sum(rate(rails_request_duration_seconds_bucket{application=\"compliance\",gql_op!=\"\"}[$interval])) by (gql_op,le))/$qe",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 10,
-                "legendFormat": "{{type}}.{{field}}",
+                "legendFormat": "{{gql_op}}",
                 "refId": "Total"
               },
               {
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "histogram_quantile(0.99, sum(rate(graphql_field_resolve_runtime_seconds_bucket{application=\"compliance\",qe!=\"1\"}[$interval])) by (type,field,le))/(-($qe - 1))",
+                "expr": "histogram_quantile(0.99, sum(rate(rails_request_duration_seconds_bucket{application=\"compliance\",gql_op!=\"\",qe!=\"1\"}[$interval])) by (gql_op,le))/(-($qe - 1))",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 10,
-                "legendFormat": "{{type}}.{{field}}",
+                "legendFormat": "{{gql_op}}",
                 "refId": "Excluding QE"
               }
             ],
@@ -4464,7 +4464,7 @@ objects:
         "timezone": "",
         "title": "Compliance",
         "uid": "compliance",
-        "version": 11,
+        "version": 12,
         "weekStart": ""
       }
   kind: ConfigMap

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -198,8 +198,6 @@ objects:
               name: compliance-rails-cache
               key: db.auth_token
               optional: true
-        - name: SETTINGS__YABEDA_GRAPHQL_ENABLE
-          value: ${SETTINGS__YABEDA_GRAPHQL_ENABLE}
         - name: IMAGE_TAG
           value: "${IMAGE}:${IMAGE_TAG}"
         - name: QE_ACCOUNTS
@@ -537,8 +535,6 @@ parameters:
   value: "false"
 - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
   value: "true"
-- name: SETTINGS__YABEDA_GRAPHQL_ENABLE
-  value: "false"
 - name: FLOORIST_SUSPEND
   description: Disable Floorist cronjob execution
   required: true


### PR DESCRIPTION
Replacing the GraphQL field resolve histogram with a simple request duration one combined with the GQL operation name that comes from the top-level query naming itself.

**Before:**
![image](https://github.com/RedHatInsights/compliance-backend/assets/649130/e337e4d8-851c-4411-a880-e528dac26021)


**After:**
![image](https://github.com/RedHatInsights/compliance-backend/assets/649130/7a0ce5be-a2b8-49ec-853a-0be4a35369e8)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
