### PR TITLE
feat(APIv2): RHINENG-2059 add aggregated list of policies to systems

### DIFF
--- a/app/controllers/concerns/v2/resolver.rb
+++ b/app/controllers/concerns/v2/resolver.rb
@@ -5,54 +5,95 @@ module V2
   module Resolver
     extend ActiveSupport::Concern
 
-    def expand_resource
-      # Get the list of fields to be selected from the serializer
-      fields = serializer.fields(permitted_params[:parents], resource.one_to_one)
-      # Append a list of additional fields required to render the response, usually RBAC related
-      fields[nil] += extra_fields
+    private
 
+    # Building the query that returns all the required data for serialization
+    def expand_resource
       # Join with the parents assumed from the route
       scope = join_parents(pundit_scope, permitted_params[:parents])
-      # Join with the additional 1:1 relationships required by the serializer,
-      # select only the fields that are really necessary for the rendering.
-      join_one_to_ones(scope, fields).select(*select_fields(fields))
+      # Join with the additional 1:1 relationships required by the serializer, select only the
+      # dependencies that are really necessary for the rendering.
+      join_aggregated(join_associated(scope)).select(*select_fields)
     end
 
-    # Reduce through all the parents of the `relation` and join+scope them or return the
-    # `relation˙ untouched if it does not have any parents.
-    def join_parents(relation, parents)
-      parents.to_a.reduce(relation) do |scope, parent|
-        ref = scope.reflect_on_association(parent)
+    # Reduce through all the associations of the `relation` and join+scope them or return the
+    # `relation˙ untouched if it does not have any associations.
+    def join_parents(relation, associations)
+      associations.to_a.reduce(relation) do |scope, association|
+        ref = scope.reflect_on_association(association)
         klass = ref.klass
 
-        scope.joins(parent)
-             .where(parent => { klass.primary_key => permitted_params[ref.foreign_key] })
+        scope.joins(association)
+             .where(association => { klass.primary_key => permitted_params[ref.foreign_key] })
              .merge(Pundit.policy_scope(current_user, klass))
       end
     end
 
     # Select the 1:1 associations that can be satisfied without any additional WHERE clause,
-    # then join them to the scope.
-    def join_one_to_ones(scope, fields)
+    # then join them with the relation.
+    def join_associated(relation)
       # Do not join with the already joined parents assumed from the (nested) route
-      associations = fields.keys.excluding(*permitted_params[:parents]).compact
-      scope.where.associated(*associations)
+      associations = dependencies.keys.excluding(*permitted_params[:parents]).compact
+      relation.where.associated(*associations)
+    end
+
+    # Self-join with the requested aggregations built using 1:n associations, also select
+    # the aggregated field from the self-joined subquery.
+    def join_aggregated(relation)
+      aggregations.reduce(relation) do |scope, (association, aggregation)|
+        scope.joins(subquery_fragment(association, aggregation))
+             .select(aggregation.alias)
+      end
+    end
+
+    # Builds a subquery with the `resource` left outer joined with the `association`, grouped
+    # by the primary key of the `resource` and returning the result with the `aggregation`.
+    # This subquery is then further self-joined with the `resource` and the joining fragment
+    # is extracted from the arel tree.
+    #
+    # The resulting fragment ends up in the following format:
+    # ```
+    # INNER JOIN (
+    #   SELECT "resource"."id", AGG("association"."XY") FROM "resource" LEFT OUTER JOIN "association" ...
+    # ) "aggregate_association" ON "aggregate_association"."id" = "resource"."id";
+    # ```
+    #
+    def subquery_fragment(association, aggregation)
+      sq = resource.left_outer_joins(association)
+                   .group(resource.primary_key)
+                   .select(resource.primary_key, aggregation)
+      resource.arel_join_fragment(sq.arel.as(association.to_s))
     end
 
     # Iterate through the (nested) fields to be selected and set their names accordingly
     # so it is understood by SQL. Furthermore, alias any field that is coming from a joined
     # table to avoid any possible hash key collision.
-    def select_fields(fields)
-      fields.flat_map do |(association, columns)|
-        columns.map do |column|
+    def select_fields
+      dependencies.flat_map do |(association, fields)|
+        fields.map do |field|
           if association
