### PR TITLE
cleanup(sortable): drop arel hash sorting compensation

### DIFF
--- a/app/models/concerns/sortable.rb
+++ b/app/models/concerns/sortable.rb
@@ -38,15 +38,7 @@ module Sortable
         column, direction = field.underscore.split(':')
         assert_sortable_by!(column, direction)
 
-        # FIXME: Rails cannot deal with Arel nodes in order hashes.
-        # After the bug is resolved, the compensation will be no longer
-        # necessaryand the fetching can be simply done by:
-        # rule = @sortable_by[column.to_sym]
-        #
-        # BUG: https://github.com/rails/rails/issues/44282
-        # FIX: https://github.com/rails/rails/pull/44284
-        rule = fetch_rule_by_column(column.to_sym)
-
+        rule = @sortable_by[column.to_sym]
         obj[:h][rule[:statement]] = direction || 'asc'
         obj[:s] << rule[:scope] if rule[:scope]
       end
@@ -60,16 +52,6 @@ module Sortable
       return if ['asc', 'desc', nil].include?(direction)
 
       raise ::Exceptions::InvalidSortingDirection, direction
-    end
-
-    def fetch_rule_by_column(column)
-      rule = @sortable_by[column]
-      if rule[:statement].is_a?(Arel::Nodes::Node)
-        # Arel node conversion to make both Rails and Brakeman happy
-        rule[:statement] = Arel.sql(rule[:statement].to_sql)
-      end
-
-      rule
     end
   end
 end

--- a/app/models/concerns/v2/sortable.rb
+++ b/app/models/concerns/v2/sortable.rb
@@ -36,15 +36,7 @@ module V2
           column, direction = field.underscore.split(':')
           assert_sortable_by!(column, direction)
 
-          # FIXME: Rails cannot deal with Arel nodes in order hashes.
-          # After the bug is resolved, the compensation will be no longer
-          # necessaryand the fetching can be simply done by:
-          # rule = @sortable_by[column.to_sym]
-          #
-          # BUG: https://github.com/rails/rails/issues/44282
-          # FIX: https://github.com/rails/rails/pull/44284
-          rule = fetch_rule_by_column(column.to_sym)
-
+          rule = @sortable_by[column.to_sym]
           obj[rule] = direction || 'asc'
         end
       end
@@ -57,16 +49,6 @@ module V2
         return if ['asc', 'desc', nil].include?(direction)
 
         raise ::Exceptions::InvalidSortingDirection, direction
-      end
-
-      def fetch_rule_by_column(column)
-        rule = @sortable_by[column]
-        if rule.is_a?(Arel::Nodes::Node)
-          # Arel node conversion to make both Rails and Brakeman happy
-          rule = Arel.sql(rule.to_sql)
-        end
-
-        rule
       end
     end
   end


### PR DESCRIPTION
Some time ago I [fixed](https://github.com/rails/rails/pull/44284) a [bug](https://github.com/rails/rails/issues/44282) in activerecord and even [failed](https://github.com/RedHatInsights/compliance-backend/pull/1214) to clean up after it in our codebase as the changes weren't backported to the version we were running. Now that we are on 7.1, it is safe to drop the compensation.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
