### PR TITLE
fix(RBAC): RHINENG-2329 compensate for badly generated swagger client

### DIFF
--- a/app/services/rbac.rb
+++ b/app/services/rbac.rb
@@ -73,20 +73,17 @@ class Rbac
     end
 
     def valid_inventory_groups_definition?(definition)
-      # FIXME: JSON.parse needs to be moved to the RBAC API client
-      JSON.parse(definition.value).instance_of?(Array) &&
+      # FIXME: Instead of parsing the value here, it should be defined properly in the rbac OpenAPI spec
+      JSON.parse(definition.value.gsub('nil', 'null')).instance_of?(Array) &&
         definition.operation == 'in' &&
         definition.key == 'group.id'
-    rescue JSON::ParserError => e
-      Rails.logger.error("Invalid JSON value received: #{e}")
-      false
     end
 
     def inventory_groups_definition_value(definition)
       # Received '[nil]' symbolizes access to ungrouped entries.
       # In output represtented with an empty array.
       # FIXME: JSON.parse needs to be moved to the RBAC API client
-      JSON.parse(definition.value).map { |dv| dv || [] }
+      JSON.parse(definition.value.gsub('nil', 'null')).map { |dv| dv || [] }
     end
   end
 end

--- a/test/graphql/queries/profile_query_test.rb
+++ b/test/graphql/queries/profile_query_test.rb
@@ -370,7 +370,7 @@ class ProfileQueryTest < ActiveSupport::TestCase
                             attribute_filter: {
                               key: 'group.id',
                               operation: 'in',
-                              value: allowed_groups
+                              value: allowed_groups.to_json
                             }
                           }])
 

--- a/test/services/rbac_test.rb
+++ b/test/services/rbac_test.rb
@@ -293,7 +293,7 @@ class RbacTest < ActiveSupport::TestCase
         )
       ]
 
-      assert_equal [], Rbac.load_inventory_groups(permissions)
+      assert_equal [[], '80e3dc30-cec3-4b49-be2d-37482c74a9ad'], Rbac.load_inventory_groups(permissions)
     end
 
     should 'list ungrouped entries with groups' do


### PR DESCRIPTION
This is an ugly hack to compensate for the badly defined OpenAPI spec of RBAC until the type definitions get fixed.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
