### PR TITLE
fix(REST): RHICOMPL-3463 fail on passing invalid format to search

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -47,6 +47,7 @@ module ErrorHandling
       ::Exceptions::InvalidSortingDirection,
       ::Exceptions::InvalidSortingColumn,
       ::Exceptions::InvalidTagEncoding,
+      PG::InvalidTextRepresentation,
       RangeError
     ]
 


### PR DESCRIPTION
When passing `id = 'string'` to a query, it should fail as an invalid param.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
