### PR TITLE
fix(build_deploy): Only Create SC Tag When Building SC Branch

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -7,16 +7,15 @@ CICD_TOOLS_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main
 source <(curl -sSL "$CICD_TOOLS_URL") image_builder
 
 export CICD_IMAGE_BUILDER_IMAGE_NAME='quay.io/cloudservices/compliance-backend'
-export CICD_IMAGE_BUILDER_BUILD_ARGS=("IMAGE_TAG=$(cicd::image_builder::get_image_tag)")
+
 # Check if the current Git branch is 'origin/security-compliance'.
 if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
-    # Generate a tag for the Docker image based on the current date and Git commit short hash.
+    # Generate a tag for the container image based on the current date and Git commit short hash.
     SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
-    
-    # Set ADDITIONAL_TAGS to the generated security compliance tag.
-    export CICD_IMAGE_BUILDER_ADDITIONAL_TAGS=("$SECURITY_COMPLIANCE_TAG")
+    export CICD_IMAGE_BUILDER_BUILD_ARGS=("IMAGE_TAG=$SECURITY_COMPLIANCE_TAG")
 else
     # If the current Git branch is not 'origin/security-compliance':
+    export CICD_IMAGE_BUILDER_BUILD_ARGS=("IMAGE_TAG=$(cicd::image_builder::get_image_tag)")
     export CICD_IMAGE_BUILDER_ADDITIONAL_TAGS=("latest")
 fi
 


### PR DESCRIPTION
## Overview
It has been observed  that the `build_deploy` script is set up so that when the SC build Job runs, it write a new image over the original `image_tag` on which the commit is based. 

This update fixes that issue. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
