### PR TITLE
fix(APIv2): RHINENG-10379 introduce weak attributes for systems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
     - 'spec/**/*'
+  CountAsOne:
+    - 'array'
+    - 'heredoc'
+    - 'method_call'
 
 Metrics/ModuleLength:
   Exclude:

--- a/app/models/v2/system.rb
+++ b/app/models/v2/system.rb
@@ -14,7 +14,7 @@ module V2
     has_many :report_systems, class_name: 'V2::ReportSystem', dependent: nil
     has_many :policies, class_name: 'V2::Policy', through: :policy_systems
     has_many :reports, class_name: 'V2::Report', through: :report_systems
-    has_many :test_results, -> { where(arel_table[:report_id].eq(V2::Report.arel_table.alias(:reports)[:id])) },
+    has_many :v2_test_results, -> { where(arel_table[:report_id].eq(V2::Report.arel_table.alias(:reports)[:id])) },
              class_name: 'V2::TestResult', dependent: :destroy, inverse_of: :system
     has_many :rule_results, class_name: 'V2::RuleResult', through: :test_results
 
@@ -107,6 +107,18 @@ module V2
 
     def os_minor_version
       attributes['os_minor_version'] || try(:system_profile)&.dig('operating_system', 'minor')
+    end
+
+    def compliant
+      attributes['v2_test_results__score'].try(:>=, attributes['reports__compliance_threshold'])
+    end
+
+    def last_scanned
+      attributes['v2_test_results__end_time']
+    end
+
+    def failed_rule_count
+      attributes['v2_test_results__failed_rule_count']
     end
 
     def self.arel_inventory_groups(groups, key)

--- a/app/serializers/v2/system_serializer.rb
+++ b/app/serializers/v2/system_serializer.rb
@@ -9,10 +9,9 @@ module V2
     derived_attribute :os_major_version, V2::System::OS_MAJOR_VERSION
     derived_attribute :os_minor_version, V2::System::OS_MINOR_VERSION
 
-    # TODO: these attributes do not work yet
-    derived_attribute :compliant, policy: [:compliance_threshold], test_result: [:score]
-    derived_attribute :last_scanned, test_result: [:end_time]
-    derived_attribute :failed_rule_count, test_result: [:failed_rule_count]
+    weak_attribute :compliant, :reports, reports: [:compliance_threshold], v2_test_results: [:score]
+    weak_attribute :last_scanned, :reports, v2_test_results: [:end_time]
+    weak_attribute :failed_rule_count, :reports, v2_test_results: [:failed_rule_count]
 
     aggregated_attribute :policies, :policies, -> { V2::System::POLICIES }
   end

--- a/spec/controllers/v2/systems_controller_spec.rb
+++ b/spec/controllers/v2/systems_controller_spec.rb
@@ -610,9 +610,9 @@ describe V2::SystemsController do
         insights_id: :insights_id,
         tags: :tags,
         policies: -> { policies.map { |policy| { id: policy.id, title: policy.title } } },
-        # compliant: :compliant,
-        # last_scanned: :last_scanned,
-        # failed_rule_count: :failed_rule_count,
+        compliant: :compliant,
+        last_scanned: :last_scanned,
+        failed_rule_count: :failed_rule_count,
         os_major_version: -> { system_profile&.dig('operating_system', 'major') },
         os_minor_version: -> { system_profile&.dig('operating_system', 'minor') }
       }


### PR DESCRIPTION
Weak attributes are left-outer joined with the main scope so they never limit its total count. Probably their only usage is for the `/reports/:id/systems` endpoint where some of these attributes are derived using `test_result` bindings that aren't always available. This solution brings in a ton of additional complexity and might not stick on the long run though...

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
