### PR TITLE
fix(Redis): RHINENG-20617 cast string to boolean for SSL mode

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
         redis_password = Settings.redis.cache_password.presence
       end
 
-      { url: redis_url, password: redis_password, ssl: Settings.redis.ssl}
+      { url: redis_url, password: redis_password, ssl: ActiveModel::Type::Boolean.new.cast(Settings.redis.ssl)}
     end
 
     # Override is necessary as it gets set during initialization without the proper config available

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@ sidekiq_config = lambda do |config|
   config.redis = {
     url: Settings.redis.url,
     password: Settings.redis.password.presence,
-    ssl: Settings.redis.ssl,
+    ssl: ActiveModel::Type::Boolean.new.cast(Settings.redis.ssl),
     network_timeout: 5
   }
   config[:dead_timeout_in_seconds] = 2.weeks.to_i

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -18,7 +18,7 @@ namespace :redis do
       Redis.new(
         url: Settings.redis.url,
         password: Settings.redis.password.presence,
-        ssl: Settings.redis.ssl
+        ssl: ActiveModel::Type::Boolean.new.cast(Settings.redis.ssl)
       ).ping
     rescue Redis::BaseError
       abort('ERROR: Redis unavailable')


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Cast Settings.redis.ssl to boolean in all Redis configurations (production, Sidekiq, and Rake tasks)