### PR TITLE
refactor(Kafka): rename HostRemover to DeletedHostCleaner

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -5,7 +5,7 @@ class InventoryEventsConsumer < ApplicationConsumer
   # rubocop:disable Metrics/AbcSize
   def consume_one
     if message_type == 'delete'
-      Kafka::HostRemover.new(payload, logger).remove_host
+      Kafka::DeletedHostCleaner.new(payload, logger).remove_host
     elsif service == 'compliance'
       Kafka::ReportParser.new(payload, logger).parse_reports
     elsif policy_id && %w[created updated].include?(message_type)

--- a/app/services/kafka/deleted_host_cleaner.rb
+++ b/app/services/kafka/deleted_host_cleaner.rb
@@ -3,7 +3,7 @@
 module Kafka
   # Service for removing a host based on a kafka message
   # FIXME: refactor the DeleteHost job into this service while utilizing V2 model validations
-  class HostRemover
+  class DeletedHostCleaner
     def initialize(message, logger)
       @message = message
       @logger = logger

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -109,10 +109,10 @@ describe InventoryEventsConsumer do
     end
 
     context 'received delete message' do
-      let(:service_class) { Kafka::HostRemover }
+      let(:service_class) { Kafka::DeletedHostCleaner }
       let(:type) { 'delete' }
 
-      it 'delegates to HostRemover service' do
+      it 'delegates to DeletedHostCleaner service' do
         allow(@service).to receive(:remove_host)
 
         expect(@service).to receive(:remove_host)

--- a/spec/services/kafka/deleted_host_cleaner_spec.rb
+++ b/spec/services/kafka/deleted_host_cleaner_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-describe Kafka::HostRemover do
+describe Kafka::DeletedHostCleaner do
   after do
     DeleteHost.clear
   end
 
-  let(:service) { Kafka::HostRemover.new(message, Karafka.logger) }
+  let(:service) { Kafka::DeletedHostCleaner.new(message, Karafka.logger) }
 
   let(:type) { 'delete' }
   let(:user) { FactoryBot.create(:v2_user) }


### PR DESCRIPTION
Since the service doesn't delete Hosts, but does cleanup after deletion by Cyndi, this is a better, less ambiguous name.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
