### PR TITLE
fix(Resolver): RHINENG-5978 temporarily use a subquery for scoping

### DIFF
--- a/app/controllers/concerns/v2/resolver.rb
+++ b/app/controllers/concerns/v2/resolver.rb
@@ -25,7 +25,7 @@ module V2
 
         scope.joins(association)
              .where(association => { klass.primary_key => permitted_params[ref.foreign_key] })
-             .merge(Pundit.policy_scope(current_user, klass))
+             .where(pundit_subquery(association))
       end
     end
 
@@ -94,6 +94,13 @@ module V2
     # Retrieve the list of aggregations on any one-to-many associations specified by the serializer
     def aggregations
       @aggregations ||= serializer.aggregations(resource.one_to_many)
+    end
+
+    def pundit_subquery(association)
+      ref = resource.reflect_on_association(association)
+      klass = ref.klass
+
+      { association => { klass.primary_key => Pundit.policy_scope(current_user, klass) } }
     end
   end
 end


### PR DESCRIPTION
There is an [issue](https://github.com/rails/rails/pull/49047) with `ActiveRecord::Base.merge` when the left side has a table alias. Until it gets fixed, we should use this subquery as a temporary solution. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
