### PR TITLE
Clean up the SEARCH constant from both APIs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,6 @@ require 'exceptions'
 
 # General controller to include all-encompassing behavior
 class ApplicationController < ActionController::API
-  SEARCH = :search
-
   include ActionController::Helpers
   include Pundit::Authorization
   include Authentication

--- a/app/controllers/concerns/collection.rb
+++ b/app/controllers/concerns/collection.rb
@@ -23,14 +23,14 @@ module Collection
 
     # rubocop:disable Metrics/AbcSize
     def search(data)
-      return data if permitted_params[self.class::SEARCH].blank?
+      return data if permitted_params[:search].blank?
 
       # Fail if search is not supported for the given model
-      if !data.respond_to?(:search_for) || permitted_params[self.class::SEARCH].match(/\x00/)
-        raise ActionController::UnpermittedParameters.new(self.class::SEARCH => permitted_params[self.class::SEARCH])
+      if !data.respond_to?(:search_for) || permitted_params[:search].match(/\x00/)
+        raise ActionController::UnpermittedParameters.new(search: permitted_params[:search])
       end
 
-      data.search_for(permitted_params[self.class::SEARCH])
+      data.search_for(permitted_params[:search])
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -21,7 +21,7 @@ module Metadata
       {
         meta: {
           total: opts[:total],
-          self.class::SEARCH => permitted_params[self.class::SEARCH],
+          search: permitted_params[:search],
           tags: tags,
           limit: pagination_limit,
           offset: pagination_offset,
@@ -90,7 +90,7 @@ module Metadata
 
     def base_link_params
       {
-        self.class::SEARCH => permitted_params[self.class::SEARCH],
+        search: permitted_params[:search],
         include: permitted_params[:include],
         limit: pagination_limit,
         tags: permitted_params[:tags],

--- a/app/controllers/concerns/parameter_handling.rb
+++ b/app/controllers/concerns/parameter_handling.rb
@@ -25,7 +25,7 @@ module ParameterHandling
   included do
     permitted_params_for_action :index, {
       relationships: ParamType.boolean,
-      self::SEARCH => ParamType.string,
+      search: ParamType.string,
       sort_by: ARRAY_OR_STRING,
       tags: ARRAY_OR_STRING,
       limit: ParamType.integer & ParamType.gt(0) & ParamType.lte(100),

--- a/app/controllers/concerns/v2/collection.rb
+++ b/app/controllers/concerns/v2/collection.rb
@@ -49,14 +49,14 @@ module V2
       # rubocop:disable Metrics/AbcSize
       # :nocov:
       def search(data)
-        return data if permitted_params[self.class::SEARCH].blank?
+        return data if permitted_params[:filter].blank?
 
         # Fail if search is not supported for the given model
-        if !data.respond_to?(:search_for) || permitted_params[self.class::SEARCH].match(/\x00/)
-          raise ActionController::UnpermittedParameters.new(self.class::SEARCH => permitted_params[self.class::SEARCH])
+        if !data.respond_to?(:search_for) || permitted_params[:filter].match(/\x00/)
+          raise ActionController::UnpermittedParameters.new(filter: permitted_params[:filter])
         end
 
-        data.search_for(permitted_params[self.class::SEARCH])
+        data.search_for(permitted_params[:filter])
       end
       # :nocov:
       # rubocop:enable Metrics/AbcSize

--- a/app/controllers/concerns/v2/metadata.rb
+++ b/app/controllers/concerns/v2/metadata.rb
@@ -22,7 +22,7 @@ module V2
         {
           meta: {
             total: total,
-            self.class::SEARCH => permitted_params[self.class::SEARCH],
+            filter: permitted_params[:filter],
             tags: tags,
             limit: pagination_limit,
             offset: pagination_offset,
@@ -89,7 +89,7 @@ module V2
 
       def base_link_params
         {
-          self.class::SEARCH => permitted_params[self.class::SEARCH],
+          filter: permitted_params[:filter],
           include: permitted_params[:include],
           limit: pagination_limit,
           tags: permitted_params[:tags],

--- a/app/controllers/concerns/v2/parameter_handling.rb
+++ b/app/controllers/concerns/v2/parameter_handling.rb
@@ -52,7 +52,7 @@ module V2
         limit: ParamType.integer & ParamType.gt(0) & ParamType.lte(100),
         offset: ParamType.integer & ParamType.gte(0),
         sort_by: ParamType.array(ParamType.string) | ParamType.string,
-        self::SEARCH => ParamType.string
+        filter: ParamType.string
       }
 
       permitted_params_for_action :show, id: ParamType.string

--- a/app/controllers/v1/profiles_controller.rb
+++ b/app/controllers/v1/profiles_controller.rb
@@ -9,7 +9,7 @@ module V1
     before_action(only: %i[show update]) { authorize profile }
 
     def index
-      permitted_params[self.class::SEARCH] ||= 'external=false and canonical=false'
+      permitted_params[:search] ||= 'external=false and canonical=false'
       permitted_params[:sort_by] ||= 'score'
       render_json resolve_collection
     end

--- a/app/controllers/v1/systems_controller.rb
+++ b/app/controllers/v1/systems_controller.rb
@@ -4,7 +4,7 @@ module V1
   # API for Systems (only Hosts for the moment)
   class SystemsController < ApplicationController
     def index
-      permitted_params[self.class::SEARCH] ||= 'has_test_results=true or has_policy=true'
+      permitted_params[:search] ||= 'has_test_results=true or has_policy=true'
       render_json resolve_collection
     end
     permission_for_action :index, Rbac::SYSTEM_READ

--- a/app/controllers/v2/application_controller.rb
+++ b/app/controllers/v2/application_controller.rb
@@ -3,8 +3,6 @@
 module V2
   # General controller to include all-encompassing behavior
   class ApplicationController < ::ActionController::API
-    SEARCH = :filter
-
     include ::ActionController::Helpers
     include ::Pundit::Authorization
     include ::Authentication

--- a/spec/controllers/v2/concerns/parameter_handling_spec.rb
+++ b/spec/controllers/v2/concerns/parameter_handling_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 describe V2::ParameterHandling do
   let(:subject) do
-    Struct.new(:action_name, :params, :resource) do |cls|
-      cls::SEARCH = :filter # FIXME: delete this after V1 is retired
+    Struct.new(:action_name, :params, :resource) do
       include V2::ParameterHandling
     end.new
   end


### PR DESCRIPTION
No longer needed as the two namespaces got diverging enough.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
