### PR TITLE
fix(RBAC): RHINENG-9591 send identity header with hyphens

### DIFF
--- a/app/services/rbac.rb
+++ b/app/services/rbac.rb
@@ -27,7 +27,7 @@ class Rbac
       begin
         API_CLIENT.get_principal_access(
           self::APPS,
-          self::OPTS.merge(header_params: { X_RH_IDENTITY: identity })
+          self::OPTS.merge(header_params: { 'X-RH-IDENTITY': identity })
         ).data
       rescue RBACApiClient::ApiError => e
         Rails.logger.info(e.message)

--- a/lib/insights/api/common/host_inventory.rb
+++ b/lib/insights/api/common/host_inventory.rb
@@ -21,7 +21,7 @@ module Insights
 
         private
 
-        def get(path = '', params: {}, headers: { X_RH_IDENTITY: @b64_identity })
+        def get(path = '', params: {}, headers: { 'X-RH-IDENTITY': @b64_identity })
           JSON.parse(Platform.connection.get("#{@url}#{path}", params, headers).body)
         end
       end

--- a/test/controllers/concerns/authentication_test.rb
+++ b/test/controllers/concerns/authentication_test.rb
@@ -330,9 +330,9 @@ class AuthenticationTest < ActionController::TestCase
       }.to_json
     )
 
-    Rbac::API_CLIENT.expects(:get_principal_access)
-                    .with(Rbac::APPS, { limit: 1000, auth_names: '', header_params: { X_RH_IDENTITY: encoded_header } })
-                    .returns(RBACApiClient::AccessPagination.new(data: []))
+    Rbac::API_CLIENT.expects(:get_principal_access).with(
+      Rbac::APPS, { limit: 1000, auth_names: '', header_params: { 'X-RH-IDENTITY': encoded_header } }
+    ).returns(RBACApiClient::AccessPagination.new(data: []))
 
     process_test(headers: { 'X-RH-IDENTITY': encoded_header })
   end


### PR DESCRIPTION
RBAC backend no longer accepts `X_RH_IDENTITY` so we have to send `X-RH-IDENTITY` instead.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
