### PR TITLE
fix(Config): provide defaults for env vars in Foreman

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -12,15 +12,15 @@
     end
 
     config = {
-      database:       ENV['POSTGRESQL_DATABASE'],
-      username:       ENV['POSTGRESQL_USER'],
+      database:       ENV.fetch('POSTGRESQL_DATABASE', 'compliance_db'),
+      username:       ENV.fetch('POSTGRESQL_USER', 'compliance_admin'),
       password:       ENV['POSTGRESQL_PASSWORD'],
-      host:           ENV['POSTGRESQL_HOST'],
-      port:           ENV['POSTGRESQL_PORT'],
+      host:           ENV.fetch('POSTGRESQL_HOST', '/var/run/postgresql'),
+      port:           ENV.fetch('POSTGRESQL_PORT', '5432'),
       admin_username: ENV['POSTGRESQL_ADMIN_USERNAME'],
       admin_password: ENV['POSTGRESQL_ADMIN_PASSWORD'],
       rds_ca:         ENV['POSTGRESQL_RDS_CA'],
-      ssl_mode:       ENV['POSTGRESQL_SSLMODE'],
+      ssl_mode:       ENV.fetch('POSTGRESQL_SSLMODE', 'prefer'),
       ssl_root_cert:  ssl_root_cert
     }
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,9 +17,6 @@
       password:       ENV['POSTGRESQL_PASSWORD'],
       host:           ENV.fetch('POSTGRESQL_HOST', '/var/run/postgresql'),
       port:           ENV.fetch('POSTGRESQL_PORT', '5432'),
-      admin_username: ENV['POSTGRESQL_ADMIN_USERNAME'],
-      admin_password: ENV['POSTGRESQL_ADMIN_PASSWORD'],
-      rds_ca:         ENV['POSTGRESQL_RDS_CA'],
       ssl_mode:       ENV.fetch('POSTGRESQL_SSLMODE', 'prefer'),
       ssl_root_cert:  ssl_root_cert
     }

--- a/config/environments/foreman.rb
+++ b/config/environments/foreman.rb
@@ -49,27 +49,6 @@ Rails.application.configure do
   # Use in memory cache store in foreman.
   config.cache_store = :memory_store, { size: 64.megabytes }
 
-  # Logging configuration might be coming from env variables that are only available after initialization
-  config.after_initialize do
-    # Set up cloudwatch logging if available
-    # FIXME: change this to `Settings.logging.type == "cloudwatch"` once Clowder supports the configuration
-    #
-    # https://github.com/RedHatInsights/clowder/blob
-    #   /9a5b2bea2009911cebbddd0ed440a8b360014e64/controllers/cloud.redhat.com/providers/logging/appinterface.go#L54
-    if Settings.logging&.credentials&.access_key_id.present?
-      $cloudwatch_client ||= CloudWatchLogger::Client.new(
-        Settings.logging.credentials,
-        Settings.logging.log_group,
-        ENV.fetch('LOGSTREAM').presence || Socket.gethostname, # logstream name falls back to hostname if unset in ENV
-        region: Settings.logging.region
-      )
-      cloudwatch_logger = Insights::Api::Common::LoggerWithAudit.new($cloudwatch_client)
-      cloudwatch_logger.formatter = $cloudwatch_client.formatter(:json)
-      config.logger.broadcast_to(cloudwatch_logger)
-      cloudwatch_logger.level = Logger::WARN # Different logging level for CloudWatch
-    end
-  end
-
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "compliance-backend_#{Rails.env}"

