### PR TITLE
chore(deps): pin postgres on version 16

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,11 @@
   ],
   "packageRules": [
     {
+      "description": "Pin postgres Docker image to v16",
+      "matchPackageNames": ["postgres"],
+      "allowedVersions": "<=16"
+    },
+    {
       "matchPackageNames": [
         "RedHatInsights/konflux-pipelines"
       ],


### PR DESCRIPTION
Addressing https://github.com/RedHatInsights/compliance-backend/pull/2722#issuecomment-4430487967

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Pin PostgreSQL Docker image to v16 via renovate.json package rule
- Prevent automatic Renovate updates of PostgreSQL versions beyond 16
<!-- end of auto-generated comment: release notes by coderabbit.ai -->