### PR TITLE
fix(Jenkinsfile): shorten ephemeral reservation to 1h

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                         RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
                         RBAC_SHORT_SHA=${RBAC_SHA:0:7}
 
-                        NAMESPACE=$(bonfire namespace reserve --duration 10h)
+                        NAMESPACE=$(bonfire namespace reserve --duration 1h)
                         oc project $NAMESPACE
 
                         bonfire deploy host-inventory kessel rbac compliance \


### PR DESCRIPTION
We're hogging resources as there's no release logic without [cicd-tools](https://github.com/RedHatInsights/cicd-tools/blob/main/_common_deploy_logic.sh#L66).

This PR will start to respect the [fallback default of 1h reservation](https://github.com/RedHatInsights/cicd-tools/blob/main/deploy_ephemeral_env.sh#L10). 