### PR TITLE
cleanup(Gemfile): reorganize dev/test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,41 +91,45 @@ gem 'cgi'
 gem 'rexml'
 gem 'webrick'
 
-# Allows for tree structures in db 
+# Allows for tree structures in db
 gem 'ancestry'
 
 group :development, :test do
+  gem 'silent_stream' # drop
+end
+
+group :development do
   gem 'awesome_print', require: false
-  gem 'brakeman'
+  gem 'bullet'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'dotenv-rails'
+  gem 'graphiql-rails'
+  gem 'irb', '>= 1.2'
+  gem 'listen', '>= 3.0.5'
+  gem 'pry-byebug'
+  gem 'pry-rails'
+  gem 'pry-remote'
+  gem 'spring'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :test do
+  gem 'brakeman'
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'faker'
-  gem 'irb', '>= 1.2'
   gem 'minitest-reporters'
   gem 'minitest-stub-const'
   gem 'mocha'
-  gem 'pry-byebug'
-  gem 'pry-remote'
   gem 'rspec-rails'
   gem 'rswag-specs'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'shoulda-context'
   gem 'shoulda-matchers'
-  gem 'silent_stream'
   gem 'simplecov'
   gem 'simplecov-cobertura', require: false
   gem 'webmock'
-end
-
-group :development do
-  gem 'graphiql-rails'
-  gem 'bullet'
-  gem 'listen', '>= 3.0.5'
-  gem 'pry-rails'
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -94,10 +94,6 @@ gem 'webrick'
 # Allows for tree structures in db
 gem 'ancestry'
 
-group :development, :test do
-  gem 'silent_stream' # drop
-end
-
 group :development do
   gem 'awesome_print', require: false
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,6 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.5.0)
-    silent_stream (1.0.6)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -518,7 +517,6 @@ DEPENDENCIES
   shoulda-context
   shoulda-matchers
   sidekiq (< 8)
-  silent_stream
   simplecov
   simplecov-cobertura
   slack-notifier


### PR DESCRIPTION
Should install less gems when running unit tests during the Jenkins pipeline :zap: 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
