### PR TITLE
refactor(specs): allow marking scalars to be skipped from URL params

### DIFF
--- a/spec/controllers/v2/concerns/indexable_by_ref_id_spec.rb
+++ b/spec/controllers/v2/concerns/indexable_by_ref_id_spec.rb
@@ -7,7 +7,7 @@
 # ```
 # let(:extra_params) { { security_guide_id: 123, profile_id: 456, id: 789 } }
 #
-# it_behaves_like 'individual', :security_guide, :profile
+# it_behaves_like 'indexable by ref_id', :security_guide, :profile
 # ```
 #
 # In a non-nested case the let block should the ID to search for and the `parents` parameter
@@ -15,13 +15,21 @@
 # ```
 # let(:extra_params) { { id: 789 } }
 #
-# it_behaves_like 'individual'
+# it_behaves_like 'indexable by ref_id'
+# ```
+# In some cases, however, additional ActiveRecord objects and scalar values are required for
+# invoking a factory. Therefore, if you don't want these objects to be passed to the `params`
+# of the request, you can safely specify ActiveRecord objects in the `extra_params`. For scalar
+# values you can use the `pw()` wrapper method that makes sure that the value is only passed to
+# the factory and not to the URL params.
+# ```
+# let(:extra_params) { { account: FactoryBot.create(:v2_account), system_count: pw(10) } }
+#
+# it_behaves_like 'indexable by ref_id'
 # ```
 #
 RSpec.shared_examples 'indexable by ref_id' do |*parents|
