### PR TITLE
perf(pods): RHINENG-8064 increase probes & revert CPU bump

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -232,7 +232,7 @@ objects:
           httpGet:
             path: /api/compliance/v1/status
             port: web
-          initialDelaySeconds: 90
+          initialDelaySeconds: 120
           periodSeconds: 30
         resources:
           limits:
@@ -498,7 +498,7 @@ parameters:
 - name: MEMORY_REQUEST_SERVICE
   value: 600Mi
 - name: CPU_LIMIT_SERVICE
-  value: 1200m
+  value: 800m
 - name: CPU_REQUEST_SERVICE
   value: 200m
 - name: MEMORY_LIMIT_CONSUMER


### PR DESCRIPTION
The readiness probe checks for the DB connection availability, in those moments the `openapi.json` via the static file middleware is definitely available. Therefore, the initial timeout for each can be safely set to the same. Furthermore the CPU bump was not necessary, the issue with deployment unavailability was because of the probes being impatient.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
