### PR TITLE
fix(RBAC): RHICOMPL-3850 compensate JSON parsing on RD.values

### DIFF
--- a/app/services/rbac.rb
+++ b/app/services/rbac.rb
@@ -73,7 +73,8 @@ class Rbac
     end
 
     def valid_inventory_groups_definition?(definition)
-      definition.value.instance_of?(Array) &&
+      # FIXME: JSON.parse needs to be moved to the RBAC API client
+      JSON.parse(definition.value).instance_of?(Array) &&
         definition.operation == 'in' &&
         definition.key == 'group.id'
     end
@@ -81,7 +82,8 @@ class Rbac
     def inventory_groups_definition_value(definition)
       # Received '[nil]' symbolizes access to ungrouped entries.
       # In output represtented with an empty array.
-      definition.value.map { |dv| dv || [] }
+      # FIXME: JSON.parse needs to be moved to the RBAC API client
+      JSON.parse(definition.value).map { |dv| dv || [] }
     end
   end
 end

--- a/test/controllers/v1/profiles_controller_test.rb
+++ b/test/controllers/v1/profiles_controller_test.rb
@@ -1141,7 +1141,7 @@ module V1
                                 attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
-                                  value: allowed_groups
+                                  value: allowed_groups.to_json
                                 }
                               }])
 
@@ -1386,7 +1386,7 @@ module V1
                                 attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
-                                  value: allowed_groups
+                                  value: allowed_groups.to_json
                                 }
                               }])
         @profile.policy.update!(hosts: hosts[1..3])
@@ -1443,7 +1443,7 @@ module V1
                                 attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
-                                  value: allowed_groups
+                                  value: allowed_groups.to_json
                                 }
                               }])
         @profile.policy.update!(hosts: hosts[0..3])

--- a/test/controllers/v1/systems_controller_test.rb
+++ b/test/controllers/v1/systems_controller_test.rb
@@ -36,7 +36,7 @@ module V1
                                 attribute_filter: {
                                   key: 'group.id',
                                   operation: 'in',
-                                  value: allowed_groups
+                                  value: allowed_groups.to_json
                                 }
                               }])
 

--- a/test/graphql/mutations/associate_systems_test.rb
+++ b/test/graphql/mutations/associate_systems_test.rb
@@ -93,7 +93,7 @@ class AssociateSystemsMutationTest < ActiveSupport::TestCase
                             attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
-                              value: allowed_groups
+                              value: allowed_groups.to_json
                             }
                           }])
 

--- a/test/graphql/queries/system_query_test.rb
+++ b/test/graphql/queries/system_query_test.rb
@@ -73,7 +73,7 @@ class SystemQueryTest < ActiveSupport::TestCase
                             attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
-                              value: [1234]
+                              value: [1234].to_json
                             }
                           }])
 
@@ -100,7 +100,7 @@ class SystemQueryTest < ActiveSupport::TestCase
                             attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
-                              value: [4321]
+                              value: [4321].to_json
                             }
                           }])
 
@@ -127,7 +127,7 @@ class SystemQueryTest < ActiveSupport::TestCase
                             attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
-                              value: [nil]
+                              value: [nil].to_json
                             }
                           }])
 
@@ -154,7 +154,7 @@ class SystemQueryTest < ActiveSupport::TestCase
                             attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
-                              value: [1234]
+                              value: [1234].to_json
                             }
                           }])
 
@@ -185,7 +185,7 @@ class SystemQueryTest < ActiveSupport::TestCase
                             attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
-                              value: [1234, 2345]
+                              value: [1234, 2345].to_json
                             }
                           }])
 

--- a/test/policies/host_policy_test.rb
+++ b/test/policies/host_policy_test.rb
@@ -26,7 +26,7 @@ class HostPolicyTest < ActiveSupport::TestCase
         attribute_filter: {
           key: 'group.id',
           operation: 'in',
-          value: [own_host_in_group.groups.first['id'], nil]
+          value: [own_host_in_group.groups.first['id'], nil].to_json
         }
       }]
     )

--- a/test/policies/policy_host_policy_test.rb
+++ b/test/policies/policy_host_policy_test.rb
@@ -30,7 +30,7 @@ class PolicyHostPolicyTest < ActiveSupport::TestCase
         attribute_filter: {
           key: 'group.id',
           operation: 'in',
-          value: [own_host_in_group.groups.first['id'], nil]
+          value: [own_host_in_group.groups.first['id'], nil].to_json
         }
       }]
     )

