### PR TITLE
RHICOMPL-3959 make the controllers usable for multiple routes

### DIFF
--- a/app/controllers/concerns/v2/collection.rb
+++ b/app/controllers/concerns/v2/collection.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module V2
+  # Generic methods to be used when calling resolve_collection on our models
+  module Collection
+    extend ActiveSupport::Concern
+
+    include ::TagFiltering
+
+    included do
+      private
+
+      def resolve_collection
+        result = filter_by_tags(sort(search(policy_scope(expand_resource))))
+        result.paginate(page: pagination_offset, per_page: pagination_limit)
+      end
+
+      # :nocov:
+      def filter_by_tags(data)
+        unless TagFiltering.tags_supported?(resource) && permitted_params[:tags]&.any?
+          return data
+        end
+
+        tags = parse_tags(permitted_params[:tags])
+        data.where('tags @> ?', tags.to_json)
+      end
+      # :nocov:
+
+      # rubocop:disable Metrics/AbcSize
+      # :nocov:
+      def search(data)
+        return data if permitted_params[self.class::SEARCH].blank?
+
+        # Fail if search is not supported for the given model
+        if !data.respond_to?(:search_for) || permitted_params[self.class::SEARCH].match(/\x00/)
+          raise ActionController::UnpermittedParameters.new(self.class::SEARCH => permitted_params[self.class::SEARCH])
+        end
+
+        data.search_for(permitted_params[self.class::SEARCH])
+      end
+      # :nocov:
+      # rubocop:enable Metrics/AbcSize
+
+      # :nocov:
+      def sort(data)
+        order_hash, extra_scopes = data.klass.build_order_by(permitted_params[:sort_by])
+
+        extra_scopes.inject(data.order(order_hash)) do |result, scope|
+          result.send(scope)
+        end
+      end
+      # :nocov:
+    end
+  end
+end

--- a/app/controllers/concerns/v2/parameter_handling.rb
+++ b/app/controllers/concerns/v2/parameter_handling.rb
@@ -71,6 +71,7 @@ module V2
       def permit_parent_ids
         params[:parents]&.each_with_object({}) do |parent, obj|
           reflection = resource.reflect_on_association(parent)
+          # Do not allow reflections that aren't defined as a parent
           next if reflection.nil?
 
           obj[reflection.foreign_key] = UUIDConstraint.new

--- a/app/controllers/v2/profiles_controller.rb
+++ b/app/controllers/v2/profiles_controller.rb
@@ -20,10 +20,7 @@ module V2
     end
 
     def profile
-      # FIXME: change after canonical_profiles becomes a table
-      # rubocop:disable Rails/FindById
-      @profile ||= authorize(resource.find_by!(id: permitted_params[:id]))
-      # rubocop:enable Rails/FindById
+      @profile ||= authorize(resource.find(permitted_params[:id]))
     end
 
     def resource

--- a/app/controllers/v2/profiles_controller.rb
+++ b/app/controllers/v2/profiles_controller.rb
@@ -20,11 +20,11 @@ module V2
     end
 
     def profile
-      @profile ||= authorize(resource.find(permitted_params[:id]))
+      @profile ||= authorize(expand_resource.find(permitted_params[:id]))
     end
 
     def resource
-      V2::Profile.where(security_guide_id: params[:security_guide_id])
+      V2::Profile
     end
 
     def serializer

--- a/app/controllers/v2/rules_controller.rb
+++ b/app/controllers/v2/rules_controller.rb
@@ -20,11 +20,11 @@ module V2
     end
 
     def rule
-      @rule ||= authorize(resource.find(permitted_params[:id]))
+      @rule ||= authorize(expand_resource.find(permitted_params[:id]))
     end
 
     def resource
-      V2::Rule.where(security_guide_id: params[:security_guide_id])
+      V2::Rule
     end
 
     def serializer

--- a/app/controllers/v2/security_guides_controller.rb
+++ b/app/controllers/v2/security_guides_controller.rb
@@ -20,7 +20,7 @@ module V2
     end
 
     def security_guide
