### PR TITLE
fix(Jenkins): allow longer run of eph deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
         CICD_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main"
         COMPONENT_NAME="compliance"
         IMAGE="quay.io/cloudservices/compliance-backend"
-        IQE_CJI_TIMEOUT="30m"
+        IQE_CJI_TIMEOUT="40m"
         IQE_FILTER_EXPRESSION=""
         IQE_MARKER_EXPRESSION="compliance_smoke"
         IQE_PLUGINS="compliance"


### PR DESCRIPTION
The deployment time usually takes longer than 30m. After this we will hopefully not need to restart CI so many times.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
