### PR TITLE
fix(KesselRbac): log identity details on unsupported identity type

### DIFF
--- a/app/services/kessel_rbac.rb
+++ b/app/services/kessel_rbac.rb
@@ -107,6 +107,12 @@ class KesselRbac
       elsif identity_type == USER_IDENTITY
         identity&.dig('user', 'user_id')
       else
+        Rails.logger.error(
+          "Kessel unsupported identity type: '#{identity_type}', " \
+          "auth_type: '#{identity&.dig('auth_type')}', " \
+          "org_id: '#{identity&.dig('org_id')}', " \
+          "identity keys: #{identity&.keys}"
+        )
         raise 'unsupported identity type'
       end
     end

--- a/app/services/kessel_rbac.rb
+++ b/app/services/kessel_rbac.rb
@@ -107,14 +107,18 @@ class KesselRbac
       elsif identity_type == USER_IDENTITY
         identity&.dig('user', 'user_id')
       else
-        Rails.logger.error(
-          "Kessel unsupported identity type: '#{identity_type}', " \
-          "auth_type: '#{identity&.dig('auth_type')}', " \
-          "org_id: '#{identity&.dig('org_id')}', " \
-          "identity keys: #{identity&.keys}"
-        )
+        log_unsupported_identity(identity, identity_type)
         raise 'unsupported identity type'
       end
+    end
+
+    def log_unsupported_identity(identity, identity_type)
+      Rails.logger.error(
+        "Kessel unsupported identity type: '#{identity_type}', " \
+        "auth_type: '#{identity&.dig('auth_type')}', " \
+        "org_id: '#{identity&.dig('org_id')}', " \
+        "identity keys: #{identity&.keys}"
+      )
     end
 
     def build_subject_reference(user)


### PR DESCRIPTION
## Summary
- Adds error logging in `KesselRbac#principal_id` when an unsupported identity type is encountered
- Logs identity type, auth_type, org_id, and identity keys to aid diagnosis
- Request ID and org_id are automatically included via Rails `config.log_tags`

## Problem
When `principal_id` encounters an identity type other than `User` or `ServiceAccount`, it raises a raw `RuntimeError` with no diagnostic information. This error is raised **outside** the `begin/rescue` block in `check_permission`, so the existing Kessel error logging (`"Kessel authorization check failed"`) never fires. The result is a 500 with no useful application logs.

## Test plan
- [ ] Deploy to stage and reproduce the failing request to `v2/policies/:id/tailorings/:id/tailoring_file`
- [ ] Verify the log line appears with identity type, auth_type, org_id, and identity keys
- [ ] Confirm the request_id is present in the log tag prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)