### PR TITLE
dev(compose): use single-node kafka without zookeeper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,26 @@
 # This docker-compose file will stand up the entire stack including ingress and inventory.
 version: "3"
 services:
-  zookeeper:
-    image: quay.io/cloudservices/cp-zookeeper
-    environment:
-      - ZOOKEEPER_CLIENT_PORT=32181
-      - ZOOKEEPER_SERVER_ID=1
-      - KAFKA_OPTS=-Dzookeeper.admin.enableServer=false
   kafka:
-    image: quay.io/cloudservices/cp-kafka
+    image: docker.io/confluentinc/cp-kafka
     ports:
       - 29092:29092
-    depends_on:
-      - zookeeper
-    links:
-      - zookeeper
     environment:
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092
-      - KAFKA_BROKER_ID=1
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
+      KAFKA_LISTENERS: 'PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      CLUSTER_ID: OTQ3MmM2NDRhNjg3NDZhOG
   createtopics:
-    image: quay.io/cloudservices/cp-kafka
+    image: docker.io/confluentinc/cp-kafka
     volumes:
       - ./xjoin-config:/xjoin-config:Z
     depends_on:


### PR DESCRIPTION
The latest version of kafka support KRaft mode which allows it to operate in single node without requiring zookeeper. This should simplify our developer setup and reduce the use of resources.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