--- a/test/services/rbac_test.rb
+++ b/test/services/rbac_test.rb
@@ -37,7 +37,7 @@ class RbacTest < ActiveSupport::TestCase
                 value: %w[
                   78e3dc30-cec3-4b49-be2d-37482c74a9ac
                   79e3dc30-cec3-4b49-be2d-37482c74a9ad
-                ],
+                ].to_json,
                 operation: 'in'
               )
             )
@@ -51,7 +51,7 @@ class RbacTest < ActiveSupport::TestCase
                 key: 'group.id',
                 value: [
                   nil # ungrouped hosts
-                ],
+                ].to_json,
                 operation: 'in'
               )
             )
@@ -66,7 +66,7 @@ class RbacTest < ActiveSupport::TestCase
                 value: %w[
                   77e3dc30-cec3-4b49-be2d-37482c74a9ac
                   77e3dc30-cec3-4b49-be2d-37482c74a9ad
-                ],
+                ].to_json,
                 operation: 'in'
               )
             )
@@ -78,7 +78,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'group.id',
-                value: '80e3dc30-cec3-4b49-be2d-37482c74a9ad',
+                value: '80e3dc30-cec3-4b49-be2d-37482c74a9ad'.to_json,
                 operation: 'equal' # 'equal' is not a supported operation
               )
             )
@@ -90,7 +90,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'foo.id', # entry with unverified key is ignored
-                value: ['77e3dc30-cec3-4b49-be2d-37482c74a9ac'],
+                value: ['77e3dc30-cec3-4b49-be2d-37482c74a9ac'].to_json,
                 operation: 'in'
               )
             )
@@ -120,7 +120,7 @@ class RbacTest < ActiveSupport::TestCase
                 value: %w[
                   78e3dc30-cec3-4b49-be2d-37482c74a9ac
                   78e3dc30-cec3-4b49-be2d-37482c74a9ad
-                ],
+                ].to_json,
                 operation: 'in'
               )
             )
@@ -141,7 +141,7 @@ class RbacTest < ActiveSupport::TestCase
                 key: 'group.id',
                 value: %w[
                   78e3dc30-cec3-4b49-be2d-37482c74a9ad
-                ],
+                ].to_json,
                 operation: 'in'
               )
             )
@@ -163,7 +163,7 @@ class RbacTest < ActiveSupport::TestCase
                 value: %w[
                   77e3dc30-cec3-4b49-be2d-37482c74a9ac
                   77e3dc30-cec3-4b49-be2d-37482c74a9ad
-                ],
+                ].to_json,
                 operation: 'in'
               )
             )
@@ -175,7 +175,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'foo.id', # entry with unverified key is ignored
-                value: ['77e3dc30-cec3-4b49-be2d-37482c74a9ac'],
+                value: ['77e3dc30-cec3-4b49-be2d-37482c74a9ac'].to_json,
                 operation: 'in'
               )
             )
@@ -194,7 +194,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'group.id',
-                value: nil,
+                value: nil.to_json,
                 operation: 'in'
               )
             )
@@ -206,7 +206,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'group.id',
-                value: nil, # nil
+                value: nil.to_json, # nil
                 operation: 'equal'
               )
             )
@@ -218,7 +218,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'group.id',
-                value: nil, # nil
+                value: nil.to_json, # nil
                 operation: 'in'
               )
             )
@@ -230,7 +230,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'group.id',
-                value: [], # []
+                value: [].to_json, # []
                 operation: 'in'
               )
             )
@@ -242,7 +242,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'group.id',
-                value: [nil],
+                value: [nil].to_json,
                 operation: 'equal' # equal
               )
             )
@@ -254,7 +254,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'groups.id', # groups.id
-                value: 'not supported',
+                value: 'not supported'.to_json,
                 operation: 'in'
               )
             )
@@ -266,7 +266,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'groups.id', # groups.id
-                value: 'some-id',
+                value: 'some-id'.to_json,
                 operation: 'equal' # equal
               )
             )
@@ -285,7 +285,7 @@ class RbacTest < ActiveSupport::TestCase
             RBACApiClient::ResourceDefinition.new(
               attribute_filter: RBACApiClient::ResourceDefinitionFilter.new(
                 key: 'group.id',
-                value: [nil, '80e3dc30-cec3-4b49-be2d-37482c74a9ad'],
+                value: [nil, '80e3dc30-cec3-4b49-be2d-37482c74a9ad'].to_json,
                 operation: 'in'
               )
             )


### PR DESCRIPTION
There is no JSON parsing on the `ResourceDefinition#value` response...ideally it should be done by the API client, but for now we're fixing it fast.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