-      @security_guide ||= authorize(resource.find(permitted_params[:id]))
+      @security_guide ||= authorize(expand_resource.find(permitted_params[:id]))
     end
 
     def scope

--- a/app/controllers/v2/value_definitions_controller.rb
+++ b/app/controllers/v2/value_definitions_controller.rb
@@ -20,11 +20,11 @@ module V2
     end
 
     def value_definition
-      @value_definition ||= authorize(resource.find(permitted_params[:id]))
+      @value_definition ||= authorize(expand_resource.find(permitted_params[:id]))
     end
 
     def resource
-      V2::ValueDefinition.where(security_guide_id: params[:security_guide_id])
+      V2::ValueDefinition
     end
 
     def serializer

--- a/app/models/v2/profile.rb
+++ b/app/models/v2/profile.rb
@@ -3,18 +3,15 @@
 module V2
   # Model for Canonical Profile
   class Profile < ApplicationRecord
-    self.table_name = 'canonical_profiles'
+    # FIXME: clean up after the remodel
+    self.table_name = :canonical_profiles
+    self.primary_key = :id
 
     sortable_by :title
 
     scoped_search on: :title, only_explicit: true, operators: %i[like unlike eq ne in notin]
     scoped_search on: :ref_id, only_explicit: true, operators: %i[eq ne in notin]
 
-    belongs_to :security_guide, class_name: 'V2::SecurityGuide'
-
-    # FIXME: delete after canonical_profiles becomes a table
-    def self.count_by
-      :id
-    end
+    belongs_to :security_guide
   end
 end

--- a/app/models/v2/rule.rb
+++ b/app/models/v2/rule.rb
@@ -4,6 +4,10 @@
 module V2
   # Model for Rules
   class Rule < ApplicationRecord
+    # FIXME: clean up after the remodel
+    self.table_name = :v2_rules
+    self.primary_key = :id
+
     SORTED_SEVERITIES = Arel.sql(
       AN::Case.new.when(
         Rule.arel_table[:severity].eq(AN::Quoted.new('high'))
@@ -14,9 +18,7 @@ module V2
       ).then(1).else(0).to_sql
     )
 
-    # FIXME: drop the foreign key and alias after remodel
-    alias_attribute :security_guide_id, :benchmark_id
-    belongs_to :security_guide, class_name: 'V2::SecurityGuide', foreign_key: 'benchmark_id', inverse_of: false
+    belongs_to :security_guide
 
     sortable_by :title
     sortable_by :severity, SORTED_SEVERITIES

--- a/app/models/v2/security_guide.rb
+++ b/app/models/v2/security_guide.rb
@@ -3,7 +3,8 @@
 module V2
   # Model for Security Guides
   class SecurityGuide < ApplicationRecord
