### PR TITLE
perf(APIv2): additional optimizations and cleanup for searches

### DIFF
--- a/app/models/v2/application_record.rb
+++ b/app/models/v2/application_record.rb
@@ -51,12 +51,12 @@ module V2
 
     # Splits up a version and converts it to an array of integers for better sorting
     def self.version_to_array(column)
-      Arel::Nodes::NamedFunction.new(
+      AN::NamedFunction.new(
         'CAST',
         [
-          Arel::Nodes::NamedFunction.new(
+          AN::NamedFunction.new(
             'string_to_array',
-            [column, Arel::Nodes::Quoted.new('.')]
+            [column, AN::Quoted.new('.')]
           ).as('int[]')
         ]
       )
@@ -74,6 +74,19 @@ module V2
           ]
         )
       )
+    end
+
+    def self.arel_inotineqneq(operator, left, right)
+      case operator
+      when 'IN'
+        AN::In.new(left, right)
+      when 'NOT IN'
+        AN::Not.new(AN::In.new(left, right))
+      when '='
+        left.eq(right.first)
+      when '<>'
+        left.not_eq(right.first)
+      end
     end
 
     def self.bulk_assign(add, del)

--- a/app/models/v2/security_guide.rb
+++ b/app/models/v2/security_guide.rb
@@ -21,7 +21,7 @@ module V2
     searchable_by :profile_ref_id, %i[eq] do |_key, _op, val|
       ids = ::V2::Profile.unscoped.where(ref_id: val).select(:security_guide_id)
 
-      { conditions: "security_guides.id IN (#{ids.to_sql})" }
+      { conditions: AN::In.new(arel_table[:id], ids.arel).to_sql }
     end
 
     searchable_by :supported_profile, %i[eq] do |_key, _op, val|
@@ -31,7 +31,7 @@ module V2
         ref_id: ref_id, os_minor_versions: { os_minor_version: os_minor.to_i }
       ).select(:security_guide_id)
 
-      { conditions: "security_guides.id IN (#{ids.to_sql})" }
+      { conditions: AN::In.new(arel_table[:id], ids.arel).to_sql }
     end
 
     sortable_by :title

--- a/app/models/v2/tailoring.rb
+++ b/app/models/v2/tailoring.rb
@@ -5,17 +5,17 @@ module V2
   class Tailoring < ApplicationRecord
     include V2::RuleTree
 
-    GROUP_ANCESTRY_IDS = Arel::Nodes::NamedFunction.new(
+    GROUP_ANCESTRY_IDS = AN::NamedFunction.new(
       'CAST',
       [
-        Arel::Nodes::NamedFunction.new(
+        AN::NamedFunction.new(
           'unnest',
           [
-            Arel::Nodes::NamedFunction.new(
+            AN::NamedFunction.new(
               'string_to_array',
               [
                 RuleGroup.arel_table[:ancestry],
-                Arel::Nodes::Quoted.new('/')
+                AN::Quoted.new('/')
               ]
             )
           ]

--- a/app/models/v2/test_result.rb
+++ b/app/models/v2/test_result.rb
@@ -81,7 +81,7 @@ module V2
                             .where(v2_rules: { severity: val.split(',') }, rule_results: { result: 'fail' })
                             .select(:test_result_id)
 
-      { conditions: "v2_test_results.id IN (#{ids.to_sql})" }
+      { conditions: AN::In.new(arel_table[:id], ids.arel).to_sql }
     end
 
     scope :with_groups, lambda { |groups, table = V2::System.arel_table, key = :id|


### PR DESCRIPTION
With the help of @dkuc I was able to further optimise some (NOT) IN subqueries, mainly used for searching. This pattern should be further used in the remaining search definitions and all the raw SQL ones can be eliminated.

**From:**
```sql
(inventory.hosts.id IN (SELECT policy_systems.system_id FROM policy_systems) 
```

**To:**
```sql
EXISTS(SELECT 1 FROM policy_systems WHERE policy_systems.system_id = inventory.hosts.id)
```


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
