### PR TITLE
fix(APIv2): RHINENG-2720 return not_found when parent ID is invalid

### DIFF
--- a/app/controllers/concerns/v2/collection.rb
+++ b/app/controllers/concerns/v2/collection.rb
@@ -30,10 +30,9 @@ module V2
       end
 
       def validate_parents!
-        permitted_params[:parents].each do |parent|
-          reflection = resource.reflect_on_association(parent)
-          reflection.klass.find(permitted_params[reflection.foreign_key])
-        end
+        *parents, current = permitted_params[:parents]
+        reflection = resource.reflect_on_association(current)
+        join_parents(reflection.klass, parents).find(permitted_params[reflection.foreign_key])
       end
 
       # :nocov:

--- a/app/controllers/v2/application_controller.rb
+++ b/app/controllers/v2/application_controller.rb
@@ -65,13 +65,13 @@ module V2
       # Get the list of fields to be selected from the serializer
       fields = serializer.fields(permitted_params)
       # Select only the fields that are really necessary
-      join_parents.select(*select_fields(fields))
+      join_parents(resource, permitted_params[:parents]).select(*select_fields(fields))
     end
 
     # Reduce through all the parents of the resource and join+scope them on the resource
     # or return with the resource untouched if not nested under other resources
-    def join_parents
-      permitted_params[:parents].to_a.reduce(resource) do |scope, parent|
+    def join_parents(resource, parents)
+      parents.to_a.reduce(resource) do |scope, parent|
         ref = scope.reflect_on_association(parent)
         klass = ref.klass
 

--- a/spec/controllers/v2/rules_controller_spec.rb
+++ b/spec/controllers/v2/rules_controller_spec.rb
@@ -78,6 +78,10 @@ describe V2::RulesController do
           profile_id: parent.id
         ).sort_by(&:id)
       end
+      let(:invalid_params) do
+        parent = FactoryBot.create(:v2_profile)
+        { security_guide_id: parent.security_guide.id, profile_id: parent.id }
+      end
 
       it_behaves_like 'collection', :security_guide, :profiles
       include_examples 'with metadata', :security_guide, :profiles


### PR DESCRIPTION
When requesting a nested `/index` with an existing but different root parent ID, the query returns an empty array instead of failing with a 404 error.

By joining the parents during parent validation and calling `find` we can trigger a not_found error when any of the parent hierarchy is invalid.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
