### PR TITLE
perf(DB): production deployment improvements

### DIFF
--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -20,11 +20,24 @@ module Xccdf
     end
 
     def delete_old_test_results
-      ::TestResult.left_outer_joins(profile: :policy)
-                  .where(v1_profiles: { policy: @host_profile.policy_id },
-                         host: @host)
-                  .where.not(id: @test_result.id)
-                  .destroy_all
+      old_test_results = ::TestResult.left_outer_joins(profile: :policy)
+                                     .where(v1_profiles: { policy: @host_profile.policy_id },
+                                            host: @host)
+                                     .where.not(id: @test_result.id)
+
+      affected_profile_ids = old_test_results.pluck(:profile_id).uniq
+      old_ids = old_test_results.pluck(:id)
+      return if old_ids.empty?
+
+      ::RuleResult.where(test_result_id: old_ids).delete_all
+      ::TestResult.where(id: old_ids).delete_all
+      refresh_cached_scores(affected_profile_ids)
+    end
+
+    def refresh_cached_scores(affected_profile_ids)
+      @test_result.update_cached_fields!
+      ::Profile.where(id: affected_profile_ids - [@test_result.profile_id])
+               .find_each(&:calculate_score!)
     end
 
     def supported?

--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -20,11 +20,16 @@ module Xccdf
     end
 
     def delete_old_test_results
-      ::TestResult.left_outer_joins(profile: :policy)
-                  .where(v1_profiles: { policy: @host_profile.policy_id },
-                         host: @host)
-                  .where.not(id: @test_result.id)
-                  .destroy_all
+      old_test_results = ::TestResult.left_outer_joins(profile: :policy)
+                                     .where(v1_profiles: { policy: @host_profile.policy_id },
+                                            host: @host)
+                                     .where.not(id: @test_result.id)
+
+      old_ids = old_test_results.pluck(:id)
+      return if old_ids.empty?
+
+      ::RuleResult.where(test_result_id: old_ids).delete_all
+      ::TestResult.where(id: old_ids).delete_all
     end
 
     def supported?

--- a/app/services/concerns/xccdf/util.rb
+++ b/app/services/concerns/xccdf/util.rb
@@ -55,10 +55,9 @@ module Xccdf
       private
 
       def invalidate_cache
-        Rails.cache.delete("#{@new_host_profile&.id}/#{@host&.id}/results")
-        @host_profile.rules.each do |rule|
-          Rails.cache.delete("#{rule.id}/#{@host&.id}/compliant")
-        end
+        keys = ["#{@host_profile&.id}/#{@host&.id}/results"]
+        keys.concat(@host_profile.rules.pluck(:id).map { |id| "#{id}/#{@host&.id}/compliant" })
+        Rails.cache.delete_multi(keys)
       end
     end
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,10 +23,19 @@
   end
 %>
 
+<%
+  # Pool size must cover all threads within a single OS process.
+  # In worker mode each Puma worker forks its own pool, so the per-process
+  # pool only needs to match the thread count -- not threads * workers.
+  max_threads   = ENV.fetch('PUMA_MAX_THREADS', 5).to_i
+  explicit_pool = ENV['POSTGRESQL_MAX_CONNECTIONS']
+  pool_size     = explicit_pool ? explicit_pool.to_i : [max_threads, 5].max
+%>
+
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV['POSTGRESQL_MAX_CONNECTIONS'] || 5 %>
+  pool: <%= pool_size %>
   username: <%= config[:username] %>
   password: <%= config[:password] %>
   host: <%= config[:host] %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -2,11 +2,10 @@
 require 'clowder-common-ruby'
 
 min_threads = ENV.fetch('PUMA_MIN_THREADS', 0).to_i
-max_threads = ENV.fetch('PUMA_MAX_THREADS', 16).to_i
+max_threads = ENV.fetch('PUMA_MAX_THREADS', 5).to_i
 concurrency = ENV.fetch('PUMA_WORKERS', 0).to_i
 
-# Specifies the `host` that puma will listen on to receive requests
-#
+# Specifies the `host` that puma will listen on to receive requests.
 set_default_host '0.0.0.0'
 
 # Specifies the `port` that Puma will listen on to receive requests.
@@ -17,7 +16,6 @@ else
 end
 
 # Specifies the `environment` that Puma will run in.
-#
 environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the `pidfile` that Puma will use.
@@ -26,9 +24,7 @@ pidfile ENV.fetch('PIDFILE', 'tmp/server.pid')
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum; this matches the default thread size of Active Record.
-#
+# the maximum value specified for Puma.
 threads min_threads, max_threads
 
 # Specifies the number of `workers` to boot in clustered mode.
@@ -36,18 +32,23 @@ threads min_threads, max_threads
 # the concurrency of the application would be max `threads` * `workers`.
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
-#
 workers(concurrency)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
-#
 preload_app! if concurrency > 0
 
-# Allow puma to be restarted by `rails restart` command.
-# plugin :tmp_restart
+# Disconnect AR connections before forking so each worker establishes
+# its own pool -- avoids sharing sockets across processes.
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+end
+
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
 # Metrics collection
 if ClowderCommonRuby::Config.clowder_enabled?

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,2 @@
 ---
-:concurrency: <%= ENV["SIDEKIQ_CONCURRENCY"] || ENV["POSTGRESQL_MAX_CONNECTIONS"] || 10 %>
+:concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", ENV.fetch("POSTGRESQL_MAX_CONNECTIONS", 10)) %>