-    self.table_name = 'benchmarks'
+    # FIXME: clean up after the remodel
+    self.primary_key = :id
 
     SORT_BY_VERSION = Arel::Nodes::NamedFunction.new(
       'CAST',

--- a/app/models/v2/value_definition.rb
+++ b/app/models/v2/value_definition.rb
@@ -4,9 +4,11 @@
 module V2
   # Model for Value Definitions
   class ValueDefinition < ApplicationRecord
-    # FIXME: drop the foreign key and alias after remodel
-    alias_attribute :security_guide_id, :benchmark_id
-    belongs_to :security_guide, class_name: 'V2::SecurityGuide', foreign_key: 'benchmark_id', inverse_of: false
+    # FIXME: clean up after the remodel
+    self.primary_key = :id
+    self.table_name = :v2_value_definitions
+
+    belongs_to :security_guide
 
     sortable_by :title
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,9 @@ Rails.application.routes.draw do
       unless Rails.env.production?
         scope 'v2', module: 'v2', as: 'v2' do
           resources :security_guides, only: [:index, :show] do
-            resources :profiles, only: [:index, :show], parents: [V2::SecurityGuide]
-            resources :value_definitions, only: [:index, :show], parents: [V2::SecurityGuide]
-            resources :rules, only: [:index, :show], parents: [V2::SecurityGuide]
+            resources :profiles, only: [:index, :show], parents: [:security_guide]
+            resources :value_definitions, only: [:index, :show], parents: [:security_guide]
+            resources :rules, only: [:index, :show], parents: [:security_guide]
           end
         end
       end

--- a/db/migrate/20230901184111_create_security_guides.rb
+++ b/db/migrate/20230901184111_create_security_guides.rb
@@ -1,0 +1,5 @@
+class CreateSecurityGuides < ActiveRecord::Migration[7.0]
+  def change
+    create_view :security_guides
+  end
+end

--- a/db/migrate/20230901184656_create_v2_value_definitions.rb
+++ b/db/migrate/20230901184656_create_v2_value_definitions.rb
@@ -1,0 +1,5 @@
+class CreateV2ValueDefinitions < ActiveRecord::Migration[7.0]
+  def change
+    create_view :v2_value_definitions
+  end
+end

--- a/db/migrate/20230901184939_create_v2_rules.rb
+++ b/db/migrate/20230901184939_create_v2_rules.rb
@@ -1,0 +1,5 @@
+class CreateV2Rules < ActiveRecord::Migration[7.0]
+  def change
+    create_view :v2_rules
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_10_085607) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_01_184939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -264,5 +264,48 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_085607) do
       profiles.value_overrides
      FROM profiles
     WHERE (profiles.parent_profile_id IS NULL);
+  SQL
+  create_view "security_guides", sql_definition: <<-SQL
+      SELECT benchmarks.id,
+      benchmarks.ref_id,
+      benchmarks.title,
+      benchmarks.description,
+      benchmarks.version,
+      benchmarks.created_at,
+      benchmarks.updated_at,
+      benchmarks.package_name
+     FROM benchmarks;
+  SQL
+  create_view "v2_value_definitions", sql_definition: <<-SQL
+      SELECT value_definitions.id,
+      value_definitions.ref_id,
+      value_definitions.title,
+      value_definitions.description,
+      value_definitions.value_type,
+      value_definitions.default_value,
+      value_definitions.lower_bound,
+      value_definitions.upper_bound,
+      value_definitions.benchmark_id AS security_guide_id
+     FROM value_definitions;
+  SQL
+  create_view "v2_rules", sql_definition: <<-SQL
+      SELECT rules.id,
+      rules.ref_id,
+      rules.supported,
+      rules.title,
+      rules.severity,
+      rules.description,
+      rules.rationale,
+      rules.created_at,
+      rules.updated_at,
+      rules.slug,
+      rules.remediation_available,
+      rules.benchmark_id AS security_guide_id,
+      rules.upstream,
+      rules.precedence,
+      rules.rule_group_id,
+      rules.value_checks,
+      rules.identifier
+     FROM rules;
   SQL
 end

--- a/db/views/security_guides_v01.sql
+++ b/db/views/security_guides_v01.sql
@@ -1,0 +1,10 @@
+SELECT
+  "benchmarks"."id",
+  "benchmarks"."ref_id",
+  "benchmarks"."title",
+  "benchmarks"."description",
+  "benchmarks"."version",
+  "benchmarks"."created_at",
+  "benchmarks"."updated_at",
+  "benchmarks"."package_name"
+FROM "benchmarks";

--- a/db/views/v2_rules_v01.sql
+++ b/db/views/v2_rules_v01.sql
@@ -1,0 +1,19 @@
+SELECT
+  "rules"."id",
+  "rules"."ref_id",
+  "rules"."supported",
+  "rules"."title",
+  "rules"."severity",
+  "rules"."description",
+  "rules"."rationale",
+  "rules"."created_at",
+  "rules"."updated_at",
+  "rules"."slug",
+  "rules"."remediation_available",
+  "rules"."benchmark_id" AS "security_guide_id",
+  "rules"."upstream",
+  "rules"."precedence",
+  "rules"."rule_group_id",
+  "rules"."value_checks",
+  "rules"."identifier"
+FROM "rules";

