### PR TITLE
cleanup(V2): remove coverage masks and obsolete compatibility methods

### DIFF
--- a/app/controllers/concerns/v2/collection.rb
+++ b/app/controllers/concerns/v2/collection.rb
@@ -34,7 +34,6 @@ module V2
         join_parents(reflection.klass, parents).find(permitted_params[reflection.foreign_key])
       end
 
-      # :nocov:
       def filter_by_tags(data)
         unless TagFiltering.tags_supported?(resource) && permitted_params[:tags]&.any?
           return data
@@ -43,9 +42,7 @@ module V2
         tags = parse_tags(permitted_params[:tags])
         data.where('tags @> ?', tags.to_json)
       end
-      # :nocov:
 
-      # :nocov:
       def search(data)
         return data if permitted_params[:filter].blank?
 
@@ -56,7 +53,6 @@ module V2
 
         data.search_for(permitted_params[:filter])
       end
-      # :nocov:
 
       def sort(data)
         order_hash = data.klass.build_order_by(permitted_params[:sort_by])

--- a/app/controllers/concerns/v2/parameter_handling.rb
+++ b/app/controllers/concerns/v2/parameter_handling.rb
@@ -58,16 +58,6 @@ module V2
 
       permitted_params_for_action :show, id: ParamType.string
 
-      # FIXME: compatibility with the V1 logic from the common concerns
-      def relationships_enabled?
-        false
-      end
-
-      # FIXME: compatibility with the V1 logic from the common concerns
-      def include_params
-        false
-      end
-
       # Use the params[:parents] configured by the route to construct a permit
       # hash containing each ID passed from the parents of a nested resource.
       def permit_parent_ids

--- a/app/controllers/concerns/v2/rendering.rb
+++ b/app/controllers/concerns/v2/rendering.rb
@@ -17,13 +17,10 @@ module V2
         }, status: status }.merge(opts))
       end
 
-      # FIXME: coverage mask should be removed after the policies endpoint is done
-      # :nocov:
       def render_model_errors(models, status: :not_acceptable, **opts)
         messages = model_errors(models)
         render_error(messages, status: status, **opts)
       end
-      # :nocov:
 
       private
 
@@ -53,8 +50,6 @@ module V2
         ['index'].include?(action_name)
       end
 
-      # FIXME: coverage mask should be removed after the policies endpoint is done
-      # :nocov:
       def model_errors(models = [])
         models = [models].flatten
         models.flat_map do |model|
@@ -64,7 +59,6 @@ module V2
           end
         end
       end
-      # :nocov:
 
       # :nocov:
       def serializer

--- a/app/controllers/concerns/v2/resolver.rb
+++ b/app/controllers/concerns/v2/resolver.rb
@@ -74,7 +74,6 @@ module V2
           if association
             "#{association}.#{field} AS #{association}__#{field}"
           else
-            # FIXME: this is just temporary until we figure out aggregations as they will be also arel-based
             field.is_a?(ApplicationRecord::AN::Node) ? field.to_sql : [resource.table_name, field].join('.')
           end
         end

--- a/app/models/concerns/v2/sortable.rb
+++ b/app/models/concerns/v2/sortable.rb
@@ -22,11 +22,9 @@ module V2
 
       # Declares the field to be used for the basis of deterministic sorting
       # when retrieving records.
-      # :nocov:
       def default_sort(column)
         @default_sort = column
       end
-      # :nocov:
 
       def sortable_by(column, statement = column)
         @sortable_by ||= {}
@@ -51,7 +49,6 @@ module V2
         end
       end
 
-      # :nocov:
       def assert_sortable_by!(column, direction)
         unless @sortable_by.key?(column&.to_sym)
           raise ::Exceptions::InvalidSortingColumn, column
@@ -61,7 +58,6 @@ module V2
 
         raise ::Exceptions::InvalidSortingDirection, direction
       end
-      # :nocov:
 
       def fetch_rule_by_column(column)
         rule = @sortable_by[column]

--- a/app/models/v2/policy.rb
+++ b/app/models/v2/policy.rb
@@ -23,7 +23,7 @@ module V2
 
     sortable_by :title
     sortable_by :os_major_version, 'security_guide.os_major_version'
-    sortable_by :total_system_count # TODO: figure out how to test this
+    sortable_by :total_system_count
     sortable_by :business_objective
     sortable_by :compliance_threshold
 

--- a/app/models/v2/system.rb
+++ b/app/models/v2/system.rb
@@ -95,11 +95,9 @@ module V2
       where(groups.include?([]) ? grouped.or(ungrouped) : grouped)
     }
 
-    # :nocov:
     def readonly?
       Rails.env.production?
     end
-    # :nocov:
 
     def group_ids
       groups.map { |group| group['id'] } || []

--- a/app/policies/v2/application_policy.rb
+++ b/app/policies/v2/application_policy.rb
@@ -16,27 +16,19 @@ module V2
     def index?
       false
     end
-    # :nocov:
 
-    # :nocov:
     def show?
       false
     end
-    # :nocov:
 
-    # :nocov:
     def create?
       false
     end
-    # :nocov:
 
-    # :nocov:
     def update?
       false
     end
-    # :nocov:
 
-    # :nocov:
     def destroy?
       false
     end
@@ -47,11 +39,9 @@ module V2
 
     private
 
-    # :nocov:
     def match_account?
       record.account_id == user.account_id
     end
-    # :nocov:
 
     # Generic scope for all models - just matching the account ID.
     # To be overridden on individual model policies if needed.


### PR DESCRIPTION
I've added some coverage masks when copy-pasting old (and untested) code into V2 that is no longer needed. Furthermore, there were some methods that maintained compatibility with APIv1 that is now obsolete as we namespaced more V2 concerns.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
