### PR TITLE
fix(test): RHINENG-2692 fix sporadic DeleteHost error

### DIFF
--- a/spec/delete_host_spec.rb
+++ b/spec/delete_host_spec.rb
@@ -50,8 +50,9 @@ describe DeleteHost do
       test_result.destroy
       rule_result.destroy
 
-      FactoryBot.create_list(:host, 3, org_id: user.account.org_id) do |host|
-        test_result = FactoryBot.create(:test_result, profile: profile, host: host)
+      [13, 19, 29].each do |n|
+        host = FactoryBot.create(:host, org_id: user.account.org_id)
+        test_result = FactoryBot.create(:test_result, profile: profile, host: host, score: n)
         FactoryBot.create(:rule_result, rule: profile.rules.sample, test_result: test_result, host: host)
       end
 
@@ -59,6 +60,7 @@ describe DeleteHost do
       expect(profile.policy.test_result_host_count).to eql(3)
 
       old_score = profile.score
+
       DeleteHost.perform_async(message)
       DeleteHost.drain
 


### PR DESCRIPTION
This sporadic error stems from the fact that the compliance score is calculated as a mean.
When one of the three created compliance scores is the average of the other two, and we delete the host associated with the compliance score that is the mean, we still get the same overall compliance score, thus the test failed.

By fixating the compliance scores of these three hosts in a manner where no combination of two scores gives us the third score, the sporadic error will not occur anymore.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