--- a/db/views/v2_value_definitions_v01.sql
+++ b/db/views/v2_value_definitions_v01.sql
@@ -1,0 +1,11 @@
+SELECT
+  "value_definitions"."id",
+  "value_definitions"."ref_id",
+  "value_definitions"."title",
+  "value_definitions"."description",
+  "value_definitions"."value_type",
+  "value_definitions"."default_value",
+  "value_definitions"."lower_bound",
+  "value_definitions"."upper_bound",
+  "value_definitions"."benchmark_id" AS "security_guide_id"
+FROM "value_definitions";

--- a/spec/controllers/v2/concerns/paginable_spec.rb
+++ b/spec/controllers/v2/concerns/paginable_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 # The `parents` parameter is required when testing nested controllers, and it should contain
-# an ordered list of model classes similarly to how they are defined in the routes. It is also
-# required to set the `extra_params` variable in a let block and pass all the parent IDs there
-# as a hash. For example:
+# an ordered list of reflection symbols similarly to how they are defined in the routes. It is
+# also required to set the `extra_params` variable in a let block and pass all the parent IDs
+# there as a hash. For example:
 # ```
-# it_behaves_like 'paginable', SecurityGuide, Profile do
+# it_behaves_like 'paginable', :security_guide, :profile do
 #   let(:extra_params) { { security_guide_id: 123, profile_id: 456 } }
 # end
 # ```
@@ -21,12 +21,7 @@ RSpec.shared_examples 'paginable' do |*parents|
   [2, 5, 10, 15, 20].each do |per_page|
     it "returns with the requested #{per_page} records per page" do
       items # force creation
-      nested_route(*parents) do |mocked_parents|
-        get :index, params: extra_params.merge(
-          { 'limit' => per_page },
-          parents: mocked_parents
-        )
-      end
+      get :index, params: extra_params.merge('limit' => per_page, parents: parents)
 
       expect(response_body_data.count).to eq(per_page)
     end
@@ -42,15 +37,11 @@ RSpec.shared_examples 'paginable' do |*parents|
           )
         end
 
-        nested_route(*parents) do |mocked_parents|
-          get :index, params: extra_params.merge(
-            {
-              'limit' => per_page,
-              'offset' => page
-            },
-            parents: mocked_parents
-          )
-        end
+        get :index, params: extra_params.merge(
+          'limit' => per_page,
+          'offset' => page,
+          parents: parents
+        )
 
         expect(response_body_data).to match_array(nth_page)
         expect(response.parsed_body['meta']['limit']).to eq(per_page)

--- a/spec/controllers/v2/concerns/searchable_spec.rb
+++ b/spec/controllers/v2/concerns/searchable_spec.rb
@@ -25,11 +25,11 @@
 # ```
 #
 # The `parents` parameter is required when testing nested controllers, and it should contain
-# an ordered list of model classes similarly to how they are defined in the routes. It is also
-# required to set the `extra_params` variable in a let block and pass all the parent IDs there
-# as a hash. For example:
+# an ordered list of reflection symbols similarly to how they are defined in the routes. It is
+# also required to set the `extra_params` variable in a let block and pass all the parent IDs
+# there as a hash. For example:
 # ```
-# it_behaves_like 'searchable', SecurityGuide, Profile do
+# it_behaves_like 'searchable', :security_guide, :profile do
 #   let(:extra_params) { { security_guide_id: 123, profile_id: 456 } }
 # end
 # ```
@@ -54,12 +54,7 @@ RSpec.shared_examples 'searchable' do |*parents|
         FactoryBot.create(entity.delete(:factory), **entity)
       end
 
-      nested_route(*parents) do |mocked_parents|
-        get :index, params: extra_params.merge(
-          { filter: search[:query] },
-          parents: mocked_parents
-        )
-      end
+      get :index, params: extra_params.merge(filter: search[:query], parents: parents)
 
       expect(response_body_data).to match_array(found.map { |item| hash_including('id' => item.id) })
     end

