### PR TITLE
fix(InventoryViews): remove redundant sending of last_scan

### DIFF
--- a/app/producers/inventory_views.rb
+++ b/app/producers/inventory_views.rb
@@ -29,8 +29,7 @@ class InventoryViews < ApplicationProducer
 
   def self.host_data(system)
     {
-      policies: system.policies.map { |p| { id: p.id, name: p.title } },
-      last_scan: system.last_check_in
+      policies: system.policies.map { |p| { id: p.id, name: p.title } }
     }
   end
 end

--- a/spec/producers/inventory_views_spec.rb
+++ b/spec/producers/inventory_views_spec.rb
@@ -23,8 +23,7 @@ describe InventoryViews do
           {
             id: system.id,
             data: {
-              policies: system.policies.map { |p| { id: p.id, name: p.title } },
-              last_scan: system.last_check_in
+              policies: system.policies.map { |p| { id: p.id, name: p.title } }
             }
           }
         ]


### PR DESCRIPTION
Inventory has to change the source of truth to themselves before we can remove this. 
This is not a priority tho, it's a minor redundancy.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
