### PR TITLE
perf(APIv2): RHINENG-8352 harmonize aliases when merging with pundit

### DIFF
--- a/app/controllers/concerns/v2/resolver.rb
+++ b/app/controllers/concerns/v2/resolver.rb
@@ -25,7 +25,7 @@ module V2
 
         scope.joins(association)
              .where(association => { klass.primary_key => permitted_params[ref.foreign_key] })
-             .where(pundit_subquery(relation, association))
+             .merge_with_alias(Pundit.policy_scope(current_user, klass))
       end
     end
 
@@ -93,13 +93,6 @@ module V2
     # Retrieve the list of aggregations on any one-to-many associations specified by the serializer
     def aggregations
       @aggregations ||= serializer.aggregations(permitted_params[:parents], resource.one_to_many)
-    end
-
-    def pundit_subquery(relation, association)
-      ref = relation.reflect_on_association(association)
-      klass = ref.klass
-
-      { association => { klass.primary_key => Pundit.policy_scope(current_user, klass) } }
     end
   end
 end

--- a/app/models/concerns/v2/merge_with_alias.rb
+++ b/app/models/concerns/v2/merge_with_alias.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module V2
+  # Extended merge method that can harmonize table aliases, mainly for pundit scoping
+  module MergeWithAlias
+    extend ActiveSupport::Concern
+
+    def merge_with_alias(other)
+      other = visitor_for_merge(aliases_for_merge).accept(other.where_clause.ast)
+      other.to_sql == '' ? self : where(other)
+    end
+
+    private
+
+    def aliases_for_merge
+      aliases = {}
+
+      # Look up all the defined table aliases in the current scope and feed them into the `aliases` hash
+      visitor = ArelVisitor.new do |node|
+        aliases[node.table_name] = node.name if node.is_a?(Arel::Nodes::TableAlias)
+      end
+
+      visitor.accept(where_clause.ast)
+      aliases
+    end
+
+    # Iterate over the `other` scope and harmonize its table aliases
+    def visitor_for_merge(aliases)
+      ArelVisitor.new(copy: true) do |node|
+        if node.is_a?(Arel::Table) && aliases.key?(node.name)
+          node.alias(aliases[node.name])
+        elsif node.is_a?(Arel::Nodes::TableAlias) && aliases.key?(node.left.name)
+          node.left.alias(aliases[node.left.name])
+        else
+          node
+        end
+      end
+    end
+
+    # Loose implementation of the BFS visitor from the historical Rails codebase
+    class ArelVisitor < Arel::Visitors::Visitor
+      def initialize(copy: false, &block)
+        super()
+        @block = block
+        @copy = copy
+      end
+
+      private
+
+      # :nocov:
+      def visit(node, *args)
+        node = node.dup if @copy
+        super
+        @block.call(node)
+      rescue TypeError => e
+        raise [e.message, 'You should implement an alias for the missing method'].join(': ')
+      end
+      # :nocov:
+
+      def nop(_node); end
+
+      def binary(node)
+        left = visit(node.left)
+        right = visit(node.right)
+
+        node.left = left if @copy
+        node.right = right if @copy
+      end
+
+      def nary(node)
+        children = node.children.map { |child| visit(child) }
+        node.instance_variable_set(:@children, children) if @copy
+      end
+
+      def attribute(node)
+        relation = visit(node.relation)
+        node.relation = relation if @copy
+      end
+
+      alias visit_Arel_Nodes_Equality binary
+      alias visit_Arel_Nodes_InfixOperation binary
+      alias visit_Arel_Nodes_NotEqual binary
+      alias visit_Arel_Nodes_Or binary
+
+      alias visit_Arel_Nodes_And nary
+      alias visit_Arel_Attributes_Attribute attribute
+
+      alias visit_ActiveRecord_Relation_QueryAttribute nop
+      alias visit_Arel_Nodes_Grouping nop
+      alias visit_Arel_Nodes_NamedFunction nop
+      alias visit_Arel_Nodes_Quoted nop
+      alias visit_Arel_Nodes_TableAlias nop
+      alias visit_Arel_Table nop
+    end
+  end
+end

--- a/app/models/v2/application_record.rb
+++ b/app/models/v2/application_record.rb
@@ -9,6 +9,8 @@ module V2
     include V2::Searchable
     include V2::Indexable
 
+    ActiveRecord::Relation.include(V2::MergeWithAlias)
+
     AN = Arel::Nodes
 
     # Placeholder field for implicit searching that should always fail as we only want to support explicit search


### PR DESCRIPTION
There was an issue with merging pundit scopes with autojoined parents as they automatically get aliased based on the reflection name. I created an `Arel::Visitor` implementing BFS that can be used for both retrieving aliases from one scope and adjusting them in another. 

There were some errors around adjusting an arel AST of a cached query, so I made sure that we can opt-in construct a new AST while visiting nodes. This is ensured by the `copy` argument of the visitor and the `dup` call on each node.

If a new query shows up with which the visitor cannot deal, an exception describing this problem is displayed that should be available when running tests.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
