### PR TITLE
feat(DB): RHINENG-1986 make tailorings and v2_policies writable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,9 @@ gem 'rack', '>= 2.1.4'
 gem 'rswag-api'
 gem 'rswag-ui'
 
-# Database view management
+# Database view, function and trigger management
 gem 'scenic'
+gem 'fx'
 
 # Config YAML files for all environments
 gem 'config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,9 @@ GEM
     ffi (1.15.5)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
+    fx (0.8.0)
+      activerecord (>= 6.0.0)
+      railties (>= 6.0.0)
     gitlab-sidekiq-fetcher (0.9.0)
       json (>= 2.5)
       sidekiq (~> 6.1)
@@ -488,6 +491,7 @@ DEPENDENCIES
   faraday
   faraday-retry
   friendly_id (~> 5.2.4)
+  fx
   gitlab-sidekiq-fetcher
   graphiql-rails
   graphql

--- a/app/models/v2/policy.rb
+++ b/app/models/v2/policy.rb
@@ -5,6 +5,7 @@ module V2
   class Policy < ApplicationRecord
     # FIXME: clean up after the remodel
     self.table_name = :v2_policies
+    self.primary_key = :id
 
     belongs_to :profile, class_name: 'V2::Profile'
     has_one :security_guide, through: :profile, class_name: 'V2::SecurityGuide'

--- a/app/models/v2/tailoring.rb
+++ b/app/models/v2/tailoring.rb
@@ -5,6 +5,7 @@ module V2
   class Tailoring < ApplicationRecord
     # FIXME: clean up after the remodel
     self.table_name = :tailorings
+    self.primary_key = :id
 
     belongs_to :policy, class_name: 'V2::Policy'
     belongs_to :profile, class_name: 'V2::Profile'

--- a/db/functions/tailorings_insert_v01.sql
+++ b/db/functions/tailorings_insert_v01.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION tailorings_insert() RETURNS trigger LANGUAGE plpgsql AS
+$func$
+DECLARE result_id uuid;
+BEGIN
+
+INSERT INTO "profiles" (
+  "policy_id",
+  "account_id",
+  "parent_profile_id",
+  "benchmark_id",
+  "value_overrides",
+  "created_at",
+  "updated_at"
+) SELECT
+  NEW."policy_id",
+  "policies"."account_id",
+  NEW."profile_id",
+  "canonical_profiles"."security_guide_id",
+  NEW."value_overrides",
+  NEW."created_at",
+  NEW."updated_at"
+FROM "policies"
+INNER JOIN "canonical_profiles" ON "canonical_profiles"."id" = "policies"."profile_id"
+WHERE "policies"."id" = NEW."policy_id" RETURNING "id" INTO "result_id";
+
+NEW."id" := "result_id";
+RETURN NEW;
+
+END
+$func$;

--- a/db/functions/v2_policies_delete_v01.sql
+++ b/db/functions/v2_policies_delete_v01.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION v2_policies_delete() RETURNS trigger LANGUAGE plpgsql AS
+$func$
+DECLARE bo_id uuid;
+BEGIN
+  DELETE FROM "policies" WHERE "id" = OLD."id" RETURNING "business_objective_id" INTO "bo_id";
+  -- Delete any remaining business objectives associated with the policy of no other policies use it
+  DELETE FROM "business_objectives" WHERE "id" = "bo_id" AND (SELECT COUNT("id") FROM "policies" WHERE "business_objectives"."id" = "bo_id") = 0;
+RETURN OLD;
+END
+$func$;

--- a/db/functions/v2_policies_insert_v01.sql
+++ b/db/functions/v2_policies_insert_v01.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE FUNCTION v2_policies_insert() RETURNS trigger LANGUAGE plpgsql AS
+$func$
+DECLARE bo_id uuid;
+DECLARE result_id uuid;
+BEGIN
+    -- Insert a new business objective record if the business_objective field is
+    -- set to a value and return with its ID.
+    INSERT INTO "business_objectives" ("title", "created_at", "updated_at")
+    SELECT NEW."business_objective", NOW(), NOW()
+    WHERE NEW."business_objective" IS NOT NULL RETURNING "id" INTO "bo_id";
+
+    INSERT INTO "policies" (
+      "name",
+      "description",
+      "compliance_threshold",
+      "business_objective_id",
+      "profile_id",
+      "account_id"
+    ) VALUES (
+      NEW."title",
+      NEW."description",
+      NEW."compliance_threshold",
+      "bo_id",
+      NEW."profile_id",
+      NEW."account_id"
+    ) RETURNING "id" INTO "result_id";
+
+    NEW."id" := "result_id";
+    RETURN NEW;
+END
+$func$;

