### PR TITLE
perf(GraphQL): RHICOMPL-3848 do not use the fragment caching tracer

### DIFF
--- a/app/graphql/schema.rb
+++ b/app/graphql/schema.rb
@@ -8,7 +8,14 @@ require_relative 'types/mutation'
 # GraphQL-ruby documentation to find out what to add or
 # remove here.
 class Schema < GraphQL::Schema
+  # Fragment cache uses a legacy tracer for detecting connection fields and raising an
+  # exceptions if they are not used in conjunction with pagination connections. As we
+  # implemented our own pagination mechanism, this feature is not really necessary for
+  # our case. Furthermore, legacy tracing is more wasteful with memory allocations and
+  # so turning it off actually can make our application more efficient.
   use GraphQL::FragmentCache
+  @own_tracers = @trace_modes = nil
+
   use ComplianceTimeout, max_seconds: 20
   query Types::Query
   mutation Types::Mutation


### PR DESCRIPTION
The `graphql-fragment-cache` gem uses a [tracer](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/blob/master/lib/graphql/fragment_cache/schema/tracer.rb) that is only used to raise an error when dealing with connection fields. As we implement our own pagination, we do not relay on this feature. Furthermore, the tracer is using the legacy tracing API, which involves a lot of extra memory usage. Therefore, turning it off should result in better performance.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
