### PR TITLE
ci(github): unpin podman-compose to fix swallowed build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set up the environment
       run: |
         cp .env.example .env
-        pipx install podman-compose==1.0.6
+        pipx install podman-compose
     - name: Build using podman-compose
       run: podman-compose build
   development-build-docker:


### PR DESCRIPTION
Podman build errors were returning exit code 0 due to a bug in
podman-compose 1.0.6.
Unpinning to use latest (v1.5.0+) propagates the exit code correctly,
turning the job red on build failure.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
