### PR TITLE
cleanup(ActiveRecord): replace except+select with reselect

### DIFF
--- a/app/controllers/concerns/v2/collection.rb
+++ b/app/controllers/concerns/v2/collection.rb
@@ -24,8 +24,7 @@ module V2
         # by default is the primary key of the table, however, in certain cases using a different
         # indexed column might produce faster results without even accessing the table.
         # Pagination is disabled when counting collection so that all returned entities are counted.
-        @count_collection ||= scope.except(:select, :limit, :offset)
-                                   .select(resource.base_class.count_by).count
+        @count_collection ||= scope.except(:limit, :offset).reselect(resource.base_class.count_by).count
       end
 
       def validate_parents!

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -12,7 +12,7 @@ module Types
       # Count the whole collection using a single column and not the whole table. This column
       # by default is the primary key of the table, however, in certain cases using a different
       # indexed column might produce faster results without even accessing the table.
-      object.items.except(:select).select(object.items.base_class.count_by).count
+      object.items.reselect(object.items.base_class.count_by).count
     end
   end
 end

--- a/app/models/v2/policy.rb
+++ b/app/models/v2/policy.rb
@@ -54,7 +54,7 @@ module V2
       match_os_minors = Arel::Nodes::NamedFunction.new('ANY', [V2::SupportedProfile.arel_table[:os_minor_versions]])
       ids = V2::Policy.joins(profile: :security_guide).joins(supported_profiles)
                       .where(Arel::Nodes.build_quoted(val).eq(match_os_minors))
-                      .except(:select).select(arel_table[:id])
+                      .reselect(arel_table[:id])
 
       { conditions: "v2_policies.id IN (#{ids.to_sql})" }
     end

--- a/app/models/v2/tailoring.rb
+++ b/app/models/v2/tailoring.rb
@@ -51,7 +51,7 @@ module V2
     end
 
     def rule_group_ref_ids
-      base = V2::RuleGroup.where(id: rules_added.except(:select).select(:rule_group_id))
+      base = V2::RuleGroup.where(id: rules_added.reselect(:rule_group_id))
       base.or(V2::RuleGroup.where(id: base.select(GROUP_ANCESTRY_IDS)))
           .pluck(:ref_id)
     end


### PR DESCRIPTION
Utilizing `reselect` where it was possible in APIv2, there's a few places remaining where it was still necessary to call `except`.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
