### PR TITLE
cleanup(Policy): remove erroneous default title

### DIFF
--- a/app/models/v2/policy.rb
+++ b/app/models/v2/policy.rb
@@ -99,7 +99,6 @@ module V2
     private
 
     def ensure_default_values
-      self.title ||= profile&.title
       self.description ||= profile&.description
       self.compliance_threshold ||= 100.0
     end

--- a/spec/controllers/v2/policies_controller_spec.rb
+++ b/spec/controllers/v2/policies_controller_spec.rb
@@ -132,11 +132,11 @@ describe V2::PoliciesController do
       context 'unset title' do
         let(:title) { nil }
 
-        it 'copies the title of the profile' do
+        it 'is not_acceptable' do
           post :create, params: params
 
-          expect(response).to have_http_status :created
-          expect(subject.title).to eq(subject.profile.title)
+          expect(response).to have_http_status :not_acceptable
+          expect(response.parsed_body['errors']).to include(match(/title can't be blank/))
         end
       end
 


### PR DESCRIPTION
Small inconsistency I found. We cannot have a default here as Policy title uniqueness is enforced on a model level.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