--- a/db/functions/v2_policies_update_v01.sql
+++ b/db/functions/v2_policies_update_v01.sql
@@ -1,0 +1,40 @@
+CREATE OR REPLACE FUNCTION v2_policies_update() RETURNS trigger LANGUAGE plpgsql AS
+$func$
+DECLARE "bo_id" uuid;
+BEGIN
+    -- Create a new business objective record if the apropriate field is set and there is no
+    -- existing business objective already assigned to the policy and return with its ID.
+    INSERT INTO "business_objectives" ("title", "created_at", "updated_at")
+    SELECT NEW."business_objective", NOW(), NOW() FROM "policies" WHERE
+      NEW."business_objective" IS NOT NULL AND
+      "policies"."business_objective_id" IS NULL AND
+      "policies"."id" = OLD."id"
+    RETURNING "id" INTO "bo_id";
+
+    -- If the previous insertion was successful, there is nothing to update, otherwise try to
+    -- update any existing business objective assigned to the policy and return with its ID.
+    IF "bo_id" IS NULL THEN
+      UPDATE "business_objectives" SET "title" = NEW."business_objective", "updated_at" = NOW()
+      FROM "policies" WHERE
+        "policies"."business_objective_id" = "business_objectives"."id" AND
+        "policies"."id" = OLD."id"
+      RETURNING "business_objectives"."id" INTO "bo_id";
+    END IF;
+
+    -- Update the policy itself, use the ID of the business objective from the previous two queries,
+    -- if the business_objective field is set to NULL, remove the link between the two tables.
+    UPDATE "policies" SET
+      "name" = NEW."title",
+      "description" = NEW."description",
+      "compliance_threshold" = NEW."compliance_threshold",
+      "business_objective_id" = CASE WHEN NEW."business_objective" IS NULL THEN NULL ELSE "bo_id" END
+    WHERE "id" = OLD."id";
+
+    -- If the business_objective field is set to NULL, delete its record in the business objectives
+    -- table using the ID retrieved during the second query.
+    DELETE FROM "business_objectives" USING "policies"
+    WHERE NEW."business_objective" IS NULL AND "business_objectives"."id" = "bo_id";
+
+    RETURN NEW;
+END
+$func$;

--- a/db/migrate/20231026190907_make_tailorings_writable.rb
+++ b/db/migrate/20231026190907_make_tailorings_writable.rb
@@ -1,0 +1,6 @@
+class MakeTailoringsWritable < ActiveRecord::Migration[7.0]
+  def change
+    create_function :tailorings_insert
+    create_trigger :tailorings_insert, on: :tailorings
+  end
+end

--- a/db/migrate/20231026194802_make_v2_policies_writable.rb
+++ b/db/migrate/20231026194802_make_v2_policies_writable.rb
@@ -1,0 +1,10 @@
+class MakeV2PoliciesWritable < ActiveRecord::Migration[7.0]
+  def change
+    create_function :v2_policies_insert
+    create_trigger :v2_policies_insert, on: :v2_policies
+    create_function :v2_policies_delete
+    create_trigger :v2_policies_delete, on: :v2_policies
+    create_function :v2_policies_update
+    create_trigger :v2_policies_update, on: :v2_policies
+  end
+end

--- a/db/seeds.dev.rb
+++ b/db/seeds.dev.rb
@@ -50,6 +50,7 @@ def create_policy(account, canonical_profile, hosts)
 
   policy = Policy.new(
     profile.slice(:name, :description, :compliance_threshold, :account)
+           .merge(profile_id: canonical_profile.id)
   )
 
   policy.save!

--- a/db/triggers/tailorings_insert_v01.sql
+++ b/db/triggers/tailorings_insert_v01.sql
@@ -1,0 +1,2 @@
+CREATE TRIGGER "tailorings_insert" INSTEAD OF INSERT ON "tailorings"
+FOR EACH ROW EXECUTE FUNCTION tailorings_insert();

--- a/db/triggers/v2_policies_delete_v01.sql
+++ b/db/triggers/v2_policies_delete_v01.sql
@@ -1,0 +1,2 @@
+CREATE TRIGGER "v2_policies_delete" INSTEAD OF DELETE ON "v2_policies"
+FOR EACH ROW EXECUTE FUNCTION v2_policies_delete();

--- a/db/triggers/v2_policies_insert_v01.sql
+++ b/db/triggers/v2_policies_insert_v01.sql
@@ -1,0 +1,2 @@
+CREATE TRIGGER "v2_policies_insert" INSTEAD OF INSERT ON "v2_policies"
+FOR EACH ROW EXECUTE FUNCTION v2_policies_insert();

--- a/db/triggers/v2_policies_update_v01.sql
+++ b/db/triggers/v2_policies_update_v01.sql
@@ -1,0 +1,2 @@
+CREATE TRIGGER "v2_policies_update" INSTEAD OF UPDATE ON "v2_policies"
+FOR EACH ROW EXECUTE FUNCTION v2_policies_update();


### PR DESCRIPTION
As these views are built on top of multiple tables, they are not writable by default. As a solution I created a few functions and triggers to make sure that the data gets passed correctly to the underlying tables. The `tailorings` table only required a trigger for insertion to prevent the violation of some constraints. The `v2_policies` needed more adjustments to make sure that the underlying business objective gets created/updated/deleted together with the policy. This is part of the effort of getting rid of the `business_objectives` table in the future.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
