### PR TITLE
feat(devel): periodically update .ruby-version based on the package

### DIFF
--- a/.github/workflows/ruby-update.yml
+++ b/.github/workflows/ruby-update.yml
@@ -1,0 +1,28 @@
+name: Regular base image update check
+on:
+  schedule:
+    - cron: "5 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Extract the version of ruby
+        run: |
+          base=$(grep -Po '(?<=FROM )([^\s]*)(?= AS build)' Dockerfile)
+          docker run --rm -u 0 "${base}":latest sh -c "
+            microdnf module enable ruby:3.1 > /dev/null;
+            microdnf repoquery ruby --info | grep Version | awk '{ print \$3 }' | head -1 > .ruby-version;
+            cat .ruby-version" > .ruby-version
+      - name: Do change if the digest changed
+        run: |
+          git config user.name 'Update-a-Bot'
+          git config user.email 'insights@redhat.com'
+          git add .ruby-version
+          git commit -m "chore(devel): update .ruby-version" || echo "No new changes"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'chore(devel): update .ruby-version'


### PR DESCRIPTION
I created a cronjob GH action that goes into our base container and tries to assess the version of Ruby to be installed. Then changes the version in the `.ruby-version` file itself and creates a PR. This has no effect in production, but should force our development environments (rbenv, rvm, etc) to run on the same version as the container :wink: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
