### PR TITLE
feat(APIv2): optionally allow the selection of additional fields

### DIFF
--- a/app/controllers/v2/application_controller.rb
+++ b/app/controllers/v2/application_controller.rb
@@ -60,6 +60,8 @@ module V2
     def expand_resource
       # Get the list of fields to be selected from the serializer
       fields = serializer.fields(permitted_params[:parents], resource.one_to_one)
+      # Append a list of additional fields required to render the response, usually RBAC related
+      fields[nil] += extra_fields
 
       # Join with the parents assumed from the route
       scope = join_parents(pundit_scope, permitted_params[:parents])
@@ -106,6 +108,11 @@ module V2
           end
         end
       end
+    end
+
+    # Default list of additional fields to be passed to the list of selected fields
+    def extra_fields
+      []
     end
   end
 end


### PR DESCRIPTION
This is mainly needed for pundit to make sure that records don't contain a wrong account_id. We usually don't display the account information in the API response and only a few tables contain this info, so I had to make it optional. If there are no other extra fields, I might refactor this to something more implicit.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
