### PR TITLE
Eliminate unnecessary record generation in factory associations

### DIFF
--- a/spec/controllers/v2/supported_profiles_controller_spec.rb
+++ b/spec/controllers/v2/supported_profiles_controller_spec.rb
@@ -26,6 +26,7 @@ describe V2::SupportedProfilesController do
     let(:extra_params) { {} }
     let(:item_count) { 2 }
     let(:parents) { nil }
+
     let(:v1_profiles) do
       FactoryBot.create(
         :v2_security_guide,
@@ -41,6 +42,7 @@ describe V2::SupportedProfilesController do
         }
       ).profiles
     end
+
     let(:v2_profiles) do
       FactoryBot.create(
         :v2_security_guide,
@@ -54,6 +56,7 @@ describe V2::SupportedProfilesController do
         }
       ).profiles
     end
+
     let(:rhel8_profiles) do
       FactoryBot.create(
         :v2_security_guide,

--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -17,12 +17,6 @@ FactoryBot.define do
       rule_count { 0 }
     end
 
-    os_minor_versions do
-      supports_minors&.map do |os_minor_version|
-        association(:profile_os_minor_version, os_minor_version: os_minor_version)
-      end
-    end
-
     value_overrides do
       create_list(:v2_value_definition, value_count, security_guide: security_guide) if value_count.positive?
       security_guide.value_definitions.each_with_object({}) do |value, object|
@@ -31,7 +25,9 @@ FactoryBot.define do
     end
 
     after(:create) do |profile, ev|
-      next if ev.rule_count.zero?
+      ev.supports_minors&.map do |os_minor_version|
+        create(:profile_os_minor_version, os_minor_version: os_minor_version, profile: profile)
+      end
 
       create_list(:v2_rule, ev.rule_count, profiles: [profile], security_guide: profile.security_guide)
     end

--- a/spec/factories/security_guide.rb
+++ b/spec/factories/security_guide.rb
@@ -14,13 +14,11 @@ FactoryBot.define do
       profile_refs { profile_count.times.map { SecureRandom.hex } }
     end
 
-    profiles do
-      profile_refs.map do |ref, supports_minors|
-        association(:v2_profile, ref_id_suffix: ref, supports_minors: supports_minors)
-      end
-    end
-
     after(:create) do |security_guide, ev|
+      ev.profile_refs.each do |ref, supports_minors|
+        create(:v2_profile, ref_id_suffix: ref, supports_minors: supports_minors, security_guide: security_guide)
+      end
+
       create_list(:v2_rule, ev.rule_count, security_guide: security_guide)
 
       security_guide.reload # FIXME: remove this after the full remodel


### PR DESCRIPTION
Some `association` calls were not reflecting the ID of the entity they are associated to implicitly, therefore, they created duplicate entities that were never used. This is probably a bug in FactoryBot, but we can eliminate it by not allowing any improvisation around duplications.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
