### PR TITLE
feat(V2::Parameters): RHICOMPL-3891 allow params for nested routes

### DIFF
--- a/app/controllers/concerns/v2/parameters.rb
+++ b/app/controllers/concerns/v2/parameters.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module V2
+  # Reusable parameter checking for all controllers
+  module Parameters
+    extend ActiveSupport::Concern
+
+    # Constraint validating model classes passed via params[:parents]
+    class ModelConstraint < StrongerParameters::Constraint
+      def value(val)
+        return val if val.is_a?(Class) && val < ::ApplicationRecord
+
+        StrongerParameters::InvalidValue.new(val, 'is not permitted')
+      end
+    end
+
+    # Constraint validating UUIDs passed via params[:*_id]
+    class UUIDConstraint < StrongerParameters::Constraint
+      def value(val)
+        return val if UUID.validate(val)
+
+        StrongerParameters::InvalidValue.new(val, 'is not permitted')
+      end
+    end
+
+    ParamType = ActionController::Parameters # shorthand
+    ParamType.action_on_unpermitted_parameters = :raise # fail on unpermitted params
+
+    DEFAULT_PERMITTED = StrongerParameters::ControllerSupport::PermittedParameters::DEFAULT_PERMITTED.merge(
+      _json: ParamType.nil,
+      # The list of parents should come from the routed resource definition as an
+      # array of ActiveRecord objects. The custom constraint prevents passing this
+      # param as a regular parameter as it is not possible to pass Ruby classes as
+      # HTTP parameters.
+      parents: ParamType.array(ModelConstraint.new)
+    )
+
+    class_methods do
+      attr_accessor :__permitted_params_for_action
+
+      private
+
+      # Configuring a list of permitted params for a given controller action
+      def permitted_params_for_action(action, params)
+        self.__permitted_params_for_action ||= {}
+        self.__permitted_params_for_action[action] = params
+      end
+    end
+
+    included do
+      permitted_params_for_action :index, {
+        limit: ParamType.integer & ParamType.gt(0) & ParamType.lte(100),
+        offset: ParamType.integer & ParamType.gt(0),
+        sort_by: ParamType.array(ParamType.string) | ParamType.string,
+        self::SEARCH => ParamType.string
+      }
+
+      permitted_params_for_action :show, id: ParamType.string
+
+      # FIXME: compatibility with the V1 logic from the common concerns
+      def relationships_enabled?
+        false
+      end
+
+      # FIXME: compatibility with the V1 logic from the common concerns
+      def include_params
+        false
+      end
+
+      # Use the params[:parents] configured by the route to construct a permit
+      # hash containing each ID passed from the parents of a nested resource.
+      def permit_parent_ids
+        params[:parents]&.each_with_object({}) do |parent, obj|
+          next unless parent.is_a?(Class)
+
+          field = [parent.name.demodulize.underscore, :id].join('_')
+          obj[field] = UUIDConstraint.new
+        end || {}
+      end
+
+      def permitted_params
+        @permitted_params ||= begin
+          action_params = self.class.__permitted_params_for_action.try(:[], action_name.to_sym) || {}
+          parent_params = ::ApplicationController.__permitted_params_for_action.try(:[], action_name.to_sym) || {}
+
+          # Merge all permit hashes to a single one using reduce and allow them through
+          params.permit([action_params, parent_params, permit_parent_ids, DEFAULT_PERMITTED].reduce(&:merge))
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/v2/application_controller.rb
+++ b/app/controllers/v2/application_controller.rb
@@ -13,7 +13,7 @@ module V2
     include ::Pagination
     include ::Collection
     include ::Rendering
-    include ::Parameters
+    include V2::Parameters
     include ::ErrorHandling
 
     before_action :set_csp_hsts

--- a/spec/controllers/v2/concerns/parameters_spec.rb
+++ b/spec/controllers/v2/concerns/parameters_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe V2::Parameters do
+  let(:subject) do
+    Struct.new(:action_name, :params) do |cls|
+      cls::SEARCH = :search # FIXME: delete this after V1 is retired
+      include V2::Parameters
+    end.new
+  end
+
+  describe '#permitted_params' do
+    before do
+      subject.action_name = action
+      subject.params = ActionController::Parameters.new(params)
+    end
+
+    shared_examples 'stronger parameter handling' do
+      context 'params is empty' do
+        let(:params) { {} }
+
+        it 'returns with params' do
+          expect(subject.permitted_params).to match(hash_including(params))
+        end
+      end
+
+      context 'params[:parents] coming from a request' do
+        let(:params) { { parents: ['FooBar'] } }
+
+        it 'raises an exception' do
+          expect { subject.permitted_params }.to raise_error(StrongerParameters::InvalidParameter)
+        end
+      end
+
+      context 'params[:parents] coming from a route' do
+        let(:params) { { parents: [V2::SecurityGuide] } }
+
+        it 'returns with params' do
+          expect(subject.permitted_params).to match(hash_including(params))
+        end
+      end
+
+      context 'non-UUID parent ID passed with params[:parents]' do
+        let(:params) { { parents: [V2::SecurityGuide], security_guide_id: '123456' } }
+
+        it 'raises an exception' do
+          expect { subject.permitted_params }.to raise_error(StrongerParameters::InvalidParameter)
+        end
+      end
+
+      context 'valid parent ID passed with params[:parents]' do
+        let(:params) { { parents: [V2::SecurityGuide], security_guide_id: Faker::Internet.uuid } }
+
+        it 'raises an exception' do
+          expect(subject.permitted_params).to match(hash_including(params))
+        end
+      end
+    end
+
+    context 'index' do
+      let(:action) { :index }
+
+      context 'valid params[:id]' do
+        let(:params) { { id: Faker::Internet.uuid } }
+
+        it 'raises an exception' do
+          expect { subject.permitted_params }.to raise_error(ActionController::UnpermittedParameters)
+        end
+      end
+
+      include_examples 'stronger parameter handling'
+    end
+
+    context 'show' do
+      let(:action) { :show }
+
+      context 'valid params[:id]' do
+        let(:params) { { id: Faker::Internet.uuid } }
+
+        it 'returns with params' do
+          expect(subject.permitted_params).to match(hash_including(params))
+        end
+      end
+
+      include_examples 'stronger parameter handling'
+    end
+  end
+end


### PR DESCRIPTION
I am splitting out the parameter handling for APIv2 as we need to have different behavior for nested routes and I don't want to allow these parameters in APIv1. Rails routes allows the specification of custom parameters for resources, which I am planning to use for setting up a list of parent models in a nested resource scenario:
```ruby
resources :security_guides do
  resources :profiles, parents: [SecurityGuide] do
    resources :rules, parents: [SecurityGuide, Profile]
  end
end
```
This list of parents will be useful for many other scenarios, but for now we will stick to using them for parameter validation only. The `StrongerParameters` gem that we use for parameter validation does not like the implicit parameters (`profile_id` and `security_guide_id` in case of the example above) of parent resources. Therefore, I adjusted the parameter validation to incorporate both the `parents` parameter coming from the router and all the possible `_id` parameters generated from these parents.

As we have no nested controllers yet, tests for this feature will arrive later...

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
