### PR TITLE
fix(APIv2): RHINENG-13048 join test_results in top_failed_rules once

### DIFF
--- a/app/models/v2/report.rb
+++ b/app/models/v2/report.rb
@@ -147,7 +147,7 @@ module V2
     def top_failed_rules
       rule_fields = %i[title ref_id identifier severity].map { |field| V2::Rule.arel_table[field] }
 
-      V2::RuleResult.joins(:test_result, :system, :rule)
+      V2::RuleResult.joins(:system, :rule) # Because joins(test_results: :system, rule: []) is not that pretty
                     .merge_with_alias(Pundit.policy_scope(User.current, V2::System))
                     .where(result: V2::RuleResult::FAILED)
                     .group(rule_fields).select(rule_fields, V2::RuleResult.arel_table[:result].count.as('count'))


### PR DESCRIPTION
**Before:**
```
SELECT "rule_results"."id", "rule_results"."rule_id", "rule_results"."result", "rule_results"."created_at", "rule_results"."updated_at", "rule_results"."test_result_id" FROM "rule_results"
INNER JOIN "v2_test_results" ON "v2_test_results"."id" = "rule_results"."test_result_id"
INNER JOIN "v2_test_results" "test_results_rule_results_join" ON "test_results_rule_results_join"."id" = "rule_results"."test_result_id"
INNER JOIN "inventory"."hosts" ON "inventory"."hosts"."id" = "test_results_rule_results_join"."system_id"
INNER JOIN "v2_rules" ON "v2_rules"."id" = "rule_results"."rule_id"
```

**After:**
```
SELECT "rule_results"."id", "rule_results"."rule_id", "rule_results"."result", "rule_results"."created_at", "rule_results"."updated_at", "rule_results"."test_result_id" FROM "rule_results"
INNER JOIN "v2_test_results" ON "v2_test_results"."id" = "rule_results"."test_result_id"
INNER JOIN "inventory"."hosts" ON "inventory"."hosts"."id" = "v2_test_results"."system_id"
INNER JOIN "v2_rules" ON "v2_rules"."id" = "rule_results"."rule_id"
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
