### PR TITLE
Minor refactorings, cleanups and deduplications around resolvers

### DIFF
--- a/app/controllers/concerns/v2/collection.rb
+++ b/app/controllers/concerns/v2/collection.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module V2
-  # Generic methods to be used when calling resolve_collection on our models
+  # Generic methods to be used when calling fetch_collection on our models
   module Collection
     extend ActiveSupport::Concern
 
@@ -10,7 +10,7 @@ module V2
     included do
       private
 
-      def resolve_collection
+      def fetch_collection
         scope = filter_by_tags(search(expand_resource))
         count = count_collection(scope)
         # If the count of records equals zero, make sure that the parents exist.

--- a/app/controllers/concerns/v2/collection.rb
+++ b/app/controllers/concerns/v2/collection.rb
@@ -11,13 +11,12 @@ module V2
       private
 
       def resolve_collection
-        scope = search(policy_scope(expand_resource))
+        scope = filter_by_tags(search(expand_resource))
         count = count_collection(scope)
         # If the count of records equals zero, make sure that the parents exist.
         validate_parents! if count.zero? && permitted_params[:parents]&.any?
 
-        result = filter_by_tags(sort(scope))
-        result.limit(pagination_limit).offset(pagination_offset)
+        sort(scope).limit(pagination_limit).offset(pagination_offset)
       end
 
       def count_collection(scope)

--- a/app/controllers/concerns/v2/resolver.rb
+++ b/app/controllers/concerns/v2/resolver.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module V2
+  # Concern for resolving database resources
+  module Resolver
+    extend ActiveSupport::Concern
+
+    def expand_resource
+      # Get the list of fields to be selected from the serializer
+      fields = serializer.fields(permitted_params[:parents], resource.one_to_one)
+      # Append a list of additional fields required to render the response, usually RBAC related
+      fields[nil] += extra_fields
+
+      # Join with the parents assumed from the route
+      scope = join_parents(pundit_scope, permitted_params[:parents])
+      # Join with the additional 1:1 relationships required by the serializer,
+      # select only the fields that are really necessary for the rendering.
+      join_one_to_ones(scope, fields).select(*select_fields(fields))
+    end
+
+    # Reduce through all the parents of the resource and join+scope them on the resource
+    # or return with the resource untouched if not nested under other resources
+    def join_parents(resource, parents)
+      parents.to_a.reduce(resource) do |scope, parent|
+        ref = scope.reflect_on_association(parent)
+        klass = ref.klass
+
+        scope.joins(parent)
+             .where(parent => { klass.primary_key => permitted_params[ref.foreign_key] })
+             .merge(Pundit.policy_scope(current_user, klass))
+      end
+    end
+
+    # Select the 1:1 associations that can be satisfied without any additional WHERE clause,
+    # then join them to the scope.
+    def join_one_to_ones(scope, fields)
+      # Do not join with the already joined parents assumed from the (nested) route
+      associations = fields.keys.excluding(*permitted_params[:parents]).compact
+      scope.where.associated(*associations)
+    end
+
+    # Iterate through the (nested) fields to be selected and set their names accordingly
+    # so it is understood by SQL. Furthermore, alias any field that is coming from a joined
+    # table to avoid any possible hash key collision.
+    def select_fields(fields)
+      fields.flat_map do |(association, columns)|
+        columns.map do |column|
+          if association
+            "#{association}.#{column} AS #{association}__#{column}"
+          else
+            # FIXME: this is just temporary until we figure out aggregations as they will be also arel-based
+            column.is_a?(ApplicationRecord::AN::Node) ? column.to_sql : [resource.table_name, column].join('.')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/v2/resolver.rb
+++ b/app/controllers/concerns/v2/resolver.rb
@@ -18,10 +18,10 @@ module V2
       join_one_to_ones(scope, fields).select(*select_fields(fields))
     end
 
-    # Reduce through all the parents of the resource and join+scope them on the resource
-    # or return with the resource untouched if not nested under other resources
-    def join_parents(resource, parents)
-      parents.to_a.reduce(resource) do |scope, parent|
+    # Reduce through all the parents of the `relation` and join+scope them or return the
+    # `relation˙ untouched if it does not have any parents.
+    def join_parents(relation, parents)
+      parents.to_a.reduce(relation) do |scope, parent|
         ref = scope.reflect_on_association(parent)
         klass = ref.klass
 

--- a/app/controllers/v2/application_controller.rb
+++ b/app/controllers/v2/application_controller.rb
@@ -10,6 +10,7 @@ module V2
     include V2::Metadata
     include V2::Pagination
     include V2::Collection
+    include V2::Resolver
     include V2::Rendering
     include V2::ParameterHandling
     include ::ErrorHandling
@@ -55,58 +56,8 @@ module V2
       user.authorized_to?(Rbac::INVENTORY_HOSTS_READ) && user.authorized_to?(permission)
     end
 
