### PR TITLE
feat(APIv2): RHINENG-5354 implement the supported_profiles endpoint

### DIFF
--- a/app/controllers/v2/supported_profiles_controller.rb
+++ b/app/controllers/v2/supported_profiles_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module V2
+  # API for Supported Profiles
+  class SupportedProfilesController < ApplicationController
+    def index
+      render_json supported_profiles
+    end
+    permission_for_action :index, Rbac::COMPLIANCE_VIEWER
+
+    private
+
+    def supported_profiles
+      @supported_profiles ||= authorize(resolve_collection)
+    end
+
+    def resource
+      V2::SupportedProfile
+    end
+
+    def serializer
+      V2::SupportedProfileSerializer
+    end
+  end
+end

--- a/app/models/v2/profile.rb
+++ b/app/models/v2/profile.rb
@@ -13,6 +13,6 @@ module V2
     scoped_search on: :ref_id, only_explicit: true, operators: %i[eq ne in notin]
 
     belongs_to :security_guide
-    has_many :profile_os_minor_versions, class_name: 'V2::ProfileOsMinorVersion', dependent: :destroy
+    has_many :os_minor_versions, class_name: 'V2::ProfileOsMinorVersion', dependent: :destroy
   end
 end

--- a/app/models/v2/supported_profile.rb
+++ b/app/models/v2/supported_profile.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V2
+  # Model for the SupportedProfiles view
+  class SupportedProfile < ApplicationRecord
+    # FIXME: clean up after the remodel
+    self.table_name = :supported_profiles
+    self.primary_key = :id
+
+    scoped_search on: :os_major_version, only_explicit: true, operators: %i[eq ne]
+
+    sortable_by :title
+    sortable_by :os_major_version
+    sortable_by :os_minor_versions
+  end
+end

--- a/app/policies/v2/supported_profile_policy.rb
+++ b/app/policies/v2/supported_profile_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V2
+  # Policies for accessing Supported Profiles
+  class SupportedProfilePolicy < V2::ApplicationPolicy
+    def index?
+      true
+    end
+
+    # All users should see all supported profiles
+    class Scope < ::ApplicationPolicy::Scope
+    end
+  end
+end

--- a/app/serializers/v2/supported_profile_serializer.rb
+++ b/app/serializers/v2/supported_profile_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module V2
+  # JSON serialization for SupportedProfile
+  class SupportedProfileSerializer < V2::ApplicationSerializer
+    attributes :title, :ref_id, :security_guide_version, :os_major_version, :os_minor_versions
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
       if !Rails.env.production? || ENV.fetch('ENABLE_API_V2', false)
         scope 'v2', module: 'v2', as: 'v2' do
           resources :security_guides, only: [:index, :show] do
+            get :supported_profiles, action: :index, controller: :supported_profiles, on: :collection
+
             resources :value_definitions, only: [:index, :show], parents: [:security_guide]
             resources :rules, only: [:index, :show], parents: [:security_guide]
             resources :profiles, only: [:index, :show], parents: [:security_guide] do

--- a/db/migrate/20240101101311_create_supported_profiles.rb
+++ b/db/migrate/20240101101311_create_supported_profiles.rb
@@ -1,0 +1,5 @@
+class CreateSupportedProfiles < ActiveRecord::Migration[7.0]
+  def change
+    create_view :supported_profiles
+  end
+end

--- a/db/migrate/20240105155203_reset_datastreams_new_year.rb
+++ b/db/migrate/20240105155203_reset_datastreams_new_year.rb
@@ -1,0 +1,5 @@
+class ResetDatastreamsNewYear < ActiveRecord::Migration[7.0]
+  def up
+    Revision.find_by(name: 'datastreams')&.delete
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_05_155203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "org_id", null: false
     t.index ["org_id"], name: "index_accounts_on_org_id", unique: true
   end
