### PR TITLE
 feat(systems): bulk backfill systems table from inventory

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -138,6 +138,57 @@ objects:
         livenessProbe:
           exec:
             command: ["pgrep" ,"-f", "rake"]
+    - name: backfill-systems
+      schedule: ${BACKFILL_SYSTEMS_SCHEDULE}
+      concurrencyPolicy: Forbid
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command: ["/bin/sh"]
+          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+          inheritEnv: true
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
+          requests:
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-backfill-systems
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: BATCH_SIZE
+          value: "${BACKFILL_BATCH_SIZE}"
+        - name: MAX_ROWS_PER_RUN
+          value: "${BACKFILL_MAX_ROWS_PER_RUN}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
+        - name: MAX_INIT_TIMEOUT_SECONDS
+          value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: IMAGE_TAG
+          value: "${IMAGE}:${IMAGE_TAG}"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOGSTREAM
+          value: "${LOGSTREAM_BACKFILL_SYSTEMS}"
+        livenessProbe:
+          exec:
+            command: ["pgrep" ,"-f", "rake"]
     - name: reindex-db
       schedule: ${REINDEX_DB_SCHEDULE}
       concurrencyPolicy: Forbid
@@ -777,6 +828,15 @@ parameters:
 - name: REINDEX_DB_SCHEDULE
   description: Cronjob schedule for DB reindex
   value: "0 5 * * *" # every day at 5 AM
+- name: BACKFILL_SYSTEMS_SCHEDULE
+  description: Cronjob schedule for systems backfill
+  value: "*/5 * * * *" # every 5 minutes
+- name: BACKFILL_BATCH_SIZE
+  description: Number of rows per batch for systems backfill
+  value: "1000"
+- name: BACKFILL_MAX_ROWS_PER_RUN
+  description: Max rows to process per cron execution for systems backfill
+  value: "50000"
 - name: MAX_INIT_TIMEOUT_SECONDS
   description: Number of seconds for timeout init container operation
   value: "120"
@@ -793,6 +853,8 @@ parameters:
   value: 'compliance-import-ssg'
 - name: LOGSTREAM_REINDEX_DB
   value: 'compliance-reindex-db'
+- name: LOGSTREAM_BACKFILL_SYSTEMS
+  value: 'compliance-backfill-systems'
 - name: RUBY_YJIT_ENABLE
   value: '0'
 - name: KESSEL_ENABLED

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,8 @@ elif [ "$APPLICATION_TYPE" = "compliance-import-ssg" ]; then
   exec bundle exec rake ssg:import_rhel_supported --trace
 elif [ "$APPLICATION_TYPE" = "compliance-reindex-db" ]; then
   exec bundle exec rake db:reindex --trace
+elif [ "$APPLICATION_TYPE" = "compliance-backfill-systems" ]; then
+  exec bundle exec rake systems:backfill --trace
 elif [ "$APPLICATION_TYPE" = "sleep" ]; then
   while true; do sleep 60; done
 else

