### PR TITLE
fix(APIv2): RHINENG-10300 update V1 counters around system assignment

### DIFF
--- a/app/controllers/v2/systems_controller.rb
+++ b/app/controllers/v2/systems_controller.rb
@@ -17,6 +17,7 @@ module V2
       inserts, deletes = V2::PolicySystem.bulk_assign(new_policy_systems, old_policy_systems)
 
       build_tailorings!
+      policy.__v1_update_total_system_count # FIXME: clean up after the remodel
 
       audit_success("Assigned #{inserts} and unassigned #{deletes} Systems to/from Policy #{policy.id}")
       render_json systems, status: :accepted
@@ -26,8 +27,10 @@ module V2
 
     def update
       if new_policy_system.save
-        render_json system, status: :accepted
+        policy.__v1_update_total_system_count # FIXME: clean up after the remodel
+
         audit_success("Assigned system #{system.id} to policy #{new_policy_system.policy_id}")
+        render_json system, status: :accepted
       else
         render_model_errors new_policy_system
       end
@@ -39,6 +42,8 @@ module V2
       policy_system = system.policy_systems.find_by!(policy_id: permitted_params[:policy_id])
 
       policy_system.destroy
+      policy.__v1_update_total_system_count # FIXME: clean up after the remodel
+
       audit_success("Unassigned system #{system.id} from policy #{policy_system.policy_id}")
       render_json system, status: :accepted
     end

--- a/app/models/v2/policy.rb
+++ b/app/models/v2/policy.rb
@@ -78,6 +78,12 @@ module V2
       V2::SupportedProfile.find_by!(ref_id: ref_id, os_major_version: os_major_version).os_minor_versions
     end
 
+    # This method is calling an APIv1 model to update the cached counter in APIv1+GQL for maintaining
+    # compatibility. After we stop using these old APIs, this will be obsolete and should be deleted.
+    def __v1_update_total_system_count
+      ::Policy.find(id).update_counters!
+    end
+
     private
 
     def ensure_default_values


### PR DESCRIPTION
When un/assigning system/s using APIv2, the cached counters in the V1 models are not updated. This can cause that the frontend will not show the correct number of assigned/compliant/etc systems after doing V2 operations. To maintain compatibility, we have to call the `::Profile#update_counters!` V1 method upon operations. This is a temporary solution and will be deleted AFTER the old APIs are dropped.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
