### PR TITLE
test(sorting): improve experience and deduplicate definitions

### DIFF
--- a/spec/fixtures/files/sortable/policies_controller.yaml
+++ b/spec/fixtures/files/sortable/policies_controller.yaml
@@ -46,38 +46,14 @@
       - 'title'
     :result: [[3, 5], 2, 0, 1, 4]
   - :sort_by:
-      - 'title:asc'
-    :result: [[3, 5], 2, 0, 1, 4]
-  - :sort_by:
-      - 'title:desc'
-    :result: [4, 1, 0, 2, [3, 5]]
-  - :sort_by:
       - 'business_objective'
     :result: [[3, 5], 2, 0, 1, 4]
-  - :sort_by:
-      - 'business_objective:asc'
-    :result: [[3, 5], 2, 0, 1, 4]
-  - :sort_by:
-      - 'business_objective:desc'
-    :result: [4, 1, 0, 2, [3, 5]]
   - :sort_by:
       - 'compliance_threshold'
     :result: [5, [3, 1], [0, 2], 4]
   - :sort_by:
-      - 'compliance_threshold:asc'
-    :result: [5, [3, 1], [0, 2], 4]
-  - :sort_by:
-      - 'compliance_threshold:desc'
-    :result: [4, [0, 2], [3, 1], 5]
-  - :sort_by:
       - 'os_major_version'
     :result: [[2, 4], [1, 5], [0, 3]]
-  - :sort_by:
-      - 'os_major_version:asc'
-    :result: [[2, 4], [1, 5], [0, 3]]
-  - :sort_by:
-      - 'os_major_version:desc'
-    :result: [[0, 3], [1, 5], [2, 4]]
   - :sort_by:
       - 'os_major_version'
       - 'compliance_threshold'

--- a/spec/fixtures/files/sortable/profiles_controller.yaml
+++ b/spec/fixtures/files/sortable/profiles_controller.yaml
@@ -27,9 +27,3 @@
   - :sort_by:
       - 'title'
     :result: [[3, 5], 2, 0, 1, 4]
-  - :sort_by:
-      - 'title:asc'
-    :result: [[3, 5], 2, 0, 1, 4]
-  - :sort_by:
-      - 'title:desc'
-    :result: [4, 1, 0, 2, [3, 5]]

--- a/spec/fixtures/files/sortable/rules_controller.yaml
+++ b/spec/fixtures/files/sortable/rules_controller.yaml
@@ -74,42 +74,24 @@
       - 'title'
     :result: [[2, 6], 1, 0, 3, 7, 4, 5, 9, 8]
   - :sort_by:
-      - 'title:asc'
-    :result: [[2, 6], 1, 0, 3, 7, 4, 5, 9, 8]
-  - :sort_by:
-      - 'title:desc'
-    :result: [8, 9, 5, 4, 7, 3, 0, 1, [2, 6]]
-  - :sort_by:
       - 'severity'
     :result: [[2, 5, 8], [1, 4, 7], [0, 3, 6, 9]]
   - :sort_by:
-      - 'severity:asc'
-    :result: [[2, 5, 8], [1, 4, 7], [0, 3, 6, 9]]
-  - :sort_by:
-      - 'severity:desc'
-    :result: [[0, 3, 6, 9], [1, 4, 7], [2, 5, 8]]
-  - :sort_by:
       - 'precedence'
     :result: [1, [6, 9], 3, 0, 7, 5, 4, 8, 2]
-  - :sort_by:
-      - 'precedence:asc'
-    :result: [1, [6, 9], 3, 0, 7, 5, 4, 8, 2]
-  - :sort_by:
-      - 'precedence:desc'
-    :result: [2, 8, 4, 5, 7, 0, 3, [6, 9], 1]
 
 # title & severity
   - :sort_by:
-      - 'title:asc'
-      - 'severity:asc'
+      - 'title'
+      - 'severity'
     :result: [2, 6, 1, 0, 3, 7, 4, 5, 9, 8]
   - :sort_by:
-      - 'title:asc'
+      - 'title'
       - 'severity:desc'
     :result: [6, 2, 1, 0, 3, 7, 4, 5, 9, 8]
   - :sort_by:
       - 'title:desc'
-      - 'severity:asc'
+      - 'severity'
     :result: [8, 9, 5, 4, 7, 3, 0, 1, 2, 6]
   - :sort_by:
       - 'title:desc'
@@ -118,16 +100,16 @@
 
 # severity & title
   - :sort_by:
-      - 'severity:asc'
-      - 'title:asc'
+      - 'severity'
+      - 'title'
     :result: [2, 5, 8, 1, 7, 4, 6, 0, 3, 9]
   - :sort_by:
