### PR TITLE
perf(clowder): increase RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR to 1.2

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -173,7 +173,7 @@ objects:
         - name: OLD_PATH_PREFIX
           value: "${OLD_PATH_PREFIX}"
         - name: RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
-          value: '0.9'
+          value: '1.2'
         - name: SECRET_KEY_BASE
           valueFrom:
             secretKeyRef:
@@ -226,13 +226,13 @@ objects:
           httpGet:
             path: /api/compliance/v1/openapi.json
             port: web
-          initialDelaySeconds: 120
+          initialDelaySeconds: 10
           periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /api/compliance/v1/status
             port: web
-          initialDelaySeconds: 120
+          initialDelaySeconds: 10
           periodSeconds: 30
         resources:
           limits:


### PR DESCRIPTION
Should improve the startup speed of the service pod (tested in ephemeral) and have less pressure on the alerts when deploying. Also we can decrease the initial delays for liveness/readiness probes to a lower level.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
