### PR TITLE
feat(APIv2): RHINENG-1986 cache failed_rule_count on test results

### DIFF
--- a/app/services/concerns/xccdf/rule_results.rb
+++ b/app/services/concerns/xccdf/rule_results.rb
@@ -28,7 +28,7 @@ module Xccdf
     end
 
     def selected_op_rule_results
-      @op_rule_results.reject do |rule_result|
+      @op_rule_results&.reject do |rule_result|
         ::RuleResult::NOT_SELECTED.include? rule_result.result
       end
     end

--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -5,10 +5,9 @@ module Xccdf
   module TestResult
     def save_test_result
       @test_result = ::TestResult.create!(
-        host: @host,
-        profile: @host_profile,
-        supported: supported?,
-        score: score,
+        host: @host, profile: @host_profile,
+        supported: supported?, score: score,
+        failed_rule_count: selected_op_rule_results&.count { |rr| ::RuleResult::FAILED.include?(rr.result) }.to_i,
         start_time: @op_test_result.start_time.in_time_zone,
         end_time: @op_test_result.end_time.in_time_zone
       )

--- a/db/migrate/20240527092643_test_result_failed_rule_count.rb
+++ b/db/migrate/20240527092643_test_result_failed_rule_count.rb
@@ -1,0 +1,17 @@
+class TestResultFailedRuleCount < ActiveRecord::Migration[7.1]
+  def up
+    add_column :test_results, :failed_rule_count, :integer, default: 0, null: false
+
+    sq = TestResult.joins(:rule_results).where(rule_results: { result: %w[fail error unknown fixed] })
+                                        .group('test_results.id').select('test_results.id', 'COUNT(rule_results.id) as cnt')
+
+
+    ActiveRecord::Base.connection.execute(
+      "UPDATE test_results SET failed_rule_count = sq.cnt FROM (#{sq.to_sql}) AS sq WHERE sq.id = test_results.id"
+    )
+  end
+
+  def down
+    remove_column :test_results, :failed_rule_count
+  end
+end

--- a/db/migrate/20240527130454_update_v2_test_results_to_version_2.rb
+++ b/db/migrate/20240527130454_update_v2_test_results_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateV2TestResultsToVersion2 < ActiveRecord::Migration[7.1]
+  def change
+    update_view :v2_test_results, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_23_140254) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_27_130454) do
   create_schema "inventory"
 
   # These are extensions that must be enabled in order to support this database
@@ -216,6 +216,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_140254) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "supported", default: true
+    t.integer "failed_rule_count", default: 0, null: false
     t.index ["host_id", "profile_id", "end_time"], name: "index_test_results_on_host_id_and_profile_id_and_end_time", unique: true
     t.index ["host_id"], name: "index_test_results_on_host_id"
     t.index ["profile_id"], name: "index_test_results_on_profile_id"
@@ -379,18 +380,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_140254) do
       profile_rules.rule_id
      FROM profile_rules;
   SQL
-  create_view "v2_test_results", sql_definition: <<-SQL
-      SELECT test_results.id,
-      test_results.profile_id AS tailoring_id,
-      test_results.host_id AS system_id,
-      test_results.start_time,
-      test_results.end_time,
-      test_results.score,
-      test_results.supported,
-      test_results.created_at,
-      test_results.updated_at
-     FROM test_results;
-  SQL
   create_view "v2_rules", sql_definition: <<-SQL
       SELECT rules.id,
       rules.ref_id,
@@ -410,6 +399,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_140254) do
       rule_references_containers.rule_references AS "references"
      FROM (rules
        LEFT JOIN rule_references_containers ON ((rule_references_containers.rule_id = rules.id)));
+  SQL
+  create_view "v2_test_results", sql_definition: <<-SQL
+      SELECT test_results.id,
+      test_results.profile_id AS tailoring_id,
+      test_results.host_id AS system_id,
+      test_results.start_time,
+      test_results.end_time,
+      test_results.score,
+      test_results.supported,
+      test_results.failed_rule_count,
+      test_results.created_at,
+      test_results.updated_at
+     FROM test_results;
   SQL
   create_function :v2_policies_insert, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.v2_policies_insert()

--- a/db/views/v2_test_results_v02.sql
+++ b/db/views/v2_test_results_v02.sql
@@ -1,0 +1,12 @@
+SELECT
+  "test_results"."id",
+  "test_results"."profile_id" "tailoring_id",
+  "test_results"."host_id" "system_id",
+  "test_results"."start_time",
+  "test_results"."end_time",
+  "test_results"."score",
+  "test_results"."supported",
+  "test_results"."failed_rule_count",
+  "test_results"."created_at",
+  "test_results"."updated_at"
+from "test_results";

--- a/test/services/concerns/xccdf/test_result_test.rb
+++ b/test/services/concerns/xccdf/test_result_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class TestResultTest < ActiveSupport::TestCase
   class Mock
     include Xccdf::TestResult
+    include Xccdf::RuleResults
 
     attr_accessor :host, :host_profile, :op_test_result, :test_result
   end


### PR DESCRIPTION
Instead of creating an `aggregated_attribute` we can rely on a static field to get the number of failed rules under a policy+system combo. This number is the same for everyone who has access, so no need for scoped filtering and the number can be calculated upon parsing the report.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