--- a/spec/controllers/v2/concerns/sortable_spec.rb
+++ b/spec/controllers/v2/concerns/sortable_spec.rb
@@ -24,11 +24,11 @@
 #     => written as [0, 1, [2, 3]]
 #
 # The `parents` parameter is required when testing nested controllers, and it should contain
-# an ordered list of model classes similarly to how they are defined in the routes. It is also
-# required to set the `extra_params` variable in a let block and pass all the parent IDs there
-# as a hash. For example:
+# an ordered list of reflection symbols similarly to how they are defined in the routes. It is
+# also required to set the `extra_params` variable in a let block and pass all the parent IDs
+# there as a hash. For example:
 # ```
-# it_behaves_like 'sortable', SecurityGuide, Profile do
+# it_behaves_like 'sortable', :security_guide, :profile do
 #   let(:extra_params) { { security_guide_id: 123, profile_id: 456 } }
 # end
 # ```
@@ -59,9 +59,7 @@ RSpec.shared_examples 'sortable' do |*parents|
         end
       end
 
-      nested_route(*parents) do |mocked_parents|
-        get :index, params: extra_params.merge(sort_by: test_case[:sort_by], parents: mocked_parents)
-      end
+      get :index, params: extra_params.merge(sort_by: test_case[:sort_by], parents: parents)
 
       expect(response_body_data.map { |item| item['id'] }).to eq(result)
     end

--- a/spec/controllers/v2/concerns/with_metadata_spec.rb
+++ b/spec/controllers/v2/concerns/with_metadata_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 # The `parents` parameter is required when testing nested controllers, and it should contain
-# an ordered list of model classes similarly to how they are defined in the routes. It is also
-# required to set the `extra_params` variable in a let block and pass all the parent IDs there
-# as a hash. For example:
+# an ordered list of reflection symbols similarly to how they are defined in the routes. It is
+# also required to set the `extra_params` variable in a let block and pass all the parent IDs
+# there as a hash. For example:
 # ```
-# include_examples 'with_metadata', SecurityGuide, Profile do
+# include_examples 'with_metadata', :security_guide, :profile do
 #   let(:extra_params) { { security_guide_id: 123, profile_id: 456 } }
 # end
 # ```
@@ -21,9 +21,7 @@ RSpec.shared_examples 'with metadata' do |*parents|
   let(:extra_params) { {} }
 
   it 'contains total, limit, offset and relationships keys' do
-    nested_route(*parents) do |mocked_parents|
-      get :index, params: extra_params.merge(parents: mocked_parents)
-    end
+    get :index, params: extra_params.merge(parents: parents)
 
     expect(response.parsed_body['meta'].keys).to contain_exactly(*meta_keys)
   end
@@ -31,9 +29,7 @@ RSpec.shared_examples 'with metadata' do |*parents|
   it 'has correct total in metadata' do
     items
 
-    nested_route(*parents) do |mocked_parents|
-      get :index, params: extra_params.merge(parents: mocked_parents)
-    end
+    get :index, params: extra_params.merge(parents: parents)
 
     expect(response.parsed_body['meta']['total']).to eq(item_count)
   end

--- a/spec/controllers/v2/profiles_controller_spec.rb
+++ b/spec/controllers/v2/profiles_controller_spec.rb
@@ -15,6 +15,7 @@ describe V2::ProfilesController do
 
   before do
     request.headers['X-RH-IDENTITY'] = current_user.account.identity_header.raw
+    allow(StrongerParameters::InvalidValue).to receive(:new) { |value, _| value.to_sym }
     allow(controller).to receive(:rbac_allowed?).and_return(rbac_allowed?)
   end
 
@@ -43,12 +44,7 @@ describe V2::ProfilesController do
           )
         end
 
-        nested_route(V2::SecurityGuide) do |parents|
-          get :index, params: {
-            security_guide_id: security_guide.id,
-            parents: parents
-          }
-        end
+        get :index, params: { security_guide_id: security_guide.id, parents: %i[security_guide] }
 
         expect(response).to have_http_status :ok
         expect(response_body_data).to match_array(collection)