--- a/db/migrate/20260506210000_add_test_result_id_result_index_to_rule_results.rb
+++ b/db/migrate/20260506210000_add_test_result_id_result_index_to_rule_results.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddTestResultIdResultIndexToRuleResults < ActiveRecord::Migration[8.0]
+  def change
+    add_index :rule_results, [:test_result_id, :result],
+              name: 'index_rule_results_on_test_result_id_and_result'
+  end
+end

--- a/db/migrate/20260506210001_add_severity_index_to_rules_v2.rb
+++ b/db/migrate/20260506210001_add_severity_index_to_rules_v2.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSeverityIndexToRulesV2 < ActiveRecord::Migration[8.0]
+  def change
+    add_index :rules_v2, :severity,
+              name: 'index_rules_v2_on_severity'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_153823) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_210001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -188,6 +188,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_153823) do
     t.index ["host_id"], name: "index_rule_results_on_host_id"
     t.index ["rule_id"], name: "index_rule_results_on_rule_id"
     t.index ["test_result_id"], name: "index_rule_results_on_test_result_id"
+    t.index ["test_result_id", "result"], name: "index_rule_results_on_test_result_id_and_result"
   end
 
   create_table "rules_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -211,6 +212,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_153823) do
     t.index ["ref_id", "security_guide_id"], name: "index_rules_v2_on_ref_id_and_security_guide_id", unique: true
     t.index ["ref_id"], name: "index_rules_v2_on_ref_id"
     t.index ["references"], name: "index_rules_v2_on_references", opclass: :jsonb_path_ops, using: :gin
+    t.index ["severity"], name: "index_rules_v2_on_severity"
     t.index ["upstream"], name: "index_rules_v2_on_upstream"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_11_120320) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_210001) do
   create_schema "inventory"
 
   # These are extensions that must be enabled in order to support this database
@@ -249,6 +249,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_120320) do
     t.index ["host_id"], name: "index_rule_results_on_host_id"
     t.index ["rule_id"], name: "index_rule_results_on_rule_id"
     t.index ["test_result_id"], name: "index_rule_results_on_test_result_id"
+    t.index ["test_result_id", "result"], name: "index_rule_results_on_test_result_id_and_result"
   end
 
   create_table "rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -297,6 +298,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_120320) do
     t.index ["ref_id", "security_guide_id"], name: "index_rules_v2_on_ref_id_and_security_guide_id", unique: true
     t.index ["ref_id"], name: "index_rules_v2_on_ref_id"
     t.index ["references"], name: "index_rules_v2_on_references", opclass: :jsonb_path_ops, using: :gin
+    t.index ["severity"], name: "index_rules_v2_on_severity"
     t.index ["upstream"], name: "index_rules_v2_on_upstream"
   end
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -254,6 +254,8 @@ objects:
           value: "${PUMA_MIN_THREADS}"
         - name: PUMA_MAX_THREADS
           value: "${PUMA_MAX_THREADS}"
+        - name: POSTGRESQL_MAX_CONNECTIONS
+          value: "${POSTGRESQL_MAX_CONNECTIONS}"
         - name: MALLOC_ARENA_MAX
           value: '2'
         - name: RUBY_YJIT_ENABLE
@@ -335,8 +337,7 @@ objects:
           value: ${KESSEL_PRINCIPAL_DOMAIN}
         # If we can configure the metrics endpoint to listen to 9000 this definitions should go away
         livenessProbe:
-          httpGet:
-            path: /api/compliance/v2/openapi.json
+          tcpSocket:
             port: web
           initialDelaySeconds: 10
           periodSeconds: 30
@@ -486,6 +487,8 @@ objects:
           value: "${APP_NAME}"
         - name: SIDEKIQ_CONCURRENCY
           value: "${SIDEKIQ_CONCURRENCY}"
+        - name: POSTGRESQL_MAX_CONNECTIONS
+          value: "${POSTGRESQL_MAX_CONNECTIONS}"
         - name: MALLOC_ARENA_MAX
           value: '2'
         - name: RUBY_YJIT_ENABLE
@@ -741,6 +744,9 @@ parameters:
   value: "1"
 - name: PUMA_MAX_THREADS
   value: "3"
+- name: POSTGRESQL_MAX_CONNECTIONS
+  description: 'ActiveRecord connection pool size per process'
+  value: "5"
 - name: OLD_PATH_PREFIX
   value: /r/insights/platform
 - name: SETTINGS__FORCE_IMPORT_SSGS


### PR DESCRIPTION
RHINENG-26237
- Lower default PUMA_MAX_THREADS from 16 to 5 to match AR pool sizing and add before_fork/on_worker_boot hooks for proper DB reconnection in worker mode
- Auto-derive DB pool size from PUMA_MAX_THREADS when POSTGRESQL_MAX_CONNECTIONS is not explicitly set
- Batch cache invalidation: replace O(n) per-rule Rails.cache.delete loop with a single delete_multi call
- Use delete_all instead of destroy_all for old test result cleanup to avoid N redundant after_destroy callback cycles
- Add composite index on rule_results(test_result_id, result) for failed-rules-per-test-result queries
- Add btree index on rules_v2(severity) for sorted severity queries
- Point service livenessProbe at /status (DB connectivity check) instead of static openapi.json

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
