### PR TITLE
fix(Rules): RHINENG-16918 search rules by identifier

### DIFF
--- a/app/models/v2/rule.rb
+++ b/app/models/v2/rule.rb
@@ -50,6 +50,14 @@ module V2
     searchable_by :severity, %i[eq ne in notin]
     searchable_by :remediation_available, %i[eq]
     searchable_by :rule_group_id, %i[eq]
+    searchable_by :identifier_label, %i[eq neq like unlike] do |_key, op, val|
+      val = "%#{val}%" if ['ILIKE', 'NOT ILIKE'].include?(op)
+
+      {
+        conditions: "v2_rules.identifier->>'label' #{op} ?",
+        parameter: [val]
+      }
+    end
 
     # This field should be only available for rules that have a remediation available and it
     # is bound to a context of a profile and a security guide. A single rule can belong to one

--- a/app/models/v2/rule_result.rb
+++ b/app/models/v2/rule_result.rb
@@ -2,6 +2,7 @@
 
 module V2
   # Class representing individual rule results unter a test result
+  # rubocop:disable Metrics/ClassLength
   class RuleResult < ApplicationRecord
     # FIXME: clean up after the remodel
     self.table_name = :rule_results
@@ -76,6 +77,15 @@ module V2
       }
     end
 
+    searchable_by :identifier_label, %i[eq neq like unlike] do |_key, op, val|
+      val = "%#{val}%" if ['ILIKE', 'NOT ILIKE'].include?(op)
+
+      {
+        conditions: "rule.identifier->>'label' #{op} ?",
+        parameter: [val]
+      }
+    end
+
     def ref_id
       attributes['rule__ref_id'] || try(:rule)&.ref_id
     end
@@ -135,4 +145,5 @@ module V2
     end
     # :nocov:
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/spec/factories/rule_result.rb
+++ b/spec/factories/rule_result.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
       severity { nil }
       remediation_available { nil }
       precedence { nil }
+      identifier { nil }
     end
 
     after(:create) do |rr, ev|
@@ -16,7 +17,8 @@ FactoryBot.define do
         title: ev.title,
         severity: ev.severity,
         remediation_available: ev.remediation_available,
-        precedence: ev.precedence
+        precedence: ev.precedence,
+        identifier: ev.identifier
       }.compact
 
       rr.rule.update(attrs) if attrs.any?

--- a/spec/fixtures/files/searchable/rule_results_controller.yaml
+++ b/spec/fixtures/files/searchable/rule_results_controller.yaml
@@ -213,3 +213,80 @@
         :test_result_id: ${test_result_id}
         :rule_id: ${rule_2.id}
   :query: rule_group_id = ${rule_1.rule_group_id}
+
+- :name: "equality search by identifier_label"
+  :entities:
+    :found:
+      - :factory: v2_rule_result
+        :title: searched title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_1.id}
+    :not_found:
+      - :factory: v2_rule_result
+        :title: not this title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_2.id}
+  :query: (identifier_label = "CEE-XYZ-1234")
+- :name: "non-equality search by identifier_label"
+  :entities:
+    :found:
+      - :factory: v2_rule_result
+        :title: not this title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_1.id}
+    :not_found:
+      - :factory: v2_rule_result
+        :title: searched title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_2.id}
+  :query: (identifier_label != "CEE-XYZ-1234")
+- :name: "like search by identifier_label"
+  :entities:
+    :found:
+      - :factory: v2_rule_result
+        :title: searched title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_1.id}
+    :not_found:
+      - :factory: v2_rule_result
+        :title: not this title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_2.id}
+  :query: (identifier_label ~ "CEE-XYZ")
+- :name: "unlike search by identifier_label"
+  :entities:
+    :found:
+      - :factory: v2_rule_result
+        :title: not this title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_1.id}
+    :not_found:
+      - :factory: v2_rule_result
+        :title: searched title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :test_result_id: ${test_result_id}
+        :rule_id: ${rule_2.id}
+  :query: (identifier_label !~ "CEE-XYZ")

--- a/spec/fixtures/files/searchable/rules_controller.yaml
+++ b/spec/fixtures/files/searchable/rules_controller.yaml
@@ -176,3 +176,88 @@
         :profile_id: ${profile_id}
         :tailoring_id: ${tailoring_id}
   :query: rule_group_id = ${rule_group.id}
+
+- :name: "equality search by identifier_label"
+  :entities:
+    :found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+    :not_found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+  :query: (identifier_label = "CEE-XYZ-1234")
+- :name: "non-equality search by identifier_label"
+  :entities:
+    :found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+    :not_found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+  :query: (identifier_label != "CEE-XYZ-1234")
+- :name: "like search by identifier_label"
+  :entities:
+    :found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+    :not_found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+  :query: (identifier_label ~ "CEE-XYZ")
+- :name: "unlike search by identifier_label"
+  :entities:
+    :found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-ABC-1234"
+          :href: "https://example.com/cee-abc-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+    :not_found:
+      - :factory: :v2_rule
+        :title: just title
+        :identifier:
+          :label: "CEE-XYZ-1234"
+          :href: "https://example.com/cee-xyz-1234"
+        :security_guide_id: ${security_guide_id}
+        :profile_id: ${profile_id}
+        :tailoring_id: ${tailoring_id}
+  :query: (identifier_label !~ "CEE-XYZ")


### PR DESCRIPTION
### What does it do?
This PR gets back filtering rules/rule_results by identifier as it was before. See https://issues.redhat.com/browse/RHINENG-14846 or https://issues.redhat.com/browse/RHINENG-16918

### How to test?

1. Check if any rules endpoint and rule_results endpoint can be filtered by:
-  `identifier_label=CEE-...`
- `identifier_label !=CEE-...`
- `identifier_label ~ 'CEE-...'`
-  `identifier_label !~ 'CEE-...`

So we have separate search attribute specifically for identifier.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