@@ -58,19 +54,19 @@ describe V2::ProfilesController do
         end
       end
 
-      include_examples 'with metadata', V2::SecurityGuide do
+      include_examples 'with metadata', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'paginable', V2::SecurityGuide do
+      it_behaves_like 'paginable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'sortable', V2::SecurityGuide do
+      it_behaves_like 'sortable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'searchable', V2::SecurityGuide do
+      it_behaves_like 'searchable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
@@ -79,12 +75,8 @@ describe V2::ProfilesController do
         let(:item) { FactoryBot.create(:v2_profile) }
 
         it 'returns not_found' do
-          nested_route(V2::SecurityGuide) do |parents|
-            get :index, params: {
-              security_guide_id: empty_security_guide.id,
-              parents: parents
-            }
-          end
+          get :index, params: { security_guide_id: empty_security_guide.id, parents: %i[security_guide] }
+
           expect(response_body_data).to be_empty
         end
       end
@@ -94,12 +86,7 @@ describe V2::ProfilesController do
       let(:rbac_allowed?) { false }
 
       it 'responds with unauthorized status' do
-        nested_route(V2::SecurityGuide) do |parents|
-          get :index, params: {
-            security_guide_id: security_guide.id,
-            parents: parents
-          }
-        end
+        get :index, params: { security_guide_id: security_guide.id, parents: %i[security_guide] }
 
         expect(response).to have_http_status :forbidden
       end
@@ -122,13 +109,7 @@ describe V2::ProfilesController do
                                 end
                               })
 
-        nested_route(V2::SecurityGuide) do |parents|
-          get :show, params: {
-            security_guide_id: security_guide.id,
-            id: profile.id,
-            parents: parents
-          }
-        end
+        get :show, params: { security_guide_id: security_guide.id, id: profile.id, parents: %i[security_guide] }
 
         expect(response.parsed_body).to match(item)
       end
@@ -138,15 +119,9 @@ describe V2::ProfilesController do
         let(:security_guide) { FactoryBot.create(:v2_security_guide) }
 
         it 'returns not_found' do
-          nested_route(V2::SecurityGuide) do |parents|
-            get :show, params: {
-              security_guide_id: security_guide.id,
-              id: item.id,
-              parents: parents
-            }
+          get :show, params: { security_guide_id: security_guide.id, id: profile.id, parents: %i[security_guide] }
 
-            expect(response).to have_http_status :not_found
-          end
+          expect(response).to have_http_status :not_found
         end
       end
     end

--- a/spec/controllers/v2/rules_controller_spec.rb
+++ b/spec/controllers/v2/rules_controller_spec.rb
@@ -18,6 +18,7 @@ describe V2::RulesController do
 
   before do
     request.headers['X-RH-IDENTITY'] = current_user.account.identity_header.raw
+    allow(StrongerParameters::InvalidValue).to receive(:new) { |value, _| value.to_sym }
     allow(controller).to receive(:rbac_allowed?).and_return(rbac_allowed?)
   end
 
@@ -46,12 +47,7 @@ describe V2::RulesController do
           )
         end
 
-        nested_route(V2::SecurityGuide) do |parents|
-          get :index, params: {
-            security_guide_id: security_guide.id,
-            parents: parents
-          }
-        end
+        get :index, params: { security_guide_id: security_guide.id, parents: %i[security_guide] }
 
         expect(response).to have_http_status :ok
         expect(response_body_data).to match_array(collection)
@@ -61,19 +57,19 @@ describe V2::RulesController do
         end
       end
 
-      include_examples 'with metadata', V2::SecurityGuide do
+      include_examples 'with metadata', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'paginable', V2::SecurityGuide do
+      it_behaves_like 'paginable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'sortable', V2::SecurityGuide do
+      it_behaves_like 'sortable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'searchable', V2::SecurityGuide do
+      it_behaves_like 'searchable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
@@ -82,12 +78,8 @@ describe V2::RulesController do
         let(:item) { FactoryBot.create(:v2_rule) }
 
         it 'returns not_found' do
