### PR TITLE
perf(build): RHICOMPL-3875 do not install docs with rubygems update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN FULL_RHEL=$(microdnf repolist --enabled | grep rhel-8);                     
     microdnf module enable postgresql:13                                        && \
     microdnf install --nodocs -y $deps $devDeps $extras                         && \
     chmod +t /tmp                                                               && \
-    gem update --system --install-dir=/usr/share/gems --bindir /usr/bin         && \
+    gem update --system -N --install-dir=/usr/share/gems --bindir /usr/bin      && \
     gem install bundler                                                         && \
     ( [[ $prod != "true" ]] || bundle config set --without 'development:test' ) && \
     ( [[ $prod != "true" ]] || bundle config set --local deployment 'true' )    && \
@@ -54,13 +54,13 @@ WORKDIR /opt/app-root/src
 
 USER 0
 
-RUN rpm -e --nodeps tzdata &>/dev/null                                  && \
-    microdnf module enable ruby:3.1                                     && \
-    microdnf install --nodocs -y $deps                                  && \
-    chmod +t /tmp                                                       && \
-    gem update --system --install-dir=/usr/share/gems --bindir /usr/bin && \
-    microdnf clean all -y                                               && \
-    chown 1001:root ./                                                  && \
+RUN rpm -e --nodeps tzdata &>/dev/null                                     && \
+    microdnf module enable ruby:3.1                                        && \
+    microdnf install --nodocs -y $deps                                     && \
+    chmod +t /tmp                                                          && \
+    gem update --system -N --install-dir=/usr/share/gems --bindir /usr/bin && \
+    microdnf clean all -y                                                  && \
+    chown 1001:root ./                                                     && \
     install -v -d -m 1777 -o 1001 ./tmp ./log
 
 USER 1001


### PR DESCRIPTION
Installing ri documentation for any gem is disabled during container buildtime, however, when running `gem update --system -V` I noticed that there is some documentation being generated that takes 1-2 minutes. This is something we don't really need.

**Before:**
```
podman build .  246.24s user 74.36s system 114% cpu 4:39.88 total
```
**After:**
```
podman build .  246.31s user 69.35s system 142% cpu 3:40.77 total
```

This should make the CI build ~~a little bit~~ significantly faster :zap: :racehorse: from 7:22 to 3:49 :racehorse: :zap: 


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