-      - 'severity:asc'
+      - 'severity'
       - 'title:desc'
     :result: [8, 5, 2, 4, 7, 1, 9, 3, 0, 6]
   - :sort_by:
       - 'severity:desc'
-      - 'title:asc'
+      - 'title'
     :result: [6, 0, 3, 9, 1, 7, 4, 2, 5, 8]
   - :sort_by:
       - 'severity:desc'
@@ -136,16 +118,16 @@
 
 # title & precedence
   - :sort_by:
-      - 'title:asc'
-      - 'precedence:asc'
+      - 'title'
+      - 'precedence'
     :result: [6, 2, 1, 0, 3, 7, 4, 5, 9, 8]
   - :sort_by:
-      - 'title:asc'
+      - 'title'
       - 'precedence:desc'
     :result: [2, 6, 1, 0, 3, 7, 4, 5, 9, 8]
   - :sort_by:
       - 'title:desc'
-      - 'precedence:asc'
+      - 'precedence'
     :result: [8, 9, 5, 4, 7, 3, 0, 1, 6, 2]
   - :sort_by:
       - 'title:desc'
@@ -154,16 +136,16 @@
 
 # precedence & title
   - :sort_by:
-      - 'precedence:asc'
-      - 'title:asc'
+      - 'precedence'
+      - 'title'
     :result: [1, 6, 9, 3, 0, 7, 5, 4, 8, 2]
   - :sort_by:
-      - 'precedence:asc'
+      - 'precedence'
       - 'title:desc'
     :result: [1, 9, 6, 3, 0, 7, 5, 4, 8, 2]
   - :sort_by:
       - 'precedence:desc'
-      - 'title:asc'
+      - 'title'
     :result: [2, 8, 4, 5, 7, 0, 3, 6, 9, 1]
   - :sort_by:
       - 'precedence:desc'
@@ -172,16 +154,16 @@
 
 # severity & precedence
   - :sort_by:
-      - 'severity:asc'
-      - 'precedence:asc'
+      - 'severity'
+      - 'precedence'
     :result: [5, 8, 2, 1, 7, 4, [6, 9], 3, 0]
   - :sort_by:
-      - 'severity:asc'
+      - 'severity'
       - 'precedence:desc'
     :result: [2, 8, 5, 4, 7, 1, 0, 3, [6, 9]]
   - :sort_by:
       - 'severity:desc'
-      - 'precedence:asc'
+      - 'precedence'
     :result: [[6, 9], 3, 0, 1, 7, 4, 5, 8, 2]
   - :sort_by:
       - 'severity:desc'
@@ -190,16 +172,16 @@
 
 # precedence & severity
   - :sort_by:
-      - 'precedence:asc'
-      - 'severity:asc'
+      - 'precedence'
+      - 'severity'
     :result: [1, [6, 9], 3, 0, 7, 5, 4, 8, 2]
   - :sort_by:
-      - 'precedence:asc'
+      - 'precedence'
       - 'severity:desc'
     :result: [1, [6, 9], 3, 0, 7, 5, 4, 8, 2]
   - :sort_by:
       - 'precedence:desc'
-      - 'severity:asc'
+      - 'severity'
     :result: [2, 8, 4, 5, 7, 0, 3, [6, 9], 1]
   - :sort_by:
       - 'precedence:desc'

--- a/spec/fixtures/files/sortable/security_guides_controller.yaml
+++ b/spec/fixtures/files/sortable/security_guides_controller.yaml
@@ -34,42 +34,24 @@
       - 'title'
     :result: [[1, 3, 5], 0, 2, 4]
   - :sort_by:
-      - 'title:asc'
-    :result: [[1, 3, 5], 0, 2, 4]
-  - :sort_by:
-      - 'title:desc'
-    :result: [4, 2, 0, [1, 3, 5]]
-  - :sort_by:
       - 'version'
     :result: [1, [5, 3], 4, 2, 0]
   - :sort_by:
-      - 'version:asc'
-    :result: [1, [3, 5], 4, 2, 0]
-  - :sort_by:
-      - 'version:desc'
-    :result: [0, 2, 4, [5, 3], 1]
-  - :sort_by:
       - 'os_major_version'
     :result: [[1, 3, 4], [0, 2, 5]]
-  - :sort_by:
-      - 'os_major_version:asc'
-    :result: [[1, 3, 4], [0, 2, 5]]
-  - :sort_by:
-      - 'os_major_version:desc'
-    :result: [[0, 2, 5], [1, 3, 4]]
 
 # title & version
   - :sort_by:
-      - 'title:asc'
-      - 'version:asc'
+      - 'title'
+      - 'version'
     :result: [1, [3, 5], 0, 2, 4]
   - :sort_by:
-      - 'title:asc'
+      - 'title'
       - 'version:desc'
     :result: [[5, 3], 1, 0, 2, 4]
   - :sort_by:
       - 'title:desc'
-      - 'version:asc'
+      - 'version'
     :result: [4, 2, 0, 1, [3, 5]]
   - :sort_by:
       - 'title:desc'
@@ -78,16 +60,16 @@
 
 # version & title
   - :sort_by:
-      - 'version:asc'
-      - 'title:asc'
+      - 'version'
+      - 'title'
     :result: [1, [3, 5], 4, 2, 0]
   - :sort_by:
-      - 'version:asc'
+      - 'version'
       - 'title:desc'
     :result: [1, [3, 5], 4, 2, 0]
   - :sort_by:
       - 'version:desc'
-      - 'title:asc'
+      - 'title'
     :result: [0, 2, 4, [5, 3], 1]
   - :sort_by:
       - 'title:desc'
@@ -96,16 +78,16 @@
 
 # title & os_major_version
   - :sort_by:
-      - 'title:asc'
-      - 'os_major_version:asc'
+      - 'title'
+      - 'os_major_version'
     :result: [[1, 3], 5, 0, 2, 4]
   - :sort_by:
-      - 'title:asc'
+      - 'title'
       - 'os_major_version:desc'
     :result: [5, [1, 3], 0, 2, 4]
   - :sort_by:
       - 'title:desc'
-      - 'os_major_version:asc'
+      - 'os_major_version'
     :result: [4, 2, 0, [1, 3], 5]
   - :sort_by:
       - 'title:desc'
@@ -114,16 +96,16 @@
 
 # os_major_version & title
   - :sort_by:
-      - 'os_major_version:asc'
-      - 'title:asc'
+      - 'os_major_version'
+      - 'title'
     :result: [[1, 3], 4, 5, 0, 2]
   - :sort_by:
-      - 'os_major_version:asc'
+      - 'os_major_version'
       - 'title:desc'
     :result: [4, [3, 1], 2, 0, 5]
   - :sort_by:
       - 'os_major_version:desc'
-      - 'title:asc'
+      - 'title'
     :result: [5, 0, 2, [3, 1], 4]
   - :sort_by:
       - 'os_major_version:desc'
@@ -132,16 +114,16 @@
 
 # version & os_major_version
   - :sort_by:
-      - 'version:asc'
-      - 'os_major_version:asc'
+      - 'version'
+      - 'os_major_version'
     :result: [1, 3, 5, 4, 2, 0]
   - :sort_by:
-      - 'version:asc'
+      - 'version'
       - 'os_major_version:desc'
     :result: [1, 5, 3, 4, 2, 0]
   - :sort_by:
       - 'version:desc'
-      - 'os_major_version:asc'
+      - 'os_major_version'
     :result: [0, 2, 4, 3, 5, 1]
   - :sort_by:
       - 'version:desc'
@@ -150,16 +132,16 @@
 
 # os_major_version & version
   - :sort_by:
-      - 'os_major_version:asc'
-      - 'version:asc'
+      - 'os_major_version'
+      - 'version'
     :result: [1, 3, 4, 5, 2, 0]
   - :sort_by:
-      - 'os_major_version:asc'
+      - 'os_major_version'
       - 'version:desc'
     :result: [4, 3, 1, 0, 2, 5]
   - :sort_by:
       - 'os_major_version:desc'
-      - 'version:asc'
+      - 'version'
     :result: [5, 2, 0, 1, 3, 4]
   - :sort_by:
       - 'os_major_version:desc'

--- a/spec/fixtures/files/sortable/value_definitions_controller.yaml
+++ b/spec/fixtures/files/sortable/value_definitions_controller.yaml
@@ -27,9 +27,3 @@
   - :sort_by:
       - 'title'
     :result: [[3, 5], 2, 0, 1, 4]
-  - :sort_by:
-      - 'title:asc'
-    :result: [[3, 5], 2, 0, 1, 4]
-  - :sort_by:
-      - 'title:desc'
-    :result: [4, 1, 0, 2, [3, 5]]


### PR DESCRIPTION
From now on the `sortable` shared example in APIv2 specs does not return the mismatching database IDs of entities, but the indexes that we actually compare against in the YAML:
```
       expected: [3, 0, 1, 5, 4, 2]
            got: [0, 3, 1, 5, 4, 2]
```
It does not deal with the nested arrays, that has to be still figured out by the developer, but it definitely improves the experience when writing these YAML files.

Additionally, I dropped the explicit `:asc` and `:desc` tests that have been replaced with automatically generated tests. So from now on if you specify a sorting without a direction, both the explicit `:asc` and reverse `:desc` sorting will be automatically done without specifying it.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