-          nested_route(V2::SecurityGuide) do |parents|
-            get :index, params: {
-              security_guide_id: empty_security_guide.id,
-              parents: parents
-            }
-          end
+          get :index, params: { security_guide_id: empty_security_guide.id, parents: %i[security_guide] }
+
           expect(response_body_data).to be_empty
         end
       end
@@ -97,12 +89,7 @@ describe V2::RulesController do
       let(:rbac_allowed?) { false }
 
       it 'responds with unauthorized status' do
-        nested_route(V2::SecurityGuide) do |parents|
-          get :index, params: {
-            security_guide_id: security_guide.id,
-            parents: parents
-          }
-        end
+        get :index, params: { security_guide_id: security_guide.id, parents: %i[security_guide] }
 
         expect(response).to have_http_status :forbidden
       end
@@ -125,13 +112,7 @@ describe V2::RulesController do
                                 end
                               })
 
-        nested_route(V2::SecurityGuide) do |parents|
-          get :show, params: {
-            security_guide_id: security_guide.id,
-            id: rule.id,
-            parents: parents
-          }
-        end
+        get :show, params: { security_guide_id: security_guide.id, id: rule.id, parents: %i[security_guide] }
 
         expect(response.parsed_body).to match(item)
       end
@@ -141,15 +122,9 @@ describe V2::RulesController do
         let(:security_guide) { FactoryBot.create(:v2_security_guide) }
 
         it 'returns not_found' do
-          nested_route(V2::SecurityGuide) do |parents|
-            get :show, params: {
-              security_guide_id: security_guide.id,
-              id: item.id,
-              parents: parents
-            }
+          get :show, params: { security_guide_id: security_guide.id, id: rule.id, parents: %i[security_guide] }
 
-            expect(response).to have_http_status :not_found
-          end
+          expect(response).to have_http_status :not_found
         end
       end
     end

--- a/spec/controllers/v2/security_guides_controller_spec.rb
+++ b/spec/controllers/v2/security_guides_controller_spec.rb
@@ -17,6 +17,7 @@ describe V2::SecurityGuidesController do
 
   before do
     request.headers['X-RH-IDENTITY'] = current_user.account.identity_header.raw
+    allow(StrongerParameters::InvalidValue).to receive(:new) { |value, _| value.to_sym }
     allow(controller).to receive(:rbac_allowed?).and_return(rbac_allowed?)
   end
 

--- a/spec/controllers/v2/value_definitions_controller_spec.rb
+++ b/spec/controllers/v2/value_definitions_controller_spec.rb
@@ -17,6 +17,7 @@ describe V2::ValueDefinitionsController do
 
   before do
     request.headers['X-RH-IDENTITY'] = current_user.account.identity_header.raw
+    allow(StrongerParameters::InvalidValue).to receive(:new) { |value, _| value.to_sym }
     allow(controller).to receive(:rbac_allowed?).and_return(rbac_allowed?)
   end
 
@@ -45,12 +46,7 @@ describe V2::ValueDefinitionsController do
           )
         end
 
-        nested_route(V2::SecurityGuide) do |parents|
-          get :index, params: {
-            security_guide_id: security_guide.id,
-            parents: parents
-          }
-        end
+        get :index, params: { security_guide_id: security_guide.id, parents: %i[security_guide] }
 
         expect(response).to have_http_status :ok
         expect(response_body_data).to match_array(collection)
@@ -60,19 +56,19 @@ describe V2::ValueDefinitionsController do
         end
       end
 
-      include_examples 'with metadata', V2::SecurityGuide do
+      include_examples 'with metadata', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'paginable', V2::SecurityGuide do
+      it_behaves_like 'paginable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'sortable', V2::SecurityGuide do
+      it_behaves_like 'sortable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
-      it_behaves_like 'searchable', V2::SecurityGuide do
+      it_behaves_like 'searchable', :security_guide do
         let(:extra_params) { { security_guide_id: security_guide.id } }
       end
 