--- a/config/initializers/0_env_config.rb
+++ b/config/initializers/0_env_config.rb
@@ -7,22 +7,9 @@ require 'clowder-common-ruby'
 
 if !ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
   config = {
-    'logging' => {
-      'type'      => ENV['LOGGING_TYPE'],
-      'region'    => ENV['LOGGING_REGION'],
-      'log_group' => ENV['LOGGING_LOG_GROUP'],
-      'credentials' => {
-        'access_key_id'     => ENV['LOGGING_ACCESS_KEY_ID'],
-        'secret_access_key' => ENV['LOGGING_SECRET_ACCESS_KEY']
-      }
-    },
     'kafka' => {
       'brokers'           => ENV.fetch('KAFKA_BROKERS', 'kafka:9092'),
       'security_protocol' => ENV.fetch('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
-      'sasl_username'     => ENV['KAFKA_SASL_USERNAME'],
-      'sasl_password'     => ENV['KAFKA_SASL_PASSWORD'],
-      'sasl_mechanism'    => ENV['KAFKA_SASL_MECHANISM'],
-      'ssl_ca_location'   => ENV['KAFKA_SSL_CA_LOCATION'],
       'topics' => {
         'inventory_events'               => ENV.fetch('KAFKA_TOPIC_INVENTORY_EVENTS', 'platform.inventory.events'),
         'upload_compliance'              => ENV.fetch('KAFKA_TOPIC_UPLOAD_COMPLIANCE', 'platform.upload.compliance'),
@@ -41,11 +28,6 @@ if !ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
       'cache_password' => ENV['REDIS_CACHE_PASSWORD']
     },
     'endpoints' => {
-      'rbac' => {
-        'scheme' => ENV['RBAC_SCHEME'],
-        'host'   => ENV['RBAC_HOST'],
-        'url'    => ENV['RBAC_URL']
-      },
       'host_inventory' => {
         'url' => ENV.fetch('HOST_INVENTORY_URL', 'http://inventory-web:8081')
       }
@@ -55,8 +37,6 @@ if !ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
         'url' => ENV.fetch('COMPLIANCE_SSG_URL', 'http://compliance-ssg:8088')
       }
     },
-    'platform_basic_auth_username' => ENV['PLATFORM_BASIC_AUTH_USERNAME'],
-    'platform_basic_auth_password' => ENV['PLATFORM_BASIC_AUTH_PASSWORD'],
     'disable_rbac' => ENV.fetch('DISABLE_RBAC', 'true')
   }
 

--- a/config/initializers/0_env_config.rb
+++ b/config/initializers/0_env_config.rb
@@ -17,27 +17,27 @@ if !ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
       }
     },
     'kafka' => {
-      'brokers'           => ENV.fetch('KAFKA_BROKERS', ''),
+      'brokers'           => ENV.fetch('KAFKA_BROKERS', 'kafka:9092'),
       'security_protocol' => ENV.fetch('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
       'sasl_username'     => ENV['KAFKA_SASL_USERNAME'],
       'sasl_password'     => ENV['KAFKA_SASL_PASSWORD'],
       'sasl_mechanism'    => ENV['KAFKA_SASL_MECHANISM'],
       'ssl_ca_location'   => ENV['KAFKA_SSL_CA_LOCATION'],
       'topics' => {
-        'inventory_events'               => ENV['KAFKA_TOPIC_INVENTORY_EVENTS'],
-        'upload_compliance'              => ENV['KAFKA_TOPIC_UPLOAD_COMPLIANCE'],
-        'payload_status'                 => ENV['KAFKA_TOPIC_PAYLOAD_STATUS'],
-        'notifications_ingress'          => ENV['KAFKA_TOPIC_NOTIFICATIONS_INGRESS'],
-        'remediation_updates_compliance' => ENV['KAFKA_TOPIC_REMEDIATION_UPDATES'],
-        'inventory_host_apps'            => ENV['KAFKA_TOPIC_INVENTORY_HOST_APPS']
+        'inventory_events'               => ENV.fetch('KAFKA_TOPIC_INVENTORY_EVENTS', 'platform.inventory.events'),
+        'upload_compliance'              => ENV.fetch('KAFKA_TOPIC_UPLOAD_COMPLIANCE', 'platform.upload.compliance'),
+        'payload_status'                 => ENV.fetch('KAFKA_TOPIC_PAYLOAD_STATUS', 'platform.payload-status'),
+        'notifications_ingress'          => ENV.fetch('KAFKA_TOPIC_NOTIFICATIONS_INGRESS', 'platform.notifications.ingress'),
+        'remediation_updates_compliance' => ENV.fetch('KAFKA_TOPIC_REMEDIATION_UPDATES', 'platform.remediation-updates.compliance'),
+        'inventory_host_apps'            => ENV.fetch('KAFKA_TOPIC_INVENTORY_HOST_APPS', 'platform.inventory.host-apps')
       }
     },
     'redis' => {
-      'url'            => ENV['REDIS_URL'],
+      'url'            => ENV.fetch('REDIS_URL', 'redis://redis:6379'),
       'password'       => ENV['REDIS_PASSWORD'],
       'ssl'            => ENV.fetch('REDIS_SSL', 'false'),
-      'cache_hostname' => ENV['REDIS_CACHE_HOSTNAME'],
-      'cache_port'     => ENV['REDIS_CACHE_PORT'],
+      'cache_hostname' => ENV.fetch('REDIS_CACHE_HOSTNAME', 'redis'),
+      'cache_port'     => ENV.fetch('REDIS_CACHE_PORT', '6379'),
       'cache_password' => ENV['REDIS_CACHE_PASSWORD']
     },
     'endpoints' => {
@@ -47,16 +47,17 @@ if !ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
         'url'    => ENV['RBAC_URL']
       },
       'host_inventory' => {
-        'url' => ENV['HOST_INVENTORY_URL']
+        'url' => ENV.fetch('HOST_INVENTORY_URL', 'http://inventory-web:8081')
       }
     },
     'private_endpoints' => {
       'compliance_ssg' => {
-        'url' => ENV['COMPLIANCE_SSG_URL']
+        'url' => ENV.fetch('COMPLIANCE_SSG_URL', 'http://compliance-ssg:8088')
       }
     },
     'platform_basic_auth_username' => ENV['PLATFORM_BASIC_AUTH_USERNAME'],
