### PR TITLE
Two minor fixes in handling dependent attribute serialization

### DIFF
--- a/app/controllers/concerns/v2/rendering.rb
+++ b/app/controllers/concerns/v2/rendering.rb
@@ -46,7 +46,7 @@ module V2
 
       # The serializer expects the list of parents to determine which `derived_attribute` should be skipped
       def serialization_context
-        { parents: permitted_params[:parents] }
+        { parents: (permitted_params[:parents].to_a + resource.one_to_one).uniq }
       end
 
       def index?

--- a/app/serializers/v2/application_serializer.rb
+++ b/app/serializers/v2/application_serializer.rb
@@ -85,8 +85,16 @@ module V2
 
         reduce_method_fields({}) do |obj, field|
           if @derived_attributes.key?(field) && meets_dependency?(@derived_attributes[field].keys, parents)
-            obj.merge(@derived_attributes[field])
+            merge_dependencies(obj, @derived_attributes[field])
           end
+        end
+      end
+
+      # Helper method for deep merging a hash of arrays
+      def merge_dependencies(left, right)
+        right.each_with_object(left) do |(k, v), obj|
+          obj[k] ||= []
+          obj[k] += v
         end
       end
     end


### PR DESCRIPTION
The dependent non-autojoined fields were ignored by default as the `one_to_one` tables were missing from the context of the serializer. Furthermore, multiple dependencies coming from the same table for two different fields were handled poorly and needed a deep(er) merging of hashes of arrays.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
