### PR TITLE
fix(api): compute all_systems_exposed via SQL aggregate on reports

### DIFF
--- a/app/models/v2/report.rb
+++ b/app/models/v2/report.rb
@@ -45,6 +45,14 @@ module V2
       )
     end
 
+    ALL_SYSTEMS_EXPOSED = lambda do
+      AN::NamedFunction.new('COUNT', [V2::System.arel_table[:id]]).eq(
+        AN::NamedFunction.new('COUNT', [V2::System.arel_table[:id]]).filter(
+          Pundit.policy_scope(User.current, V2::System).where_clause.ast
+        )
+      )
+    end
+
     PERCENT_COMPLIANT = lambda do
       AN::NamedFunction.new(
         'COALESCE',
@@ -130,10 +138,6 @@ module V2
 
     def profile_title
       attributes['profile__title'] || try(:profile)&.title
-    end
-
-    def all_systems_exposed # rubocop:disable Naming/PredicateMethod
-      policy.total_system_count == try(:aggregate_assigned_system_count)
     end
 
     def delete_associated

--- a/app/serializers/v2/report_serializer.rb
+++ b/app/serializers/v2/report_serializer.rb
@@ -8,8 +8,8 @@ module V2
     derived_attribute :os_major_version, security_guide: [:os_major_version]
     derived_attribute :profile_title, profile: [:title]
     derived_attribute :ref_id, profile: [:ref_id]
-    derived_attribute :all_systems_exposed
 
+    aggregated_attribute :all_systems_exposed, :reporting_and_non_reporting_systems, V2::Report::ALL_SYSTEMS_EXPOSED
     aggregated_attribute :percent_compliant, :reporting_and_non_reporting_systems, V2::Report::PERCENT_COMPLIANT
     aggregated_attribute :assigned_system_count, :reporting_and_non_reporting_systems, V2::Report::SYSTEM_COUNT
     aggregated_attribute :compliant_system_count, :reporting_and_non_reporting_systems, V2::Report::COMPLIANT_SYSTEM_COUNT


### PR DESCRIPTION
## Problem

`GET /api/compliance/v2/reports?filter=with_reported_systems=true` raised a `NoMethodError` in production: `undefined method 'total_system_count' for nil`.

The `all_systems_exposed` attribute was computed by lazy-loading a `V2::Policy` association and calling `policy.total_system_count` on it. This was written when `total_system_count` was a cached column on the old `policies` table. After the full migration to `policies_v2` — which has no such column — `total_system_count` became a computed method requiring the aggregate subquery to be pre-loaded. Since the association is lazy-loaded without that subquery, the method silently fell back to an N+1 `policy_systems.count` at best, and crashed with a `nil` dereference at worst.

## Changes

- Add `ALL_SYSTEMS_EXPOSED` SQL lambda to `V2::Report` — a boolean equality of total system count vs RBAC-filtered system count: `COUNT(systems.id) = COUNT(systems.id) FILTER (WHERE <rbac>)`
- Promote `all_systems_exposed` from a `derived_attribute` (Ruby method, relied on the `policy` association) to an `aggregated_attribute` on `reporting_and_non_reporting_systems` (pure SQL, no association load)
- Remove the `all_systems_exposed` Ruby method and its cross-domain `policy.total_system_count` call entirely

## Result

- No nil dereference — there is no association to load
- No N+1 — the boolean is computed inside the existing `reporting_and_non_reporting_systems` subquery alongside all other system counts, with zero extra SQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Fixed nil dereference in filtered reports endpoint** by computing `all_systems_exposed` as a SQL aggregate instead of a lazy-loaded Ruby method, eliminating `NoMethodError: undefined method 'total_system_count'` and N+1 query behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->