### PR TITLE
fix(kafka): RHINENG-9805 stop using platform.upload.compliance topic

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -35,12 +35,7 @@ class InventoryEventsConsumer < ApplicationConsumer
   def handle_report_parsing
     parse_output = parse_report
     validation_topic = Settings.kafka.topics.upload_compliance
-    logger.error("[DBG] calling produce with validation_topic: #{validation_topic}")
     produce(parse_output, topic: validation_topic) if validation_topic
-  rescue StandardError => e
-    logger.error("[DBG] #{e.message}")
-    logger.error("[DBG] #{e.backtrace}")
-    raise e
   end
 
   def handle_host_delete

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -25,8 +25,6 @@ objects:
       name: compliance
       version: 15
     kafkaTopics:
-      - topicName: platform.upload.compliance
-        partitions: 1
       - topicName: platform.payload-status
         partitions: 1
       - topicName: platform.inventory.events


### PR DESCRIPTION
The topic has been deleted even though we did not ask for it. However, it seems to be no longer used by anyone else and as we have payload tracker, it became obsolete for us. So we can just delete it from clowder, the [logic](https://github.com/RedHatInsights/compliance-backend/blob/master/app/consumers/inventory_events_consumer.rb#L39) in our code already stops using it if isn't specified in the clowder config.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
