### PR TITLE
fix(APIv2): RHINENG-10037 clone rules/values from a supported profile

### DIFF
--- a/app/models/v2/policy_system.rb
+++ b/app/models/v2/policy_system.rb
@@ -19,8 +19,8 @@ module V2
         # Look up the latest Profile supporting the given OS minor version
         tailoring.profile = policy.profile.variant_for_minor(system.os_minor_version)
 
-        tailoring.rules = policy.profile.rules
-        tailoring.value_overrides = policy.profile.value_overrides
+        tailoring.rules = tailoring.profile.rules # FIXME: this is inefficient
+        tailoring.value_overrides = tailoring.profile.value_overrides
       end
     end
 

--- a/spec/controllers/v2/systems_controller_spec.rb
+++ b/spec/controllers/v2/systems_controller_spec.rb
@@ -393,6 +393,30 @@ describe V2::SystemsController do
         end
       end
 
+      context 'policy created from a no longer supported profile' do
+        let(:parent) { FactoryBot.create(:v2_policy, account: current_user.account) }
+
+        before { FactoryBot.create(:v2_profile, ref_id: parent.profile.ref_id, supports_minors: [0, 1, 2, 8]) }
+
+        it 'clones a tailoring from a supported profile' do
+          patch :update, params: { id: item.id, policy_id: parent.id, parents: [:policies] }
+
+          expect(response).to have_http_status :accepted
+          expect(first_tailoring.profile_id).not_to eq(parent.profile_id)
+        end
+
+        context 'mismatch in supported rules' do
+          before { FactoryBot.create(:v2_rule, profile_id: parent.profile_id) }
+
+          it 'clones a tailoring from a supported profile' do
+            patch :update, params: { id: item.id, policy_id: parent.id, parents: [:policies] }
+
+            expect(response).to have_http_status :accepted
+            expect(first_tailoring.profile_id).not_to eq(parent.profile_id)
+          end
+        end
+      end
+
       context 'OS major version mismatch' do
         let(:os_major_version) { 6 }
 


### PR DESCRIPTION
When assigning a system to a policy, the tailoring creation is triggered if there is no already tailoring created. In case there is a rule support mismatch between the policy's parent profile and the one that the system supports, the validation on the rule assignment fails. This caused issues when assigning systems to older policies with no longer supported parent profile. The fix is trivial, the rule cloning should always happen from the tailoring's parent and not the policy's.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