-    def expand_resource
-      # Get the list of fields to be selected from the serializer
-      fields = serializer.fields(permitted_params[:parents], resource.one_to_one)
-      # Append a list of additional fields required to render the response, usually RBAC related
-      fields[nil] += extra_fields
-
-      # Join with the parents assumed from the route
-      scope = join_parents(pundit_scope, permitted_params[:parents])
-      # Join with the additional 1:1 relationships required by the serializer,
-      # select only the fields that are really necessary for the rendering.
-      join_one_to_ones(scope, fields).select(*select_fields(fields))
-    end
-
     def pundit_scope
       Pundit.policy_scope(current_user, resource)
-    end
-
-    # Reduce through all the parents of the resource and join+scope them on the resource
-    # or return with the resource untouched if not nested under other resources
-    def join_parents(resource, parents)
-      parents.to_a.reduce(resource) do |scope, parent|
-        ref = scope.reflect_on_association(parent)
-        klass = ref.klass
-
-        scope.joins(parent)
-             .where(parent => { klass.primary_key => permitted_params[ref.foreign_key] })
-             .merge(Pundit.policy_scope(current_user, klass))
-      end
-    end
-
-    # Select the 1:1 associations that can be satisfied without any additional WHERE clause,
-    # then join them to the scope.
-    def join_one_to_ones(scope, fields)
-      # Do not join with the already joined parents assumed from the (nested) route
-      associations = fields.keys.excluding(*permitted_params[:parents]).compact
-      scope.where.associated(*associations)
-    end
-
-    # Iterate through the (nested) fields to be selected and set their names accordingly
-    # so it is understood by SQL. Furthermore, alias any field that is coming from a joined
-    # table to avoid any possible hash key collision.
-    def select_fields(fields)
-      fields.flat_map do |(association, columns)|
-        columns.map do |column|
-          if association
-            "#{association}.#{column} AS #{association}__#{column}"
-          else
-            # FIXME: this is just temporary until we figure out aggregations as they will be also arel-based
-            column.is_a?(ApplicationRecord::AN::Node) ? column.to_sql : [resource.table_name, column].join('.')
-          end
-        end
-      end
     end
 
     # Default list of additional fields to be passed to the list of selected fields

--- a/app/controllers/v2/policies_controller.rb
+++ b/app/controllers/v2/policies_controller.rb
@@ -57,7 +57,7 @@ module V2
     private
 
     def compliance_policies
-      @compliance_policies ||= authorize(resolve_collection)
+      @compliance_policies ||= authorize(fetch_collection)
     end
 
     def compliance_policy

--- a/app/controllers/v2/profiles_controller.rb
+++ b/app/controllers/v2/profiles_controller.rb
@@ -18,7 +18,7 @@ module V2
     private
 
     def profiles
-      @profiles ||= authorize(resolve_collection)
+      @profiles ||= authorize(fetch_collection)
     end
 
     def profile

--- a/app/controllers/v2/rules_controller.rb
+++ b/app/controllers/v2/rules_controller.rb
@@ -18,7 +18,7 @@ module V2
     private
 
     def rules
-      @rules ||= authorize(resolve_collection)
+      @rules ||= authorize(fetch_collection)
     end
 
     def rule

--- a/app/controllers/v2/security_guides_controller.rb
+++ b/app/controllers/v2/security_guides_controller.rb
@@ -16,7 +16,7 @@ module V2
     private
 
     def security_guides
-      @security_guides ||= authorize(resolve_collection)
+      @security_guides ||= authorize(fetch_collection)
     end
 
     def security_guide

--- a/app/controllers/v2/supported_profiles_controller.rb
+++ b/app/controllers/v2/supported_profiles_controller.rb
@@ -11,7 +11,7 @@ module V2
     private
 
     def supported_profiles
-      @supported_profiles ||= authorize(resolve_collection)
+      @supported_profiles ||= authorize(fetch_collection)
     end
 
     def resource

--- a/app/controllers/v2/systems_controller.rb
+++ b/app/controllers/v2/systems_controller.rb
@@ -16,7 +16,7 @@ module V2
     private
 
     def systems
-      @systems ||= authorize(resolve_collection)
+      @systems ||= authorize(fetch_collection)
     end
 
     def system

--- a/app/controllers/v2/value_definitions_controller.rb
+++ b/app/controllers/v2/value_definitions_controller.rb
@@ -16,7 +16,7 @@ module V2
     private
 
     def value_definitions
-      @value_definitions ||= authorize(resolve_collection)
+      @value_definitions ||= authorize(fetch_collection)
     end
 
     def value_definition


### PR DESCRIPTION
* Renamed `resolve_collection` to `fetch_collection`
* Extracted the `V2::Resolver` concern that now contains the `expand_resource`
* Moved around with the tag filtering as it has to happen before counting the results
* Dropped one `policy_scope` call as it was duplicated in `expand_resource`

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