-            "#{association}.#{column} AS #{association}__#{column}"
+            "#{association}.#{field} AS #{association}__#{field}"
           else
             # FIXME: this is just temporary until we figure out aggregations as they will be also arel-based
-            column.is_a?(ApplicationRecord::AN::Node) ? column.to_sql : [resource.table_name, column].join('.')
+            field.is_a?(ApplicationRecord::AN::Node) ? field.to_sql : [resource.table_name, field].join('.')
           end
         end
       end
+    end
+
+    # Get the list of dependent (relations => [fields]) to be selected from the serializer and append the
+    # list of additional fields required to render the response, usually RBAC related.
+    def dependencies
+      @dependencies ||= begin
+        deps = serializer.dependencies(permitted_params[:parents], resource.one_to_one)
+        deps[nil] += extra_fields
+        deps
+      end
+    end
+
+    # Retrieve the list of aggregations on any one-to-many associations specified by the serializer
+    def aggregations
+      @aggregations ||= serializer.aggregations(resource.one_to_many)
     end
   end
 end

--- a/app/models/v2/application_record.rb
+++ b/app/models/v2/application_record.rb
@@ -24,5 +24,22 @@ module V2
         obj << key.to_sym if reflection.has_one? || reflection.belongs_to?
       end
     end
+
+    # Returns with a list of symbols describing one-to-many relationships
+    def self.one_to_many
+      reflections.each_with_object([]) do |(key, reflection), obj|
+        obj << key.to_sym unless reflection.has_one? || reflection.belongs_to?
+      end
+    end
+
+    # Creates an Arel-fragment from a self-joined subquery that can be passed as an argument
+    # to the `ActiveRecord::Base.joins` method.
+    # rubocop:disable Metrics/AbcSize
+    def self.arel_join_fragment(subquery)
+      select(primary_key).arel.join(subquery)
+                         .on(subquery[primary_key].eq(arel_table[primary_key]))
+                         .ast.cores.first.source.right.first
+    end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/models/v2/system.rb
+++ b/app/models/v2/system.rb
@@ -46,6 +46,21 @@ module V2
       ]
     )
 
+    POLICIES = AN::NamedFunction.new(
+      'COALESCE', [
+        AN::NamedFunction.new(
+          'JSON_AGG', [
+            AN::NamedFunction.new(
+              'JSON_BUILD_OBJECT', [
+                AN::Quoted.new('id'), Policy.arel_table[:id], AN::Quoted.new('title'), Policy.arel_table[:title]
+              ]
+            )
+          ]
+        ).filter(Policy.arel_table[:id].not_eq(nil)),
+        AN::Quoted.new('[]')
+      ]
+    )
+
     sortable_by :display_name
     sortable_by :os_major_version
     sortable_by :os_minor_version

--- a/app/serializers/v2/system_serializer.rb
+++ b/app/serializers/v2/system_serializer.rb
@@ -6,8 +6,9 @@ module V2
     attributes :display_name, :groups, :culled_timestamp,
                :stale_timestamp, :stale_warning_timestamp, :updated, :insights_id, :tags
 
-    # TODO: policies field only makes sense after assignment is possible
     derived_attribute :os_major_version, V2::System::OS_MAJOR_VERSION
     derived_attribute :os_minor_version, V2::System::OS_MINOR_VERSION
+
+    aggregated_attribute :policies, :policies, V2::System::POLICIES
   end
 end

--- a/spec/controllers/v2/systems_controller_spec.rb
+++ b/spec/controllers/v2/systems_controller_spec.rb
@@ -15,6 +15,7 @@ describe V2::SystemsController do
       updated: -> { updated.as_json },
       insights_id: :insights_id,
       tags: :tags,
+      policies: -> { policies.map { |policy| { id: policy.id, name: policy.name } } },
       os_major_version: -> { system_profile&.dig('operating_system', 'major') },
       os_minor_version: -> { system_profile&.dig('operating_system', 'minor') }
     }


### PR DESCRIPTION
I created a self-join solution for aggregating self-to-many resources that can be declared using the new `aggregated_attribute` DSL method in the V2 serializers. The self-join part is done in the `V2::Resolver` concern automatically, based on what the serializer returns when requested. This allows us to combine aggregated datasets into an API response without tampering with the integrity of the rest of the returned data.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
