### PR TITLE
fix(Jenkins): allow longer run of eph deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
         IQE_MARKER_EXPRESSION="compliance_smoke"
         IQE_PLUGINS="compliance"
         REF_ENV="insights-stage"
+        DEPLOY_TIMEOUT="1200"
     }
 
     stages {


### PR DESCRIPTION
The deployment time usually takes longer than 30m. After this we will hopefully not need to restart CI so many times.

Default is 15m, now we will do 20.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

CI:
- Add DEPLOY_TIMEOUT env var in Jenkinsfile to extend deployment timeout to 20 minutes