### PR TITLE
fix(Dockerfile): force ruby platform for nokogiri in bundle config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN FULL_RHEL=$(microdnf repolist --enabled | grep rhel-8);                     
     ( [[ $prod != "true" ]] || bundle config set --local deployment 'true' )            && \
     ( [[ $prod != "true" ]] || bundle config set --local path './.bundle' )             && \
     bundle config set --local retry '2'                                                 && \
+    bundle config set --local force_ruby_platform true                                  && \
     ( [[ $prod != "true" ]] || bundle install --without development test )              && \
     ( [[ $prod == "true" ]] || bundle install )                                         && \
     microdnf clean all -y                                                               && \


### PR DESCRIPTION
Nokogiri tries to install itself on aarch64 builds (when running docker on apple silicon) and it fails with an older version of glibc. Therefore, we have to force the local compilation even stronger by setting it into the bundle config.

@marleystipich2 @romanblanco @RoamingNoMaD please test this on your setup after clearing the environment

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
