### PR TITLE
feat(APIv2): RHINENG-2913 extend derived_attribute to non-parents

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -27,4 +27,11 @@ class ApplicationRecord < ActiveRecord::Base
   def self.count_by
     primary_key.to_sym
   end
+
+  # Returns with a list of symbols describing one-to-one relationships
+  def self.one_to_one
+    reflections.each_with_object([]) do |(key, reflection), obj|
+      obj << key.to_sym if reflection.has_one? || reflection.belongs_to?
+    end
+  end
 end

--- a/app/serializers/v2/application_serializer.rb
+++ b/app/serializers/v2/application_serializer.rb
@@ -18,8 +18,8 @@ module V2
       #   **method_fields[except nil]
       # }
       #
-      def fields(context)
-        data = method_fields(context[:parents])
+      def fields(parents, one_to_one)
+        data = method_fields((parents.to_a + one_to_one).uniq)
         data[nil] = (_descriptor.attributes.map(&:name).map(&:to_sym) + data[nil].to_a).compact
         data
       end


### PR DESCRIPTION
The idea here is to reuse the `derived_attribute` for fields joinable from 1:1 associations that aren't in the routing hierarchy of the given resource. A good example will be the `/policies` route that should display `os_major_version` of each entity that is available by joining it with the `SecurityGuide` association. 

1. Created the `ApplicationRecord.one_to_one` method to return a list of 1:1 associations on a given model
2. Adjusted the `V2::ApplicationSerializer.fields` method to additionally accept this list as an argument
3. Created `V2::ApplicationController#join_one_to_ones` method that joins the required 1:1 associations on the current scope on demand
4. Adjusted the `V2::ApplicationController#expand_resource` to include the `join_one_to_ones` in its chain

These changes should allow us to expose `os_major_version` on `/profiles` using:
```ruby
derived_attribute :os_major_version, security_guide: [:ref_id]
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
