### PR TITLE
feat(RSpec): helper wrapper for nested route `params[:parents]` mocking

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,18 @@ def stub_rbac_permissions(*arr, **hsh)
 end
 # rubocop:enable Metrics/MethodLength
 
+def nested_route(*parents)
+  # Mock the .to_s method on each parent in the array to avoid RSpec converting it
+  parents.each { |parent| allow(parent).to receive(:to_s).and_return(parent) }
+
+  yield(parents)
+ensure # Make sure that the mock is just for the time of the HTTP request
+  parents.each do |parent|
+    klass = RSpec::Mocks.space.proxy_for(parent)
+    klass.instance_variable_get(:@method_doubles)[:to_s].reset
+  end
+end
+
 def response_body_data
   response.parsed_body['data']
 end


### PR DESCRIPTION
RSpec automatically coerces all passed params to string by calling the `to_s` method on them. This is unfortunate as we are using route-level parameters to determine the nesting of a given route. To avoid this, I created a wrapper that can temporarily mock the `.to_s` method on a given list of parent classes that would be passed as a route-level parameter. After the request is called, the mocks are reset back to normal so there should be no side effects. The method yields a list of mocked parents that can be passed with the `params` in the block:

```ruby
nested(Model1, Model2) do |parents|
  get :index, params: { model_1_id: 1, model_2_id: 2, parents: parents }
end
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
