### PR TITLE
dangleberry supreme

### DIFF
--- a/app/services/concerns/xccdf/hosts.rb
+++ b/app/services/concerns/xccdf/hosts.rb
@@ -9,7 +9,8 @@ module Xccdf
                 .with_ref_ids(test_result_profile.ref_id)
                       .find_by(account: @account),
         account: @account,
-        os_minor_version: @host.os_minor_version.to_s
+        os_minor_version: @host.os_minor_version.to_s,
+        set_os_minor_version: @host.os_minor_version.to_s
       )
     end
     alias save_host_profile host_profile

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -17,9 +17,11 @@ class XccdfReportParser
   class UnknownProfileError < StandardError; end
   # Error to raise if the incoming report contains an unknown rule
   class UnknownRuleError < StandardError; end
+  # Error to raise if the report's SSG version does not match the policy
+  class SSGVersionMismatch < StandardError; end
 
   ERRORS = [
-    MissingIdError, WrongFormatError, OSVersionMismatch, UnknownProfileError,
+    MissingIdError, WrongFormatError, OSVersionMismatch, SSGVersionMismatch, UnknownProfileError,
     ActiveRecord::RecordInvalid, ExternalReportError, UnknownBenchmarkError, UnknownRuleError
   ].freeze
 
@@ -82,6 +84,18 @@ class XccdfReportParser
     # rubocop:enable Style/GuardClause
   end
 
+  def check_ssg_version
+    return unless @policy
+
+    policy_benchmark_ids = @policy.profiles.select(:benchmark_id).distinct.pluck(:benchmark_id)
+    return if policy_benchmark_ids.include?(benchmark.id)
+
+    raise SSGVersionMismatch,
+          "SSG version mismatch for policy #{@policy.id}: report was generated with " \
+          "scap-security-guide #{security_guide.version} but the policy expects " \
+          "#{policy_ssg_versions.join(', ')}. #{parse_failure_message}"
+  end
+
   def check_for_missing_benchmark
     # rubocop:disable Style/GuardClause
     unless security_guide.persisted?
@@ -124,6 +138,7 @@ class XccdfReportParser
   def save_all
     check_os_version
     check_for_external_reports
+    check_ssg_version
     check_for_missing_benchmark_info
 
     Host.transaction do
@@ -132,6 +147,10 @@ class XccdfReportParser
   end
 
   private
+
+  def policy_ssg_versions
+    @policy.benchmarks.distinct.pluck(:version)
+  end
 
   def parse_failure_message
     "Report for profile #{@test_result_file.test_result.profile_id} against " \

--- a/test/jobs/parse_report_job_test.rb
+++ b/test/jobs/parse_report_job_test.rb
@@ -189,6 +189,29 @@ class ParseReportJobTest < ActiveJob::TestCase
     @parse_report_job.perform(0, @msg_value)
   end
 
+  test 'SSG version mismatch is handled as a parse failure' do
+    XccdfReportParser.stubs(:new).returns(@parser)
+    @parser.stubs(:save_all).raises(
+      XccdfReportParser::SSGVersionMismatch.new('SSG version mismatch')
+    )
+    profile_stub = OpenStruct.new(
+      test_result: OpenStruct.new(profile_id: 'profileid')
+    )
+    @parser.stubs(:test_result_file).returns(profile_stub)
+    Sidekiq.stubs(:redis).returns(false)
+    @parse_report_job.stubs(:jid).returns('1')
+
+    Host.stubs(:find_by).returns(@host)
+
+    ReportUploadFailed.expects(:deliver)
+
+    SafeDownloader.expects(:download_reports)
+                  .with('', ssl_only: Settings.report_download_ssl_only)
+                  .returns(ActiveSupport::Gzip.decompress(@file))
+    assert_audited_fail 'Failed to parse report profileid'
+    @parse_report_job.perform(0, @msg_value)
+  end
+
   test 'emits notification non compliant without a report' do
     XccdfReportParser.stubs(:new).returns(@parser)
     Sidekiq.stubs(:redis).returns(false)