@@ -81,12 +77,8 @@ describe V2::ValueDefinitionsController do
         let(:item) { FactoryBot.create(:v2_value_definition) }
 
         it 'returns no data from empty security guide' do
-          nested_route(V2::SecurityGuide) do |parents|
-            get :index, params: {
-              security_guide_id: empty_security_guide.id,
-              parents: parents
-            }
-          end
+          get :index, params: { security_guide_id: empty_security_guide.id, parents: %i[security_guide] }
+
           expect(response_body_data).to be_empty
         end
       end
@@ -96,12 +88,7 @@ describe V2::ValueDefinitionsController do
       let(:rbac_allowed?) { false }
 
       it 'responds with unauthorized status' do
-        nested_route(V2::SecurityGuide) do |parents|
-          get :index, params: {
-            security_guide_id: security_guide.id,
-            parents: parents
-          }
-        end
+        get :index, params: { security_guide_id: security_guide.id, parents: %i[security_guide] }
 
         expect(response).to have_http_status :forbidden
       end
@@ -124,13 +111,11 @@ describe V2::ValueDefinitionsController do
                                 end
                               })
 
-        nested_route(V2::SecurityGuide) do |parents|
-          get :show, params: {
-            security_guide_id: security_guide.id,
-            id: value_definition.id,
-            parents: parents
-          }
-        end
+        get :show, params: {
+          security_guide_id: security_guide.id,
+          id: value_definition.id,
+          parents: %i[security_guide]
+        }
 
         expect(response.parsed_body).to match(item)
       end
@@ -140,15 +125,13 @@ describe V2::ValueDefinitionsController do
         let(:security_guide) { FactoryBot.create(:v2_security_guide) }
 
         it 'returns not_found' do
-          nested_route(V2::SecurityGuide) do |parents|
-            get :show, params: {
-              security_guide_id: security_guide.id,
-              id: item.id,
-              parents: parents
-            }
+          get :show, params: {
+            security_guide_id: security_guide.id,
+            id: item.id,
+            parents: %i[security_guide]
+          }
 
-            expect(response).to have_http_status :not_found
-          end
+          expect(response).to have_http_status :not_found
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,18 +41,6 @@ if Rails.env.test?
   end
   # rubocop:enable Metrics/MethodLength
 
-  def nested_route(*parents)
-    # Mock the .to_s method on each parent in the array to avoid RSpec converting it
-    parents.each { |parent| allow(parent).to receive(:to_s).and_return(parent) }
-
-    yield(parents)
-  ensure # Make sure that the mock is just for the time of the HTTP request
-    parents.each do |parent|
-      klass = RSpec::Mocks.space.proxy_for(parent)
-      klass.instance_variable_get(:@method_doubles)[:to_s].reset
-    end
-  end
-
   # Assembles object to be passed into factory
   # - adds url params into an object based on yaml entity definition in sorting and searching specs
   def factory_params(item, extra_params)


### PR DESCRIPTION
* V2 model reflections and foreign keys now match the parent IDs in nested routes
* Simplified relationships on the V2 models, less to clean up later after the remodel
* Instead of parent resources, routes now define parent reflections
* Resources are automatically joined & scoped with their parent resources in nested routes

Note that the `parents` configuration expects the reflection (`has_many`, `belongs_to`, etc) name, which is in some cases pluralized, e.g.:
```ruby
# app/models/v2/rules.rb
belongs_to :security_guide
has_many :profile_rules, dependent: :delete_all
has_many :profiles, through: :profile_rules, source: :profile, class_name: 'V2::Profile'


# config/routes.rb
resources :security_guides, only: [:index, :show] do
  resources :profiles, only: [:index, :show], parents: [:security_guide] do
    resources :rules, only: [:index, :show], parents: [:security_guide, :profiles] # SG is singular, profiles is plural
  end
end

``` 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
