### PR TITLE
fix(PolicyHost): RHICOMPL-3949 scope down unassignment per policy

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -51,6 +51,7 @@ class Policy < ApplicationRecord
 
     # Remove only those assigned hosts, which are accessible by the user
     removed = Pundit.policy_scope(user, PolicyHost)
+                    .where(policy: self)
                     .where.not(host_id: new_host_ids).destroy_all
 
     # The new hosts are already scoped down for the user


### PR DESCRIPTION
The unassignment of systems per policy has been affecting other policies as the query for the selection of hosts to delete was not taking into account the policy ID.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