-  let(:passable_params) do
-    extra_params.reject { |_, ep| ep.is_a?(ActiveRecord::Base) }
-  end
+  let(:passable_params) { reject_nonscalar(extra_params) }
 
   it 'returns item by ref_id' do
     expected = hash_including('data' => {

--- a/spec/controllers/v2/concerns/paginable_spec.rb
+++ b/spec/controllers/v2/concerns/paginable_spec.rb
@@ -18,11 +18,13 @@
 # it_behaves_like 'paginable'
 # ```
 #
-# In some cases, however, additional ActiveRecord objects are required for invoking a factory.
-# Therefore, if you don't want these objects to be passed to the `params` of the request, you
-# can specify them in the `extra_params` as objects (i.e. without the `_id` suffix):
+# In some cases, however, additional ActiveRecord objects and scalar values are required for
+# invoking a factory. Therefore, if you don't want these objects to be passed to the `params`
+# of the request, you can safely specify ActiveRecord objects in the `extra_params`. For scalar
+# values you can use the `pw()` wrapper method that makes sure that the value is only passed to
+# the factory and not to the URL params.
 # ```
-# let(:extra_params) { { account: FactoryBot.create(:v2_account) } }
+# let(:extra_params) { { account: FactoryBot.create(:v2_account), system_count: pw(10) } }
 #
 # it_behaves_like 'paginable'
 # ```
@@ -30,9 +32,8 @@
 RSpec.shared_examples 'paginable' do |*parents|
   let(:item_count) { 20 } # We need more items to be created to test pagination properly
 
-  let(:passable_params) do
-    extra_params.reject { |_, ep| ep.is_a?(ActiveRecord::Base) }
-  end
+  # Do not pass instances of `ActiveRecord` or scalar values wrapped with `pw()` to the URL parameters
+  let(:passable_params) { reject_nonscalar(extra_params) }
 
   [2, 5, 10, 15, 20].each do |per_page|
     it "returns with the requested #{per_page} records per page" do

--- a/spec/controllers/v2/concerns/rendering_spec.rb
+++ b/spec/controllers/v2/concerns/rendering_spec.rb
@@ -18,19 +18,19 @@
 # it_behaves_like 'collection'
 # ```
 #
-# In some cases, however, additional ActiveRecord objects are required for invoking a factory.
-# Therefore, if you don't want these objects to be passed to the `params` of the request, you
-# can specify them in the `extra_params` as objects (i.e. without the `_id` suffix):
+# In some cases, however, additional ActiveRecord objects and scalar values are required for
+# invoking a factory. Therefore, if you don't want these objects to be passed to the `params`
+# of the request, you can safely specify ActiveRecord objects in the `extra_params`. For scalar
+# values you can use the `pw()` wrapper method that makes sure that the value is only passed to
+# the factory and not to the URL params.
 # ```
-# let(:extra_params) { { account: FactoryBot.create(:v2_account) } }
+# let(:extra_params) { { account: FactoryBot.create(:v2_account), system_count: pw(10) } }
 #
 # it_behaves_like 'collection'
 # ```
 #
 RSpec.shared_examples 'collection' do |*parents|
-  let(:passable_params) do
-    extra_params.reject { |_, ep| ep.is_a?(ActiveRecord::Base) }
-  end
+  let(:passable_params) { reject_nonscalar(extra_params) }
 
   it 'returns base fields for each result' do
     collection = items.map do |item|
@@ -117,10 +117,19 @@ end
 # it_behaves_like 'individual'
 # ```
 #
+# In some cases, however, additional ActiveRecord objects and scalar values are required for
+# invoking a factory. Therefore, if you don't want these objects to be passed to the `params`
+# of the request, you can safely specify ActiveRecord objects in the `extra_params`. For scalar
+# values you can use the `pw()` wrapper method that makes sure that the value is only passed to
+# the factory and not to the URL params.
+# ```
+# let(:extra_params) { { account: FactoryBot.create(:v2_account), system_count: pw(10) } }
+#
+# it_behaves_like 'individual'
+# ```
+#
 RSpec.shared_examples 'individual' do |*parents|
-  let(:passable_params) do
-    extra_params.reject { |_, ep| ep.is_a?(ActiveRecord::Base) }
-  end
+  let(:passable_params) { reject_nonscalar(extra_params) }
 
   it 'returns item by id' do
     expected = hash_including('data' => {

--- a/spec/controllers/v2/concerns/searchable_spec.rb
+++ b/spec/controllers/v2/concerns/searchable_spec.rb
@@ -43,19 +43,19 @@
 # it_behaves_like 'searchable'
 # ```
 #
-# In some cases, however, additional ActiveRecord objects are required for invoking a factory.
-# Therefore, if you don't want these objects to be passed to the `params` of the request, you
-# can specify them in the `extra_params` as objects (i.e. without the `_id` suffix):
+# In some cases, however, additional ActiveRecord objects and scalar values are required for
+# invoking a factory. Therefore, if you don't want these objects to be passed to the `params`
+# of the request, you can safely specify ActiveRecord objects in the `extra_params`. For scalar
+# values you can use the `pw()` wrapper method that makes sure that the value is only passed to
+# the factory and not to the URL params.
 # ```
-# let(:extra_params) { { account: FactoryBot.create(:v2_account) } }
+# let(:extra_params) { { account: FactoryBot.create(:v2_account), system_count: pw(10) } }
 #
 # it_behaves_like 'searchable'
 # ```
 #
 RSpec.shared_examples 'searchable' do |*parents|
-  let(:passable_params) do
-    extra_params.reject { |_, ep| ep.is_a?(ActiveRecord::Base) }
-  end
+  let(:passable_params) { reject_nonscalar(extra_params) }
 
   path = Rails.root.join('spec/fixtures/files/searchable', "#{described_class.name.demodulize.underscore}.yaml")
   searches = YAML.safe_load_file(path, permitted_classes: [Symbol])

--- a/spec/controllers/v2/concerns/sortable_spec.rb
+++ b/spec/controllers/v2/concerns/sortable_spec.rb
@@ -42,19 +42,19 @@
 # it_behaves_like 'sortable'
 # ```
 #
-# In some cases, however, additional ActiveRecord objects are required for invoking a factory.
-# Therefore, if you don't want these objects to be passed to the `params` of the request, you
-# can specify them in the `extra_params` as objects (i.e. without the `_id` suffix):
+# In some cases, however, additional ActiveRecord objects and scalar values are required for
+# invoking a factory. Therefore, if you don't want these objects to be passed to the `params`
+# of the request, you can safely specify ActiveRecord objects in the `extra_params`. For scalar
+# values you can use the `pw()` wrapper method that makes sure that the value is only passed to
+# the factory and not to the URL params.
 # ```
-# let(:extra_params) { { account: FactoryBot.create(:v2_account) } }
+# let(:extra_params) { { account: FactoryBot.create(:v2_account), system_count: pw(10) } }
 #
 # it_behaves_like 'sortable'
 # ```
 #
 RSpec.shared_examples 'sortable' do |*parents|
-  let(:passable_params) do
-    extra_params.reject { |_, ep| ep.is_a?(ActiveRecord::Base) }
-  end
+  let(:passable_params) { reject_nonscalar(extra_params) }
 
   path = Rails.root.join('spec/fixtures/files/sortable', "#{described_class.name.demodulize.underscore}.yaml")
   tests = YAML.safe_load_file(path, permitted_classes: [Symbol])

--- a/spec/controllers/v2/concerns/with_metadata_spec.rb
+++ b/spec/controllers/v2/concerns/with_metadata_spec.rb
@@ -18,19 +18,19 @@
 # include_examples 'with_metadata'
 # ```
 #
-# In some cases, however, additional ActiveRecord objects are required for invoking a factory.
-# Therefore, if you don't want these objects to be passed to the `params` of the request, you
-# can specify them in the `extra_params` as objects (i.e. without the `_id` suffix):
+# In some cases, however, additional ActiveRecord objects and scalar values are required for
+# invoking a factory. Therefore, if you don't want these objects to be passed to the `params`
+# of the request, you can safely specify ActiveRecord objects in the `extra_params`. For scalar
+# values you can use the `pw()` wrapper method that makes sure that the value is only passed to
+# the factory and not to the URL params.
 # ```
-# let(:extra_params) { { account: FactoryBot.create(:v2_account) } }
+# let(:extra_params) { { account: FactoryBot.create(:v2_account), system_count: pw(10) } }
 #
 # it_behaves_like 'with_metadata'
 # ```
 #
 RSpec.shared_examples 'with metadata' do |*parents|
-  let(:passable_params) do
-    extra_params.reject { |_, ep| ep.is_a?(ActiveRecord::Base) }
-  end
+  let(:passable_params) { reject_nonscalar(extra_params) }
 
   let(:item_count) { 10 }
 

--- a/spec/controllers/v2/policies_controller_spec.rb
+++ b/spec/controllers/v2/policies_controller_spec.rb
@@ -25,15 +25,14 @@ describe V2::PoliciesController do
   end
 
   context '/policies' do
-    let(:systems) do
-      # We are not using these systems, but we need their OS major versions to be passed into factories in sortable
+    let(:rhels) do
       [7, 8, 9].each_with_object({}) do |i, obj|
-        obj["system_#{i}".to_sym] = FactoryBot.create(:system, account: current_user.account, os_major_version: i)
+        obj["rhel_#{i}".to_sym] = pw(i)
       end
     end
 
     describe 'GET index' do
-      let(:extra_params) { { account: current_user.account, **systems } }
+      let(:extra_params) { { account: current_user.account, **rhels } }
       let(:parents) { nil }
       let(:item_count) { 2 }
 
@@ -214,7 +213,9 @@ describe V2::PoliciesController do
 
     describe 'GET index' do
       let(:extra_params) do
-        { account: current_user.account, system_id: parent.id, system_7: parent, system_8: parent, system_9: parent }
+        ver = pw(parent.os_major_version)
+        # Pass the same RHEL version under each `rhel_#` parameter as we are under a policy
+        { account: current_user.account, system_id: parent.id, rhel_7: ver, rhel_8: ver, rhel_9: ver }
       end
       let(:parent) { FactoryBot.create(:system, account: current_user.account) }
       let(:item_count) { 2 }

--- a/spec/controllers/v2/tailorings_controller_spec.rb
+++ b/spec/controllers/v2/tailorings_controller_spec.rb
@@ -37,8 +37,7 @@ describe V2::TailoringsController do
           profile: canonical_profiles.last
         )
       end
-      # passing policy explicitly, to have it's ref_id accessible in in YAML fixture
-      let(:extra_params) { { policy: parent, policy_id: parent.id } }
+      let(:extra_params) { { ref_id: pw(parent.ref_id), policy_id: parent.id } }
       let(:item_count) { 3 }
       let(:items) do
         item_count.times.map do |version|

--- a/spec/fixtures/files/searchable/tailorings_controller.yaml
+++ b/spec/fixtures/files/searchable/tailorings_controller.yaml
@@ -6,16 +6,16 @@
       - :factory: :v2_tailoring
         :os_minor_version: 2
         :policy_id: ${policy_id}
-        :ref_id: ${policy.ref_id}
+        :ref_id: ${ref_id}
     :not_found:
       - :factory: :v2_tailoring
         :os_minor_version: 1
         :policy_id: ${policy_id}
-        :ref_id: ${policy.ref_id}
+        :ref_id: ${ref_id}
       - :factory: :v2_tailoring
         :os_minor_version: 0
         :policy_id: ${policy_id}
-        :ref_id: ${policy.ref_id}
+        :ref_id: ${ref_id}
   :query: (os_minor_version = 2)
 - :name: "non-equality search by os_minor_version"
   :entities:
@@ -23,14 +23,14 @@
       - :factory: :v2_tailoring
         :os_minor_version: 2
         :policy_id: ${policy_id}
-        :ref_id: ${policy.ref_id}
+        :ref_id: ${ref_id}
       - :factory: :v2_tailoring
         :os_minor_version: 1
         :policy_id: ${policy_id}
-        :ref_id: ${policy.ref_id}
+        :ref_id: ${ref_id}
     :not_found:
       - :factory: :v2_tailoring
         :os_minor_version: 0
         :policy_id: ${policy_id}
-        :ref_id: ${policy.ref_id}
+        :ref_id: ${ref_id}
   :query: (os_minor_version != 0)

--- a/spec/fixtures/files/sortable/policies_controller.yaml
+++ b/spec/fixtures/files/sortable/policies_controller.yaml
@@ -3,7 +3,7 @@
     :title: 'aba'
     :business_objective: 'aba'
     :compliance_threshold: 90
-    :os_major_version: ${system_9.os_major_version}
+    :os_major_version: ${rhel_9}
     :supports_minors:
       - 0
     :account: ${account}
@@ -13,7 +13,7 @@
     :title: 'bac'
     :business_objective: 'bac'
     :compliance_threshold: 85
-    :os_major_version: ${system_8.os_major_version}
+    :os_major_version: ${rhel_8}
     :supports_minors:
       - 0
     :account: ${account}
@@ -23,7 +23,7 @@
     :title: 'aab'
     :business_objective: 'aab'
     :compliance_threshold: 90
-    :os_major_version: ${system_7.os_major_version}
+    :os_major_version: ${rhel_7}
     :supports_minors:
       - 0
     :account: ${account}
@@ -33,7 +33,7 @@
     :title: 'aaa'
     :business_objective: 'aaa'
     :compliance_threshold: 85
-    :os_major_version: ${system_9.os_major_version}
+    :os_major_version: ${rhel_9}
     :supports_minors:
       - 0
     :account: ${account}
@@ -43,7 +43,7 @@
     :title: 'caa'
     :business_objective: 'caa'
     :compliance_threshold: 100
-    :os_major_version: ${system_7.os_major_version}
+    :os_major_version: ${rhel_7}
     :supports_minors:
       - 0
     :account: ${account}
@@ -53,7 +53,7 @@
     :title: 'aaa'
     :business_objective: 'aaa'
     :compliance_threshold: 80
-    :os_major_version: ${system_8.os_major_version}
+    :os_major_version: ${rhel_8}
     :supports_minors:
       - 0
     :account: ${account}

--- a/spec/fixtures/files/sortable/tailorings_controller.yaml
+++ b/spec/fixtures/files/sortable/tailorings_controller.yaml
@@ -2,17 +2,17 @@
   - :factory: :v2_tailoring
     :os_minor_version: 0
     :policy_id: ${policy_id}
-    :ref_id: ${policy.ref_id}
+    :ref_id: ${ref_id}
 
   - :factory: :v2_tailoring
     :os_minor_version: 1
     :policy_id: ${policy_id}
-    :ref_id: ${policy.ref_id}
+    :ref_id: ${ref_id}
 
   - :factory: :v2_tailoring
     :os_minor_version: 2
     :policy_id: ${policy_id}
-    :ref_id: ${policy.ref_id}
+    :ref_id: ${ref_id}
 
 :queries:
   - :sort_by:


### PR DESCRIPTION
The `extra_params` in controller spec shared examples has a dual use:
* additional attributes for the factories
* additional parameters for the URL as `passable_params`

While the factories have no problems with consuming any kind of parameters, the `passable_params` it a bit more picky as routing often depend on what params are passed to a controller. Furthermore, sometimes we want to pass values to the factory that we don't want to see in the URL. As an initial solution, there was a simple logic implemented in the `passable_params` to omit any object that is the instance of `ActiveRecord::Base`, which allowed us to pass objects to the `extra_params` without polluting the URL. 

This solution isn't flexible enough for our needs and we already had to do some hacks when testing `V2::PoliciesController` and `V2::SystemsController`. So as a simplification, I am proposing a `pw` (parameter-wrapper) method that can mark scalar values such as integers or strings to be skipped from `passable_params` while consuming them for factories.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