@@ -28,16 +28,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
     t.string "title", null: false
     t.text "description", null: false
     t.string "version", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "package_name"
     t.index ["ref_id", "version"], name: "index_benchmarks_on_ref_id_and_version", unique: true
   end
 
   create_table "business_objectives", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["title"], name: "index_business_objectives_on_title"
   end
 
@@ -46,7 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
     t.string "scope"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
@@ -72,8 +72,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
   create_table "policy_hosts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "policy_id", null: false
     t.uuid "host_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["host_id"], name: "index_policy_hosts_on_host_id"
     t.index ["policy_id", "host_id"], name: "index_policy_hosts_on_policy_id_and_host_id", unique: true
     t.index ["policy_id"], name: "index_policy_hosts_on_policy_id"
@@ -90,8 +90,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
   create_table "profile_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "profile_id", null: false
     t.uuid "rule_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["profile_id", "rule_id"], name: "index_profile_rules_on_profile_id_and_rule_id", unique: true
     t.index ["profile_id"], name: "index_profile_rules_on_profile_id"
     t.index ["rule_id"], name: "index_profile_rules_on_rule_id"
@@ -100,8 +100,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
   create_table "profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "ref_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "description"
     t.uuid "account_id"
     t.uuid "benchmark_id", null: false
@@ -126,8 +126,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
   create_table "revisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "revision", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_revisions_on_name", unique: true
   end
 
@@ -171,8 +171,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
     t.uuid "host_id"
     t.uuid "rule_id"
     t.string "result"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "test_result_id"
     t.index ["host_id", "rule_id", "test_result_id"], name: "index_rule_results_on_host_id_and_rule_id_and_test_result_id", unique: true
     t.index ["host_id"], name: "index_rule_results_on_host_id"
@@ -187,8 +187,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
     t.string "severity"
     t.text "description"
     t.text "rationale"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.boolean "remediation_available", default: false, null: false
     t.uuid "benchmark_id", null: false
@@ -206,13 +206,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
   end
 
   create_table "test_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "start_time"
-    t.datetime "end_time"
+    t.datetime "start_time", precision: nil
+    t.datetime "end_time", precision: nil
     t.decimal "score"
     t.uuid "profile_id"
     t.uuid "host_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "supported", default: true
     t.index ["host_id", "profile_id", "end_time"], name: "index_test_results_on_host_id_and_profile_id_and_end_time", unique: true
     t.index ["host_id"], name: "index_test_results_on_host_id"
@@ -233,8 +233,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
     t.boolean "active"
     t.boolean "org_admin"
     t.uuid "account_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["account_id"], name: "index_users_on_account_id"
   end
 
@@ -347,6 +347,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
       benchmarks.package_name
      FROM benchmarks;
   SQL