--- a/lib/tasks/systems_backfill.rake
+++ b/lib/tasks/systems_backfill.rake
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/Documentation
+class SystemsBackfiller
+  # rubocop:enable Style/Documentation
+  def initialize(batch_size:, max_upserts:, logger:)
+    @batch_size = batch_size
+    @max_upserts = max_upserts
+    @logger = logger
+    @total_upserted = 0
+  end
+
+  def run
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    org_ids = discover_orgs
+    process_orgs(org_ids)
+
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    elapsed = (end_time - start_time).round(2)
+
+    @logger.info("systems:backfill completed in #{elapsed}s. " \
+                 "Total upserted: #{@total_upserted}.")
+  end
+
+  private
+
+  def discover_orgs
+    @logger.info('Discovering org_ids from inventory.hosts...')
+    org_ids = ActiveRecord::Base.connection.select_values('SELECT DISTINCT org_id FROM inventory.hosts')
+    @logger.info("Found #{org_ids.size} org_ids. Starting pagination loop.")
+    org_ids
+  end
+
+  def process_orgs(org_ids)
+    org_ids.lazy.take_while { @total_upserted < @max_upserts }.each do |org_id|
+      process_single_org(org_id)
+    end
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def process_single_org(org_id)
+    org_upserted = 0
+    safe_org_id = ActiveRecord::Base.connection.quote_string(org_id)
+    upsert_count = -1
+
+    while upsert_count != 0 && @total_upserted < @max_upserts
+      result = ActiveRecord::Base.connection.execute(generate_upsert_sql(safe_org_id))
+      upsert_count = result.cmd_tuples
+
+      @total_upserted += upsert_count
+      org_upserted += upsert_count
+
+      if upsert_count.positive?
+        @logger.info("Batch complete: org_id=#{org_id} upserted=#{upsert_count}")
+      else
+        @logger.info("No more rows to backfill for org_id=#{org_id}")
+      end
+    end
+
+    @logger.info("Finished org_id=#{org_id}. Total upserted for org: #{org_upserted}")
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # rubocop:disable Metrics/MethodLength
+  def generate_upsert_sql(safe_org_id)
+    <<-SQL
+      WITH batch AS (
+        SELECT h.id, h.account, h.org_id, h.display_name, h.tags, h.updated,
+               h.created, h.stale_timestamp, h.system_profile, h.groups,
+               h.insights_id
+        FROM inventory.hosts h
+        LEFT JOIN systems s ON h.id = s.id
+        WHERE h.org_id = '#{safe_org_id}'
+          AND (s.id IS NULL OR h.updated > s.updated)
+        LIMIT #{@batch_size}
+      )
+      INSERT INTO systems (
+        id, account, org_id, display_name, tags, updated,
+        created, stale_timestamp, system_profile, groups,
+        insights_id, deleted_at
+      )
+      SELECT
+        id, account, org_id, display_name, tags, updated,
+        created, stale_timestamp, system_profile, groups,
+        insights_id, NULL
+      FROM batch
+      ON CONFLICT (id) DO UPDATE SET
+        account = EXCLUDED.account,
+        org_id = EXCLUDED.org_id,
+        display_name = EXCLUDED.display_name,
+        tags = EXCLUDED.tags,
+        updated = EXCLUDED.updated,
+        created = EXCLUDED.created,
+        stale_timestamp = EXCLUDED.stale_timestamp,
+        system_profile = EXCLUDED.system_profile,
+        groups = EXCLUDED.groups,
+        insights_id = EXCLUDED.insights_id,
+        deleted_at = EXCLUDED.deleted_at
+      WHERE systems.updated < EXCLUDED.updated;
+    SQL
+  end
+  # rubocop:enable Metrics/MethodLength
+end
+
+namespace :systems do
+  desc 'Bulk backfill data from inventory.hosts to the new systems table'
+  task backfill: :environment do
+    batch_size = ENV.fetch('BATCH_SIZE', 1000).to_i
+    max_upserts = ENV.fetch('MAX_ROWS_PER_RUN', 50_000).to_i
+
+    logger = Logger.new($stdout)
+    logger.info("systems:backfill started. BATCH_SIZE=#{batch_size} MAX_ROWS_PER_RUN=#{max_upserts}")
+
+    SystemsBackfiller.new(batch_size: batch_size, max_upserts: max_upserts, logger: logger).run
+  end
+end

--- a/spec/lib/tasks/systems_backfill_rake_spec.rb
+++ b/spec/lib/tasks/systems_backfill_rake_spec.rb
@@ -125,11 +125,13 @@ RSpec.describe 'systems:backfill', type: :task do
 
           count_after = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
           expect(count_after).to eq(5)
-          
+
           # Verify counts per org
-          org1_count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM systems WHERE org_id = '#{org_id}'").to_i
-          org2_count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM systems WHERE org_id = '#{org_2}'").to_i
-          
+          org1_count = ActiveRecord::Base.connection
+                                         .select_value("SELECT COUNT(*) FROM systems WHERE org_id = '#{org_id}'").to_i
+          org2_count = ActiveRecord::Base.connection
+                                         .select_value("SELECT COUNT(*) FROM systems WHERE org_id = '#{org_2}'").to_i
+
           expect(org1_count).to eq(3)
           expect(org2_count).to eq(2)
         ensure

