### PR TITLE
perf(CI): RHICOMPL-3878 enable caching of yum packages between stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Build using podman-compose
       run: podman-compose build
     - name: Build using docker-compose
-      run: docker-compose build
+      run: DOCKER_BUILDKIT=1 docker-compose build
   unit-tests:
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
The `RUN` command in the `Dockerfile` suppors a two-way overlayed [cache mount](https://docs.docker.com/build/guide/mounts/), i.e. all changes are stored both inside the container and outside the file after the build finishes. In our case this can be utilized to speed up the installation process of the packages in `$deps`  for the second stage. The first stage is explicitly configured to store RPMs and other metadata under `/var/cache/yum` and doesn't clear the cache upon a successful build. By mounting the same cache for the second stage, there are zero packages downloaded when installing. The `microdnf clean all` command at the end of the second stage clears both the container's and the host's cache, so the container size remains small and the host will not leak cached RPMs to other test runs.

The whole build process is ~20 seconds faster:
```
# Before
podman build .  257.70s user 71.00s system 132% cpu 4:08.86 total
# After
podman build .  237.44s user 67.19s system 134% cpu 3:45.85 total
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