-    'platform_basic_auth_password' => ENV['PLATFORM_BASIC_AUTH_PASSWORD']
+    'platform_basic_auth_password' => ENV['PLATFORM_BASIC_AUTH_PASSWORD'],
+    'disable_rbac' => ENV.fetch('DISABLE_RBAC', 'true')
   }
 
   Settings.add_source!(config)

--- a/config/initializers/rbac.rb
+++ b/config/initializers/rbac.rb
@@ -1,9 +1,13 @@
-RBACApiClient.configure do |config|
-  config.host = Settings.endpoints.rbac.host
-  config.scheme = Settings.endpoints.rbac.scheme
-  config.ssl_ca_cert = ENV['SSL_CERT_FILE'].presence
-  if Settings.platform_basic_auth_username.present?
-    config.username = Settings.platform_basic_auth_username
-    config.password = Settings.platform_basic_auth_password
+# frozen_string_literal: true
+
+unless ActiveModel::Type::Boolean.new.cast(Settings.disable_rbac)
+  RBACApiClient.configure do |config|
+    config.host = Settings.endpoints.rbac.host
+    config.scheme = Settings.endpoints.rbac.scheme
+    config.ssl_ca_cert = ENV['SSL_CERT_FILE'].presence
+    if Settings.platform_basic_auth_username.present?
+      config.username = Settings.platform_basic_auth_username
+      config.password = Settings.platform_basic_auth_password
+    end
   end
 end

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -13,6 +13,8 @@ end
 if %w[sidekiq karafka].any? { |p| $0.include?(p) }
   if ClowderCommonRuby::Config.clowder_enabled?
     ENV['PROMETHEUS_EXPORTER_PORT'] = ClowderCommonRuby::Config.load.metricsPort.to_s
+  else
+    ENV['PROMETHEUS_EXPORTER_PORT'] ||= '9090'
   end
 
   Yabeda::ActiveJob.install!

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -13,7 +13,7 @@ set_default_host '0.0.0.0'
 if ClowderCommonRuby::Config.clowder_enabled?
   port ClowderCommonRuby::Config.load.webPort
 else
-  port ENV.fetch('WEB_PORT', 3000)
+  port ENV.fetch('WEB_PORT', 8000)
 end
 
 # Specifies the `environment` that Puma will run in.
@@ -52,6 +52,8 @@ preload_app! if concurrency > 0
 # Metrics collection
 if ClowderCommonRuby::Config.clowder_enabled?
   ENV['PROMETHEUS_EXPORTER_PORT'] = ClowderCommonRuby::Config.load.metricsPort.to_s
+else
+  ENV['PROMETHEUS_EXPORTER_PORT'] ||= '9090'
 end
 activate_control_app("unix://#{File.expand_path(File.join(File.dirname(__FILE__), '../tmp/puma.sock'))}")
 plugin :yabeda


### PR DESCRIPTION
* Provide env var defaults in a Foreman environment
* Remove DB admin login and password env vars as we only use admin in IoP
* Remove RDS, Cloudwatch and RBAC related config as they're not present in this environment
* Remove Kafka security related env vars as IoP uses plaintext mode

I will probably remove Redis once we've gotten rid of Sidekiq

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Set sensible non-Clowder defaults for configuration when environment variables are missing and remove unused environment-specific settings.

New Features:
- Provide default values for logging, Kafka topics and brokers, Redis, host inventory, compliance SSG, database, and web port when corresponding environment variables are unset.
- Set a default Prometheus exporter port for non-Clowder environments in both Puma and Yabeda initializers.

Bug Fixes:
- Avoid misconfiguration of Foreman environments by ensuring missing environment variables fall back to working defaults instead of remaining unset.

Enhancements:
- Remove unused RBAC, Kafka security, database admin, and RDS-related configuration keys that are not applicable in this environment.