### PR TITLE
docs(APIv2): correct searching by attributes

### DIFF
--- a/spec/integration/v2/reports_spec.rb
+++ b/spec/integration/v2/reports_spec.rb
@@ -211,7 +211,7 @@ describe 'Reports', swagger_doc: 'v2/openapi.json' do
       pagination_params_v2
       ids_only_param
       sort_params_v2(V2::Report, except: %i[os_major_version])
-      search_params_v2(V2::Report, except: %i[os_major_version with_reported_systems])
+      search_params_v2(V2::Report, except: %i[os_major_version with_reported_systems percent_compliant])
 
       parameter name: :system_id, in: :path, type: :string, required: true
 

--- a/spec/integration/v2/systems_spec.rb
+++ b/spec/integration/v2/systems_spec.rb
@@ -21,7 +21,9 @@ describe 'Systems', swagger_doc: 'v2/openapi.json' do
       pagination_params_v2
       ids_only_param
       sort_params_v2(V2::System)
-      search_params_v2(V2::System, except: %i[never_reported])
+      # NOTE: os_version filtering works on /systems, but is not encouraged, for other than FE needs
+      #       see 445f86bb9bc13f4202ad86eb3770213040958985
+      search_params_v2(V2::System, except: %i[never_reported os_version])
 
       response '200', 'Lists Systems' do
         v2_collection_schema 'system'
@@ -155,7 +157,7 @@ describe 'Systems', swagger_doc: 'v2/openapi.json' do
       ids_only_param
       sort_params_v2(V2::System, except: %i[os_major_version])
       search_params_v2(
-        V2::System, except: %i[never_reported os_major_version policies profile_ref_id assigned_or_scanned]
+        V2::System, except: %i[os_version never_reported os_major_version policies profile_ref_id assigned_or_scanned]
       )
 
       parameter name: :policy_id, in: :path, type: :string, required: true
@@ -397,7 +399,7 @@ describe 'Systems', swagger_doc: 'v2/openapi.json' do
       pagination_params_v2
       ids_only_param
       sort_params_v2(V2::System, except: %i[os_major_version])
-      search_params_v2(V2::System, except: %i[os_major_version policies profile_ref_id assigned_or_scanned])
+      search_params_v2(V2::System, except: %i[os_version os_major_version policies profile_ref_id assigned_or_scanned])
 
       parameter name: :report_id, in: :path, type: :string, required: true
 

--- a/swagger/v2/openapi.json
+++ b/swagger/v2/openapi.json
@@ -7591,7 +7591,7 @@
             "name": "filter",
             "in": "query",
             "required": false,
-            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_version`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
             "schema": {
               "type": "string"
             }
@@ -9214,7 +9214,7 @@
             "name": "filter",
             "in": "query",
             "required": false,
-            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_version`, `os_minor_version`, and `group_name`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_minor_version`, and `group_name`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
             "schema": {
               "type": "string"
             }
@@ -11453,7 +11453,7 @@
             "name": "filter",
             "in": "query",
             "required": false,
-            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_version`, `os_minor_version`, `never_reported`, and `group_name`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_minor_version`, `never_reported`, and `group_name`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
             "schema": {
               "type": "string"
             }

--- a/swagger/v2/openapi.json
+++ b/swagger/v2/openapi.json
@@ -2389,7 +2389,7 @@
             "name": "filter",
             "in": "query",
             "required": false,
-            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Reports are searchable using attributes `title` and `percent_compliant`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Reports are searchable using attributes `title`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
only `/systems` endpoint should allow to filter by `os_version`

follow-up to 445f86bb9bc13f4202ad86eb3770213040958985

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
