### PR TITLE
fix(APIv2): bulk deletion should delete link not the entity

### DIFF
--- a/app/controllers/v2/systems_controller.rb
+++ b/app/controllers/v2/systems_controller.rb
@@ -14,10 +14,7 @@ module V2
     permission_for_action :show, Rbac::SYSTEM_READ
 
     def create
-      inserts, deletes = V2::PolicySystem.bulk_assign(
-        new_policy_systems,
-        pundit_scope(policy.systems).where.not(id: permitted_params[:ids])
-      )
+      inserts, deletes = V2::PolicySystem.bulk_assign(new_policy_systems, old_policy_systems)
 
       build_tailorings!
 
@@ -77,6 +74,12 @@ module V2
                             .os_major_versions(major).os_minor_versions(minors)
 
         items.map { |item| V2::PolicySystem.new(policy: policy, system: item) }
+      end
+    end
+
+    def old_policy_systems
+      @old_policy_systems ||= begin
+        policy.policy_systems.joins(:system).merge_with_alias(pundit_scope(policy.systems))
       end
     end
 

--- a/app/models/v2/application_record.rb
+++ b/app/models/v2/application_record.rb
@@ -81,8 +81,8 @@ module V2
       insert = delete = 0
 
       transaction do
-        insert = import(add, on_duplicate_key_ignore: true, validate: false)
         delete = del.delete_all
+        insert = import(add, on_duplicate_key_ignore: true, validate: false)
       end
 
       [insert.ids.count, delete]


### PR DESCRIPTION
The bulk assignment was always deleting the right side from the database when unassigning. This means that when unassigning a system from a tailoring, we didn't delete the `TailoringSystem` record, but the `System` itself. Same happened for `TailoringRule` unassignment. Furthermore, due to the dynamic evaluation of the entities to be unassigned, the unassignment itself interfered with the assignment.

So I adjusted the unassignments to deal with the linking entities and reordered the deletion to happen before the assignment. This is something we aren't really able to test in our codebase though 😞 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
