### PR TITLE
feat(gitignore): ignore cursor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ bower.json
 # Ignore node_modules
 node_modules/
 
+# Ignore cursor folder
+.cursor/
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key


### PR DESCRIPTION
I want to add some skills locally and I don't think we should commit and share them yet.
Especially since we all use different setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Add `.cursor/` directory to `.gitignore` to exclude local cursor folder from version control

## Contributions by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| Janos Laszlo Vasik | 2 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->