### PR TITLE
feat(ci): add IoP container publishing workflow

### DIFF
--- a/.github/workflows/iop-container-publish.yaml
+++ b/.github/workflows/iop-container-publish.yaml
@@ -1,0 +1,73 @@
+name: Container image build and publish
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+      - 'foreman-*.*'
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: "iop/compliance"
+
+jobs:
+  build:
+    concurrency:
+      group: "${{ github.workflow }}-${{ github.ref }}"
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20
+        with:
+          cosign-release: 'v2.2.4'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_IOP_BUILD_USERNAME }}
+          password: ${{ secrets.QUAY_IOP_BUILD_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
+        with:
+          platforms: linux/amd64
+          context: .
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        if: github.event_name != 'pull_request'
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}


### PR DESCRIPTION
## Summary
Adds automated GitHub Actions workflow to build and push Compliance container images to quay.io/iop/compliance for IoP (Insights on-Prem) deployments.

Follows the established pattern from [iop-gateway](https://github.com/RedHatInsights/iop-gateway/blob/master/.github/workflows/container-publish.yaml).

## Changes
- Added \`.github/workflows/iop-container-publish.yaml\`
- Builds on push to master branch
- Pushes to \`quay.io/iop/compliance\` with tags: master, sha-*, latest
- Signs images with cosign for supply chain security

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