+  create_view "supported_profiles", sql_definition: <<-SQL
+      SELECT (array_agg(canonical_profiles.id ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS id,
+      (array_agg(canonical_profiles.title ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS title,
+      canonical_profiles.ref_id,
+      (array_agg(security_guides.version ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS security_guide_version,
+      security_guides.os_major_version,
+      array_agg(DISTINCT profile_os_minor_versions.os_minor_version ORDER BY profile_os_minor_versions.os_minor_version DESC) AS os_minor_versions
+     FROM ((canonical_profiles
+       JOIN security_guides ON ((security_guides.id = canonical_profiles.security_guide_id)))
+       JOIN profile_os_minor_versions ON ((profile_os_minor_versions.profile_id = canonical_profiles.id)))
+    GROUP BY canonical_profiles.ref_id, security_guides.os_major_version;
+  SQL
   create_function :v2_policies_insert, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.v2_policies_insert()
        RETURNS trigger
@@ -355,6 +367,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
       DECLARE bo_id uuid;
       DECLARE result_id uuid;
       BEGIN
+          -- Insert a new business objective record if the business_objective field is
+          -- set to a value and return with its ID.
           INSERT INTO "business_objectives" ("title", "created_at", "updated_at")
           SELECT NEW."business_objective", NOW(), NOW()
           WHERE NEW."business_objective" IS NOT NULL RETURNING "id" INTO "bo_id";
@@ -387,10 +401,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
       AS $function$
       DECLARE bo_id uuid;
       BEGIN
-        SELECT "business_objective_id" INTO "bo_id" FROM "policies" WHERE "id" = OLD."id";
-        DELETE FROM "policies" WHERE "id" = OLD."id";
-        DELETE FROM "business_objectives" WHERE "id" = bo_id;
-        RETURN OLD;
+        DELETE FROM "policies" WHERE "id" = OLD."id" RETURNING "business_objective_id" INTO "bo_id";
+        -- Delete any remaining business objectives associated with the policy of no other policies use it
+        DELETE FROM "business_objectives" WHERE "id" = "bo_id" AND (SELECT COUNT("id") FROM "policies" WHERE "business_objectives"."id" = "bo_id") = 0;
+      RETURN OLD;
       END
       $function$
   SQL
@@ -401,6 +415,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
       AS $function$
       DECLARE "bo_id" uuid;
       BEGIN
+          -- Create a new business objective record if the apropriate field is set and there is no
+          -- existing business objective already assigned to the policy and return with its ID.
           INSERT INTO "business_objectives" ("title", "created_at", "updated_at")
           SELECT NEW."business_objective", NOW(), NOW() FROM "policies" WHERE
             NEW."business_objective" IS NOT NULL AND
@@ -408,6 +424,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
             "policies"."id" = OLD."id"
           RETURNING "id" INTO "bo_id";
 
+          -- If the previous insertion was successful, there is nothing to update, otherwise try to
+          -- update any existing business objective assigned to the policy and return with its ID.
           IF "bo_id" IS NULL THEN
             UPDATE "business_objectives" SET "title" = NEW."business_objective", "updated_at" = NOW()
             FROM "policies" WHERE
@@ -416,6 +434,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
             RETURNING "business_objectives"."id" INTO "bo_id";
           END IF;
 
+          -- Update the policy itself, use the ID of the business objective from the previous two queries,
+          -- if the business_objective field is set to NULL, remove the link between the two tables.
           UPDATE "policies" SET
             "name" = NEW."title",
             "description" = NEW."description",
@@ -423,6 +443,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_095417) do
             "business_objective_id" = CASE WHEN NEW."business_objective" IS NULL THEN NULL ELSE "bo_id" END
           WHERE "id" = OLD."id";
 
+          -- If the business_objective field is set to NULL, delete its record in the business objectives
+          -- table using the ID retrieved during the second query.
           DELETE FROM "business_objectives" USING "policies"
           WHERE NEW."business_objective" IS NULL AND "business_objectives"."id" = "bo_id";
 

--- a/db/views/supported_profiles_v01.sql
+++ b/db/views/supported_profiles_v01.sql
@@ -1,0 +1,11 @@
+SELECT
+  (ARRAY_AGG("canonical_profiles"."id" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "id",
+  (ARRAY_AGG("canonical_profiles"."title" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "title",
+  "canonical_profiles"."ref_id" AS "ref_id",
+  (ARRAY_AGG("security_guides"."version" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "security_guide_version",
+  "security_guides"."os_major_version" AS "os_major_version",
+  ARRAY_AGG(DISTINCT "profile_os_minor_versions"."os_minor_version" ORDER BY "profile_os_minor_versions"."os_minor_version" DESC) AS "os_minor_versions"
+FROM "canonical_profiles"
+INNER JOIN "security_guides" ON "security_guides"."id" = "canonical_profiles"."security_guide_id"
+INNER JOIN "profile_os_minor_versions" ON "profile_os_minor_versions"."profile_id" = "canonical_profiles"."id"
+GROUP BY "canonical_profiles"."ref_id", "security_guides"."os_major_version";

--- a/spec/controllers/v2/supported_profiles_controller_spec.rb
+++ b/spec/controllers/v2/supported_profiles_controller_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe V2::SupportedProfilesController do
+  let(:attributes) do
+    {
+      ref_id: :ref_id,
+      title: :title,
+      security_guide_version: :security_guide_version,
+      os_major_version: :os_major_version,
+      os_minor_versions: :os_minor_versions
+    }
+  end
+
+  let(:current_user) { FactoryBot.create(:v2_user) }
+  let(:rbac_allowed?) { true }
+
+  before do
+    request.headers['X-RH-IDENTITY'] = current_user.account.identity_header.raw
+    allow(StrongerParameters::InvalidValue).to receive(:new) { |value, _| value.to_sym }
+    allow(controller).to receive(:rbac_allowed?).and_return(rbac_allowed?)
+  end
+
+  describe 'GET index' do
+    let(:extra_params) { {} }
+    let(:item_count) { 2 }
+    let(:parents) { nil }
+    let(:v1_profiles) do
+      FactoryBot.create(
+        :v2_security_guide_with_profiles,
+        os_major_version: 7,
+        version: '1.0.0',
+        profile_refs: {
+          c2s: %w[1 2],
+          standard: %w[2],
+          hipaa: %w[1],
+          ospp: %w[2],
+          cui: %w[1 2]
+        }
+      ).profiles
+    end
+    let(:v2_profiles) do
+      FactoryBot.create(
+        :v2_security_guide_with_profiles,
+        os_major_version: 7,
+        version: '2.0.0',
+        profile_refs: {
+          c2s: %w[2],
+          standard: %w[1],
+          ospp: %w[2]
+        }
+      ).profiles
+    end
+    let(:rhel8_profiles) do
+      FactoryBot.create(
+        :v2_security_guide_with_profiles,
+        os_major_version: 8,
+        version: '1.0.0',
+        profile_refs: %w[
+          c2s hipaa standard cui ospp cis_server_l1 pci-dss stig stig-gui e8 cjis ncp ism_o server rhelh-vpp
+        ].each_with_object({}) { |item, obj| obj[item] = %w[0] }
+      ).profiles
+    end
+
+    let(:items) do
+      ids = (rhel8_profiles + v2_profiles + v1_profiles.reject do |profile|
+        v2_profiles.map(&:ref_id).include?(profile.ref_id)
+      end).map(&:id)
+
+      V2::SupportedProfile.where(id: ids).order(:id)
+    end
+
+    it_behaves_like 'collection' do
+      let(:extra_params) { { limit: 20 } }
+    end
+    include_examples 'with metadata' do
+      let(:item_count) { 20 }
+    end
+    it_behaves_like 'paginable'
+    it_behaves_like 'sortable'
+    it_behaves_like 'searchable'
+  end
+end

--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -5,11 +5,20 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     title { Faker::Lorem.sentence }
     description { Faker::Lorem.paragraph }
-    ref_id { "xccdf_org.ssgproject.content_profile_#{SecureRandom.hex}" }
+    ref_id { "xccdf_org.ssgproject.content_profile_#{ref_id_suffix}" }
     security_guide { association :v2_security_guide, os_major_version: os_major_version }
+    upstream { false }
 
     transient do
       os_major_version { 7 }
+      ref_id_suffix { SecureRandom.hex }
+      supports_minors { [] }
+    end
+
+    os_minor_versions do
+      supports_minors&.map do |os_minor_version|
+        association(:profile_os_minor_version, os_minor_version: os_minor_version)
+      end
     end
   end
 end

--- a/spec/factories/profile_os_minor_version.rb
+++ b/spec/factories/profile_os_minor_version.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :profile_os_minor_version, class: 'V2::ProfileOsMinorVersion' do
+    profile { association :v2_profile, os_major_version: os_major_version }
+    os_minor_version { Faker::Number.between(from: 0, to: 9) }
+
+    transient do
+      os_major_version { 7 }
+    end
+  end
+end

--- a/spec/factories/security_guide.rb
+++ b/spec/factories/security_guide.rb
@@ -11,6 +11,19 @@ FactoryBot.define do
       os_major_version { 7 }
     end
 
+    factory :v2_security_guide_with_profiles do
+      transient do
+        profile_count { 3 }
+        profile_refs { profile_count.times.map { SecureRandom.hex } }
+      end
+
+      profiles do
+        profile_refs.map do |ref, supports_minors|
+          association(:v2_profile, ref_id_suffix: ref, supports_minors: supports_minors)
+        end
+      end
+    end
+
     after(:create, &:reload) # FIXME: remove this after the full remodel
   end
 end

--- a/spec/fixtures/files/searchable/supported_profiles_controller.yaml
+++ b/spec/fixtures/files/searchable/supported_profiles_controller.yaml
@@ -1,0 +1,28 @@
+---
+
+- :name: "equality search by os_major_version"
+  :entities:
+    :found:
+      - :factory: :v2_profile
+        :os_major_version: 7
+        :supports_minors:
+          - 0
+    :not_found:
+      - :factory: :v2_profile
+        :os_major_version: 8
+        :supports_minors:
+          - 0
+  :query: (os_major_version = 7)
+- :name: "non-equality search by os_major_version"
+  :entities:
+    :found:
+      - :factory: :v2_profile
+        :os_major_version: 8
+        :supports_minors:
+          - 0
+    :not_found:
+      - :factory: :v2_profile
+        :os_major_version: 7
+        :supports_minors:
+          - 0
+  :query: (os_major_version != 7)

--- a/spec/fixtures/files/sortable/supported_profiles_controller.yaml
+++ b/spec/fixtures/files/sortable/supported_profiles_controller.yaml
@@ -1,0 +1,60 @@
+:entities:
+  - :factory: :v2_profile
+    :title: 'aba'
+    :os_major_version: 7
+    :supports_minors:
+      - 1
+      - 2
+
+  - :factory: :v2_profile
+    :title: 'bac'
+    :os_major_version: 7
+    :supports_minors:
+      - 3
+      - 4
+
+  - :factory: :v2_profile
+    :title: 'aab'
+    :os_major_version: 7
+    :supports_minors:
+      - 4
+      - 5
+
+  - :factory: :v2_profile
+    :title: 'aaa'
+    :os_major_version: 8
+    :supports_minors:
+      - 1
+      - 2
+
+  - :factory: :v2_profile
+    :title: 'caa'
+    :os_major_version: 8
+    :supports_minors:
+      - 2
+      - 3
+
+  - :factory: :v2_profile
+    :title: 'aaa'
+    :os_major_version: 9
+    :supports_minors:
+      - 0
+
+:queries:
+  - :sort_by:
+      - 'title'
+    :result: [[3, 5], 2, 0, 1, 4]
+  - :sort_by:
+      - 'os_major_version'
+    :result: [[0, 1, 2], [3, 4], 5]
+  - :sort_by:
+      - 'os_minor_versions'
+    :result: [5, [0, 3], 4, 1, 2]
+  - :sort_by:
+      - 'os_major_version'
+      - 'os_minor_versions'
+    :result: [0, 1, 2, 3, 4, 5]
+  - :sort_by:
+      - 'title'
+      - 'os_major_version'
+    :result: [3, 5, 2, 0, 1, 4]


### PR DESCRIPTION
The idea here is to extract the complex `OsMinorVersions` query from the GQL implementation to a view, so it can be abstracted away from ActiveRecord. This might change in the future, but as long as we are in the remodelling process, we are fine like this.

The query joins `canonical_profiles` with `security_guides` and the with new `profile_os_minor_versions` table to group results by the `ref_id` and `os_major_version`. This results in a lot of redundant aggregated data, from which w need just the first entity for `id`,  `title` and `security_guide_version`, which are sorted all by the `security_guide_version` always selecting the oldest one. However, we do need all the `os_minor_versions` aggregated into an array of integers so we can construct the support matrix for the create policy page.

The rest of the code is just a classic controller with an index-only approach as we have other workflows to retrieve profiles.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
