### PR TITLE
feat(APIv2): allow passing context to resolver aggregations

### DIFF
--- a/app/controllers/concerns/v2/resolver.rb
+++ b/app/controllers/concerns/v2/resolver.rb
@@ -40,9 +40,9 @@ module V2
     # Self-join with the requested aggregations built using 1:n associations, also select
     # the aggregated field from the self-joined subquery.
     def join_aggregated(relation)
-      aggregations.reduce(relation) do |scope, (association, aggregation)|
-        scope.joins(subquery_fragment(association, aggregation))
-             .select(aggregation.alias)
+      aggregations.reduce(relation) do |scope, (association, (aggregation, column))|
+        scope.joins(subquery_fragment(association, aggregation.call.as(column)))
+             .select(column)
       end
     end
 

--- a/app/serializers/v2/application_serializer.rb
+++ b/app/serializers/v2/application_serializer.rb
@@ -27,9 +27,9 @@ module V2
       end
 
       # Match any declared `aggregate_field` against the available relationships, return with a hash of
-      # aggregations in a `{ name => field }` format.
+      # aggregations in a `{ name => [field, alias] }` format.
       def aggregations(parents, to_many)
-        filter_from(@aggregated_attributes, to_many - parents.to_a).each_with_object({}) do |(k, (v)), obj|
+        filter_from(@aggregated_attributes, to_many - parents.to_a).each_with_object({}) do |(k, v), obj|
           obj[k] = v
         end
       end
@@ -64,15 +64,15 @@ module V2
 
       # This method allows the definition attributes that are aggregated from any left-outer-joined has_many
       # `association`. The attribute is forwarded to an `aggregate_#{name}` method in the model that should
-      # exist when calling the serializer. The aggregation `function` is automatically aliased with this
-      # name.
+      # exist as an attribute when calling the serializer. The result of the aggregation `function`  should
+      # be aliased to this name when resolving the aggegation.
       def aggregated_attribute(name, association, function)
         target = "aggregate_#{name}"
         attributes name
         define_method(name) { @object.send(target.to_sym) }
 
         @aggregated_attributes ||= {}
-        @aggregated_attributes[name] = { association => [function.as(target)] }
+        @aggregated_attributes[name] = { association => [function, target] }
       end
 
       protected

--- a/app/serializers/v2/system_serializer.rb
+++ b/app/serializers/v2/system_serializer.rb
@@ -9,6 +9,6 @@ module V2
     derived_attribute :os_major_version, V2::System::OS_MAJOR_VERSION
     derived_attribute :os_minor_version, V2::System::OS_MINOR_VERSION
 
-    aggregated_attribute :policies, :policies, V2::System::POLICIES
+    aggregated_attribute :policies, :policies, -> { V2::System::POLICIES }
   end
 end


### PR DESCRIPTION
There is a need to contextualize an aggregation for the `current_user` and there was also an issue with alias lookup on certain dynamically generated Arel nodes. This change deals with both issues, by moving the alias setup of an aggregation to the `V2::Resolver` and converting the last argument of `aggregated_attribute` to a lambda.

```ruby
aggregated_attribute :name, :relation, lambda do
  # ...
  Pundit.policy_scope(User.current, V2::System)
  # ...
end
```


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
