### PR TITLE
fix(Clowder): RHCLOUD-27386 workaround for REDIS_SSL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         APP_NAME="compliance"
         ARTIFACTS_DIR=""
         CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"
+        DEPLOY_TIMEOUT="1800"
         COMPONENT_NAME="compliance"
         COMPONENTS_W_RESOURCES="compliance"
         IMAGE="quay.io/cloudservices/compliance-backend"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,8 @@ Rails.application.configure do
         redis_password = Settings.redis.cache_password.present? ? Settings.redis.cache_password : nil
       end
 
-      { url: redis_url, password: redis_password, ssl: Settings.redis.ssl}
+      # FIXME: Settings.redis.ssl after clowder provides it
+      { url: redis_url, password: redis_password, ssl: ENV.fetch('SETTINGS__REDIS__SSL', nil)}
     end
 
     # Override is necessary as it gets set during initialization without the proper config available

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@ sidekiq_config = lambda do |config|
   config.redis = {
     url: Settings.redis.url,
     password: Settings.redis.password.presence,
-    ssl: Settings.redis.ssl,
+    ssl: ENV.fetch('SETTINGS__REDIS__SSL', nil), # FIXME: Settings.redis.ssl after clowder provides it
     network_timeout: 5
   }
   config[:dead_timeout_in_seconds] = 2.weeks.to_i

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -19,7 +19,7 @@ namespace :redis do
       Redis.new(
         url: Settings.redis.url,
         password: Settings.redis.password.presence,
-        ssl: Settings.redis.ssl
+        ssl: ENV.fetch('SETTINGS__REDIS__SSL', nil) # FIXME: Settings.redis.ssl after clowder provides it
       ).ping
     rescue Redis::BaseError
       abort('ERROR: Redis unavailable')


### PR DESCRIPTION
As clowder doesn't provide the SSL option for redis yet, we relied on the `SETTINGS__REDIS__SSL` environment variable. The latest version of the `config` gem merges settings coming from clowder in a different way and somehow ignores this environment variable. This causes a failure in starting up sidekiq in some cases, so I am working it around by directly reading the environment variable until clowder doesn't provide us this param out of the box.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
