### PR TITLE
chore: configure renovate to only run on master branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "ignorePaths": [
     ".pre-commit-config.yaml"
   ],
+  "baseBranches": ["master"],
   "tekton": {
     "enabled": true,
     "packageRules": [


### PR DESCRIPTION
Currently, mintmaker will try to update all onboarded components but this is unnecessary for SC branches and just clutters the repo PR list. Only allowing renovate to run on main/master should help.

## Summary by Sourcery

CI:
- Restrict Renovate to only run on master branch