--- a/test/models/policy_test.rb
+++ b/test/models/policy_test.rb
@@ -366,6 +366,42 @@ class PolicyTest < ActiveSupport::TestCase
         assert_equal @os_minor_version, child_profile.os_minor_version
       end
     end
+
+    should 'always set os_minor_version when both lookup and set params are provided' do
+      assert_difference('Profile.count', 1) do
+        child_profile = @canonical.clone_to(
+          account: @account,
+          policy: @policy,
+          os_minor_version: @os_minor_version,
+          set_os_minor_version: @os_minor_version
+        )
+
+        assert child_profile
+        assert_equal @os_minor_version, child_profile.os_minor_version
+        assert child_profile.os_minor_version.present?
+      end
+    end
+
+    should 'not create duplicate profile when os_minor_version already taken' do
+      @canonical.clone_to(
+        account: @account,
+        policy: @policy,
+        set_os_minor_version: @os_minor_version
+      )
+
+      different_benchmark = FactoryBot.create(:benchmark)
+      different_canonical = FactoryBot.create(
+        :canonical_profile, benchmark: different_benchmark
+      )
+
+      assert_raises(ActiveRecord::RecordInvalid) do
+        different_canonical.clone_to(
+          account: @account,
+          policy: @policy,
+          set_os_minor_version: @os_minor_version
+        )
+      end
+    end
   end
 
   context 'update_os_minor_versions' do


### PR DESCRIPTION
# ゴゴゴゴ dangleberry supreme ゴゴゴゴ

**Stand Master:** `XccdfReportParser`
**Stand Name:** 「DANGLEBERRY SUPREME」
**Stand Cry:** ORA ORA ORA ORA ORA!

---

## The Enemy Stand: 「DANGLING TAILORING」

An enemy Stand has been creating **6,653 dangling profiles** and **11.2M orphaned profile_rules** across **1,971 orgs**. Every time a host scans with a mismatched SSG version, it spawns a hollow clone with no `os_minor_version`.

*"I can't pollute the hell out of your profile_rules table without getting closer."*

## This PR's Stand Abilities

### THE WORLD -- SSG Version Check
`XccdfReportParser#save_all` now rejects reports whose SSG version doesn't match any benchmark on the policy. Mismatched reports are stopped before they enter the transaction.

### STAR PLATINUM -- set_os_minor_version
`Xccdf::Hosts#host_profile` now passes `set_os_minor_version` to `clone_to`, ensuring every new profile gets a proper `os_minor_version`.

## Post-deploy cleanup

After this is deployed, please request the AppSRE team to run the following cleanup SQL against the prod database (GABI is read-only and cannot run DELETE statements):

```sql
DELETE FROM rule_results WHERE test_result_id IN (
  SELECT id FROM test_results WHERE profile_id IN (
    SELECT id FROM profiles WHERE parent_profile_id IS NOT NULL AND os_minor_version = ''));

DELETE FROM test_results WHERE profile_id IN (
  SELECT id FROM profiles WHERE parent_profile_id IS NOT NULL AND os_minor_version = '');

DELETE FROM profile_rules WHERE profile_id IN (
  SELECT id FROM profiles WHERE parent_profile_id IS NOT NULL AND os_minor_version = '');

DELETE FROM profiles WHERE parent_profile_id IS NOT NULL AND os_minor_version = '';

DELETE FROM profile_rules WHERE profile_id NOT IN (SELECT id FROM profiles);
```

## Test Plan
- [ ] Run existing test suite
- [ ] Verify SSG mismatch reports are rejected with clear error
- [ ] Monitor Kibana for `SSGVersionMismatch` errors post-deploy
- [ ] Confirm no new dangling profiles appear

*Yare yare daze...*