### PR TITLE
chore(deps): use RH catalog redis image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -382,7 +382,7 @@ services:
       - ACG_CONFIG=/opt/app-root/src/devel.json
       - RUBY_YJIT_ENABLE=1
   redis:
-    image: quay.io/cloudservices/redis:latest
+    image: registry.redhat.io/rhel9/redis-7:latest
     platform: linux/amd64
     ports:
       - 6379:6379


### PR DESCRIPTION
Change necessary due to quay image having been removed.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Build:
- Switch Redis image in docker-compose.yml from quay.io/cloudservices/redis:latest to registry.redhat.io/rhel9/redis-7