### PR TITLE
perf(APIv2): self-joining in aggregation with a reduced (pundit) scope

### DIFF
--- a/app/models/v2/system.rb
+++ b/app/models/v2/system.rb
@@ -105,15 +105,15 @@ module V2
 
     searchable_by :os_major_version, %i[eq neq in notin], except_parents: %i[policies reports] do |_key, op, val|
       {
-        conditions: os_major_versions(val.split(',').map(&:to_i), %w[IN =].include?(op)).arel
-                                                                                        .where_sql.sub(/^where /i, '')
+        conditions: unscoped.os_major_versions(val.split(',').map(&:to_i), %w[IN =].include?(op))
+                            .arel.where_sql.sub(/^where /i, '')
       }
     end
 
     searchable_by :os_minor_version, %i[eq neq in notin] do |_key, op, val|
       {
-        conditions: os_minor_versions(val.split(',').map(&:to_i), %w[IN =].include?(op)).arel
-                                                                                        .where_sql.sub(/^where /i, '')
+        conditions: unscoped.os_minor_versions(val.split(',').map(&:to_i), %w[IN =].include?(op)).arel
+                            .where_sql.sub(/^where /i, '')
       }
     end
 

--- a/app/policies/v2/application_policy.rb
+++ b/app/policies/v2/application_policy.rb
@@ -56,6 +56,12 @@ module V2
       def resolve
         scope.all
       end
+
+      # Redefine this method in subclasses if you want to limit the join scope for aggregations.
+      # This is not intended for limiting the user access, but to improve query performance.
+      def aggregate
+        scope.all
+      end
     end
   end
 end

--- a/app/policies/v2/system_policy.rb
+++ b/app/policies/v2/system_policy.rb
@@ -45,6 +45,11 @@ module V2
         user.cert_authenticated? ? resolve_cert_auth : resolve_regular
       end
 
+      # In aggregations, we should not join with all systems, so scoping them `org_id`
+      def aggregate
+        base_scope
+      end
+
       private
 
       def resolve_regular


### PR DESCRIPTION
I am introducing the `aggregate` method on pundit scopes that allows us additional scoping of resources for aggregations. This is not for user access limitation, but for performance optimizations in SQL. User access scoping is always handled on the highest level and in FILTER calls inside aggregation. Hopefully we will only need this for the inventory, that is scoped with org_id, but this could be useful for rule results or test results if there are performance issues.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
