### PR TITLE
fix(Host): RHINENG-2329 return empty scope as arel node for groups

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -135,7 +135,7 @@ class Host < ApplicationRecord
   def self.arel_inventory_groups(groups, key)
     jsons = groups.map { |group| [{ key => group }].to_json.dump }
 
-    return Arel.sql('1 = 0') if jsons.empty?
+    return AN::InfixOperation.new('=', Arel.sql('1'), Arel.sql('0')) if jsons.empty?
 
     AN::InfixOperation.new(
       '@>', arel_table[:groups],


### PR DESCRIPTION
The `SqlLiteral` arel object has no `or` method defined, so the ungrouped hosts only condition needs to be converted to a different node that returns with an empty collection.
 
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
