### PR TITLE
fix(CI): update build_deploy.sh to correctly generate sc tagged images

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -12,7 +12,7 @@ export CICD_IMAGE_BUILDER_IMAGE_NAME='quay.io/cloudservices/compliance-backend'
 if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
     # Generate a tag for the container image based on the current date and Git commit short hash.
     SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
-    export CICD_IMAGE_BUILDER_BUILD_ARGS=("IMAGE_TAG=$SECURITY_COMPLIANCE_TAG")
+    export "IMAGE_TAG=${SECURITY_COMPLIANCE_TAG}"
 else
     # If the current Git branch is not 'origin/security-compliance':
     export CICD_IMAGE_BUILDER_BUILD_ARGS=("IMAGE_TAG=$(cicd::image_builder::get_image_tag)")


### PR DESCRIPTION
## Overview
This update changes the following to properly generate the `SC IMAGE TAG` when building off of the `security-compliance` branch.  

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
