### PR TITLE
fix(RBAC): RHICOMPL-3850 replace attributeFilter with attribute_filter

### DIFF
--- a/app/services/rbac.rb
+++ b/app/services/rbac.rb
@@ -39,13 +39,13 @@ class Rbac
       permissions.each_with_object([]) do |permission, ids|
         next unless verify(permission.permission, INVENTORY_HOSTS_READ)
         # Empty array on 'resource_definitions' symbolizes a global access to the permitted resource.
-        # In such case, the method returns Rbac::ANY and skips parsing of attributeFilter.
+        # In such case, the method returns Rbac::ANY and skips parsing of attribute_filter.
         return ANY if permission.resource_definitions == []
 
         permission.resource_definitions.each do |filter|
-          next unless valid_inventory_groups_definition?(filter[:attributeFilter])
+          next unless valid_inventory_groups_definition?(filter[:attribute_filter])
 
-          ids.append(*inventory_groups_definition_value(filter[:attributeFilter]))
+          ids.append(*inventory_groups_definition_value(filter[:attribute_filter]))
         end
       end
     end

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -1138,7 +1138,7 @@ module V1
 
         allowed_groups = hosts[0..1].map { |h| h.groups.first['id'] }
         stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                                attributeFilter: {
+                                attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
                                   value: allowed_groups
@@ -1383,7 +1383,7 @@ module V1
         stub_supported_ssg(hosts, [@profile.benchmark.version])
         allowed_groups = hosts[0..1].map { |h| h.groups.first['id'] }
         stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                                attributeFilter: {
+                                attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
                                   value: allowed_groups
@@ -1440,7 +1440,7 @@ module V1
         stub_supported_ssg(hosts, [@profile.benchmark.version])
         allowed_groups = hosts[0..1].map { |h| h.groups.first['id'] }
         stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                                attributeFilter: {
+                                attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
                                   value: allowed_groups

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -33,7 +33,7 @@ module V1
         allowed_groups = [@host1.groups.first['id'], nil]
 
         stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                                attributeFilter: {
+                                attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
                                   value: allowed_groups

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -90,7 +90,7 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
 
     allowed_groups = hosts[0..1].map { |h| h.groups.first['id'] }
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                            attributeFilter: {
+                            attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
                               value: allowed_groups

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -367,7 +367,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
 
     allowed_groups = hosts[0..1].map { |h| h.groups.first['id'] }
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                            attributeFilter: {
+                            attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
                               value: allowed_groups

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -70,7 +70,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     @host1.update(groups: [{ id: 1234 }])
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                            attributeFilter: {
+                            attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
                               value: [1234]
@@ -97,7 +97,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     @host1.update(groups: [{ id: 1234 }])
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                            attributeFilter: {
+                            attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
                               value: [4321]
@@ -124,7 +124,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     @host1.update(groups: [])
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                            attributeFilter: {
+                            attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
                               value: [nil]
@@ -151,7 +151,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     @host1.update(groups: [])
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                            attributeFilter: {
+                            attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
                               value: [1234]
@@ -182,7 +182,7 @@ class SystemQueryTest < ActiveSupport::TestCase
 
     @host1.update(groups: [])
     stub_rbac_permissions(Rbac::COMPLIANCE_ADMIN, Rbac::INVENTORY_HOSTS_READ => [{
-                            attributeFilter: {
+                            attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
                               value: [1234, 2345]

--- a/test/policies/host_policy_test.rb
+++ b/test/policies/host_policy_test.rb
@@ -23,7 +23,7 @@ class HostPolicyTest < ActiveSupport::TestCase
 
     stub_rbac_permissions(
       Rbac::INVENTORY_HOSTS_READ => [{
-        attributeFilter: {
+        attribute_filter: {
           key: 'group.id',
           operation: 'in',
           value: [own_host_in_group.groups.first['id'], nil]

--- a/test/policies/policy_host_policy_test.rb
+++ b/test/policies/policy_host_policy_test.rb
@@ -27,7 +27,7 @@ class PolicyHostPolicyTest < ActiveSupport::TestCase
 
     stub_rbac_permissions(
       Rbac::INVENTORY_HOSTS_READ => [{
-        attributeFilter: {
+        attribute_filter: {
           key: 'group.id',
           operation: 'in',
           value: [own_host_in_group.groups.first['id'], nil]

--- a/test/services/rbac_test.rb
+++ b/test/services/rbac_test.rb
@@ -32,7 +32,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: %w[
                   78e3dc30-cec3-4b49-be2d-37482c74a9ac
@@ -47,7 +47,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: [
                   nil # ungrouped hosts
@@ -61,7 +61,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: 'inventory:groups:write', # entry with unverified permission is ignored
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: %w[
                   77e3dc30-cec3-4b49-be2d-37482c74a9ac
@@ -76,7 +76,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: '80e3dc30-cec3-4b49-be2d-37482c74a9ad',
                 operation: 'equal' # 'equal' is not a supported operation
@@ -88,7 +88,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'foo.id', # entry with unverified key is ignored
                 value: ['77e3dc30-cec3-4b49-be2d-37482c74a9ac'],
                 operation: 'in'
@@ -115,7 +115,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: %w[
                   78e3dc30-cec3-4b49-be2d-37482c74a9ac
@@ -137,7 +137,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: 'inventory:hosts:*', # inventory:hosts:*
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: %w[
                   78e3dc30-cec3-4b49-be2d-37482c74a9ad
@@ -158,7 +158,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: 'inventory:groups:write', # entry with unverified permission is ignored
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: %w[
                   77e3dc30-cec3-4b49-be2d-37482c74a9ac
@@ -173,7 +173,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'foo.id', # entry with unverified key is ignored
                 value: ['77e3dc30-cec3-4b49-be2d-37482c74a9ac'],
                 operation: 'in'
@@ -192,7 +192,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: 'inventory:hosts:*', # inventory:hosts:*
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: nil,
                 operation: 'in'
@@ -204,7 +204,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: nil, # nil
                 operation: 'equal'
@@ -216,7 +216,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: nil, # nil
                 operation: 'in'
@@ -228,7 +228,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: [], # []
                 operation: 'in'
@@ -240,7 +240,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: [nil],
                 operation: 'equal' # equal
@@ -252,7 +252,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: [nil],
                 operation: 'between' # between
@@ -264,7 +264,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'groups.id', # groups.id
                 value: 'not supported',
                 operation: 'in'
@@ -276,7 +276,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'groups.id', # groups.id
                 value: 'some-id',
                 operation: 'equal' # equal
@@ -295,7 +295,7 @@ class RbacTest < ActiveSupport::TestCase
           permission: Rbac::INVENTORY_HOSTS_READ,
           resource_definitions: [
             {
-              attributeFilter: {
+              attribute_filter: {
                 key: 'group.id',
                 value: [nil, '80e3dc30-cec3-4b49-be2d-37482c74a9ad'],
                 operation: 'in'


### PR DESCRIPTION
This was incorrectly coded, the `attributeFilter` coming from the RBAC API is converted to [`attribute_filter`](https://github.com/RedHatInsights/insights-rbac-api-client-ruby/blob/7a4462db8cb6eed30991f97aa298dcea03cbf034/docs/ResourceDefinition.md?plain=1#L7).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