--- a/spec/lib/tasks/systems_backfill_rake_spec.rb
+++ b/spec/lib/tasks/systems_backfill_rake_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'systems:backfill', type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:org_id) { '12345' }
+  let(:account) { Account.find_or_create_by(org_id: org_id) }
+
+  describe 'missing systems from new table' do
+    let!(:missing_system) { FactoryBot.create(:system, account: account) }
+
+    it 'inserts missing systems' do
+      count_before = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
+      expect(count_before).to eq(0)
+
+      Rake::Task['systems:backfill'].execute
+
+      count_after = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
+      expect(count_after).to eq(1)
+    end
+  end
+
+  describe 'conflict resolution' do
+    let(:host_id) { SecureRandom.uuid }
+
+    context 'updates systems if inventory.hosts is newer' do
+      let(:new_name) { Faker::Lorem.word }
+      let!(:newer_system) { FactoryBot.create(:system, id: host_id, display_name: new_name, account: account) }
+
+      it 'updates systems if inventory.hosts is newer' do
+        # Create stale record in `systems`
+        ActiveRecord::Base.connection.execute(<<-SQL)
+          INSERT INTO systems (id, org_id, display_name, tags, updated, created, stale_timestamp, system_profile)
+          VALUES ('#{host_id}', '#{org_id}', '#{Faker::Lorem.word}', '{}', '#{2.days.ago.iso8601}', '#{2.days.ago.iso8601}', '#{2.days.ago.iso8601}', '{}')
+        SQL
+
+        Rake::Task['systems:backfill'].execute
+
+        name = ActiveRecord::Base.connection.select_value("SELECT display_name FROM systems WHERE id = '#{host_id}'")
+        expect(name).to eq(new_name)
+      end
+    end
+
+    context 'skips update if systems is equal or newer' do
+      let(:live_name) { Faker::Lorem.word }
+      let!(:stale_system) { FactoryBot.create(:system, id: host_id, account: account, updated: 2.days.ago) }
+
+      it 'skips update if systems is equal or newer' do
+        # Create fresh record in `systems`
+        ActiveRecord::Base.connection.execute(<<-SQL)
+          INSERT INTO systems (id, org_id, display_name, tags, updated, created, stale_timestamp, system_profile)
+          VALUES ('#{host_id}', '#{org_id}', '#{live_name}', '{}', '#{1.day.ago.iso8601}', '#{2.days.ago.iso8601}', '#{2.days.ago.iso8601}', '{}')
+        SQL
+
+        Rake::Task['systems:backfill'].execute
+
+        name = ActiveRecord::Base.connection.select_value("SELECT display_name FROM systems WHERE id = '#{host_id}'")
+        expect(name).to eq(live_name) # Ignored the backfill
+      end
+    end
+  end
+
+  describe 'batching and limits' do
+    context 'respects MAX_ROWS_PER_RUN' do
+      let!(:systems) { FactoryBot.create_list(:system, 2, account: account) }
+
+      it 'respects MAX_ROWS_PER_RUN' do
+        begin
+          ENV['MAX_ROWS_PER_RUN'] = '1'
+          ENV['BATCH_SIZE'] = '1'
+
+          Rake::Task['systems:backfill'].execute
+
+          count = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
+          expect(count).to eq(1)
+        ensure
+          ENV.delete('MAX_ROWS_PER_RUN')
+          ENV.delete('BATCH_SIZE')
+        end
+      end
+    end
+
+    context 'processes multiple batches correctly' do
+      let!(:systems) { FactoryBot.create_list(:system, 5, account: account) }
+
+      it 'processes multiple batches correctly' do
+        begin
+          ENV['MAX_ROWS_PER_RUN'] = '100'
+          ENV['BATCH_SIZE'] = '2'
+
+          count_before = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
+          expect(count_before).to eq(0)
+
+          Rake::Task['systems:backfill'].execute
+
+          count_after = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
+          expect(count_after).to eq(5)
+        ensure
+          ENV.delete('MAX_ROWS_PER_RUN')
+          ENV.delete('BATCH_SIZE')
+        end
+      end
+    end
+
+    context 'processes multiple accounts (organizations)' do
+      let(:org_2) { '67890' }
+      let(:account_2) { Account.find_or_create_by(org_id: org_2) }
+      let!(:org_1_systems) { FactoryBot.create_list(:system, 3, account: account) }
+      let!(:org_2_systems) { FactoryBot.create_list(:system, 2, account: account_2) }
+
+      it 'processes multiple accounts' do
+        begin
+          ENV['MAX_ROWS_PER_RUN'] = '100'
+          ENV['BATCH_SIZE'] = '10'
+
+          count_before = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
+          expect(count_before).to eq(0)
+
+          Rake::Task['systems:backfill'].execute
+
+          count_after = ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM systems').to_i
+          expect(count_after).to eq(5)
+          
+          # Verify counts per org
+          org1_count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM systems WHERE org_id = '#{org_id}'").to_i
+          org2_count = ActiveRecord::Base.connection.select_value("SELECT COUNT(*) FROM systems WHERE org_id = '#{org_2}'").to_i
+          
+          expect(org1_count).to eq(3)
+          expect(org2_count).to eq(2)
+        ensure
+          ENV.delete('MAX_ROWS_PER_RUN')
+          ENV.delete('BATCH_SIZE')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
   ## Commit Summary
   • feat(systems): add bulk backfill rake task
   • chore(deploy): add backfill-systems CronJob to clowdapp.yaml

   ## Jira Ticket
   • https://redhat.atlassian.net/browse/RHINENG-26774

   ## Secure Coding Practices Checklist GitHub Link
   • https://github.com/RedHatInsights/secure-coding-checklist

   ## Secure Coding Checklist
   [✓] Input Validation
   [ ] Output Encoding
   [ ] Authentication and Password Management
   [ ] Session Management
   [ ] Access Control
   [ ] Cryptographic Practices
   [✓] Error Handling and Logging
   [ ] Data Protection
   [ ] Communication Security
   [✓] System Configuration
   [✓] Database Security
   [ ] File Management
   [✓] Memory Management
   [✓] General Coding Practices

   ## Overview
   • **Add bulk backfill Rake task for systems table:** new `systems:backfill` task (class `SystemsBackfiller`) migrates records from `inventory.hosts` to `systems` using
 a batched SQL `INSERT...SELECT...LEFT JOIN` with `ON CONFLICT ... WHERE systems.updated < EXCLUDED.updated`. Raw SQL mitigates object allocation overhead, explicitly
 guarding against SQLi via `quote_string`.
   • **Configure automated backfill CronJob:** new `backfill-systems` CronJob entry in `deploy/clowdapp.yaml` to run `bundle exec rake systems:backfill` (configurable
 schedule), with pod spec, init-container, resources, liveness probe, and LOGSTREAM env.
   • **Batch and rate limits configurable via environment:** `BATCH_SIZE` and `MAX_ROWS_PER_RUN` (defaults: 1000 and 50,000) control per-batch size and total upserts per
 run to minimize Ruby memory usage.
   • **Template parameters added:** `BACKFILL_SYSTEMS_SCHEDULE`, `BACKFILL_BATCH_SIZE`, `BACKFILL_MAX_ROWS_PER_RUN`, and `LOGSTREAM_BACKFILL_SYSTEMS`.
   • **Comprehensive Tests:** new RSpec task spec (`spec/lib/tasks/systems_backfill_rake_spec.rb`) covering insert, update, conflict-resolution (skip when systems is
 equal/newer), and limits. Utilizes `FactoryBot` to ensure production-like records during batch and multi-organization test coverage, while maintaining exception-safe ENV
 cleanup.

   ## AI/LLM Usage
   This PR was authored with the assistance of an AI coding agent (Gemini 2.5 Pro via pi/unipi) to scaffold raw SQL batching, test updates, and Clowder config
 modifications. All AI output was reviewed, tested, and modified by the human author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add bulk backfill Rake task (`systems:backfill`) to migrate records from `inventory.hosts` to `systems` table with batched SQL INSERT...SELECT...LEFT JOIN and conflict resolution
- Add `backfill-systems` CronJob to `deploy/clowdapp.yaml` with configurable schedule and pod specifications
- Make batch processing configurable via `BATCH_SIZE` (default: 1000) and `MAX_ROWS_PER_RUN` (default: 50,000) environment variables
- Add template parameters: `BACKFILL_SYSTEMS_SCHEDULE`, `BACKFILL_BATCH_SIZE`, `BACKFILL_MAX_ROWS_PER_RUN`, and `LOGSTREAM_BACKFILL_SYSTEMS`
- Include comprehensive RSpec tests covering insert, update, conflict resolution, limits, and multi-organization scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->