### PR TITLE
fix(APIv2): correct class name in has_many reference

### DIFF
--- a/app/models/v2/security_guide.rb
+++ b/app/models/v2/security_guide.rb
@@ -17,7 +17,7 @@ module V2
     )
 
     has_many :profiles, class_name: 'V2::Profile', dependent: :destroy
-    has_many :value_definitions, class_name: 'V2::ValueDefinitions', dependent: :destroy
+    has_many :value_definitions, class_name: 'V2::ValueDefinition', dependent: :destroy
     has_many :rules, class_name: 'V2::Rule', dependent: :destroy
 
     searchable_by :title, %i[like unlike eq ne in notin]


### PR DESCRIPTION
Reproducer:

```
irb(main):012:0> V2::SecurityGuide.destroy_all
  V2::SecurityGuide Load (0.7ms)  SELECT "security_guides".* FROM "security_guides"
  TRANSACTION (0.2ms)  BEGIN
  V2::Profile Load (0.3ms)  SELECT "canonical_profiles".* FROM "canonical_profiles" WHERE "canonical_profiles"."security_guide_id" = $1  [["security_guide_id", "857df73d-be70-41bd-82b7-99e95800cf4f"]]
  V2::ProfileOsMinorVersion Load (0.3ms)  SELECT "profile_os_minor_versions".* FROM "profile_os_minor_versions" WHERE "profile_os_minor_versions"."profile_id" = $1  [["profile_id", "f5ad77a4-3f16-4116-a23d-8f73d167587f"]]
  V2::ProfileOsMinorVersion Destroy (0.4ms)  DELETE FROM "profile_os_minor_versions" WHERE "profile_os_minor_versions"."id" = $1  [["id", "288f8f7c-a6f1-489c-bdea-b2b047aa5acb"]]
  V2::Profile Destroy (0.8ms)  DELETE FROM "canonical_profiles" WHERE "canonical_profiles"."id" = $1  [["id", "f5ad77a4-3f16-4116-a23d-8f73d167587f"]]
  TRANSACTION (0.2ms)  ROLLBACK
/usr/share/gems/gems/activerecord-7.0.7.2/lib/active_record/reflection.rb:441:in `rescue in compute_class': Rails couldn't find a valid model for V2::ValueDefinitions association. Please provide the :class_name option on the association declaration. If :class_name is already provided, make sure it's an ActiveRecord::Base subclass. (NameError)
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
