### PR TITLE
chore(deps): update net-imap to 0.6.4 and nokogiri to 1.19.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
     multi_json (1.19.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -289,7 +289,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oj (3.16.16)


### PR DESCRIPTION
Updates dependencies:
- net-imap: 0.6.3 → 0.6.4
- nokogiri: 1.19.2 → 1.19.3

## Test plan
- [x] All RSpec tests passing (1,831 examples, 0 failures)
- [x] All Minitest tests passing (381 tests, 0 failures)