### PR TITLE
chore(localdev): adds `localhost/` prefix to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     image: docker.io/confluentinc/cp-kafka
     platform: linux/amd64
     depends_on:
-      - kafka
+      kafka:
+        condition: service_started
     links:
       - kafka
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
@@ -39,8 +40,10 @@ services:
       - LOGLEVEL=INFO
       - PROMETHEUS_PORT=8001
     depends_on:
-      - kafka
-      - createtopics
+      kafka:
+        condition: service_started
+      createtopics:
+        condition: service_completed_successfully
     links:
       - kafka
   minio:
@@ -101,7 +104,10 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      - kafka
+      kafka:
+        condition: service_started
+      createbuckets:
+        condition: service_completed_successfully
     links:
       - kafka
   db:
@@ -139,12 +145,12 @@ services:
       - BYPASS_BOP_VERIFICATION=True
       - IT_BYPASS_TOKEN_VALIDATION=True
     depends_on:
-      - build-rbac-db
-      - db
-      - redis
-    links:
-      - db
-      - redis
+      build-rbac-db:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     ports:
       - 9002:8080
     volumes:
@@ -281,12 +287,12 @@ services:
     volumes:
       - .:/opt/app-root/src/:z
     depends_on:
-      - db
-      - compliance-ssg
-      - build-rails-db
-    links:
-      - db
-      - compliance-ssg
+      db:
+        condition: service_healthy
+      compliance-ssg:
+        condition: service_started
+      build-rails-db:
+        condition: service_completed_successfully
     environment:
       - POSTGRESQL_TEST_DATABASE=compliance_test
       - RAILS_LOG_TO_STDOUT=true
@@ -322,16 +328,14 @@ services:
     volumes:
       - .:/opt/app-root/src:z
     depends_on:
-      - db
-      - redis
-      - rbac
-      - compliance-ssg
-      - import-ssg
-    links:
-      - db
-      - redis
-      - rbac
-      - compliance-ssg
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      rbac:
+        condition: service_started
+      compliance-ssg:
+        condition: service_started
   inventory-consumer:
     image: localhost/compliance-backend-rails
     platform: linux/amd64
@@ -351,9 +355,12 @@ services:
     volumes:
       - .:/opt/app-root/src:z
     depends_on:
-      - db
-      - rbac
-      - kafka
+      db:
+        condition: service_healthy
+      rbac:
+        condition: service_started
+      kafka:
+        condition: service_started
     links:
       - db
       - rbac
@@ -368,8 +375,10 @@ services:
     volumes:
       - .:/opt/app-root/src:z
     depends_on:
-      - redis
-      - rbac
+      redis:
+        condition: service_started
+      rbac:
+        condition: service_started
     links:
       - redis
       - rbac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     depends_on:
       kafka:
         condition: service_started
-    links:
-      - kafka
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
                        sleep 10 && \
                        kafka-topics --create --if-not-exists --topic platform.upload.announce --bootstrap-server kafka:29092 && \
@@ -44,8 +42,6 @@ services:
         condition: service_started
       createtopics:
         condition: service_completed_successfully
-    links:
-      - kafka
   minio:
     image: docker.io/minio/minio
     platform: linux/amd64
@@ -67,8 +63,6 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    links:
-      - minio
     entrypoint: /bin/sh
     command: -c '
       /usr/bin/mc alias set myminio http://minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD >/dev/null;
@@ -108,8 +102,6 @@ services:
         condition: service_started
       createbuckets:
         condition: service_completed_successfully
-    links:
-      - kafka
   db:
     image: docker.io/library/postgres:16-alpine
     platform: linux/amd64
@@ -176,9 +168,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    links:
-      - db
-      - redis
     volumes:
       - ./config/devel/rbac/definitions:/opt/rbac/rbac/management/role/definitions
       - ./config/devel/rbac/permissions:/opt/rbac/rbac/management/role/permissions
@@ -211,8 +200,6 @@ services:
     depends_on:
       inventory-migrator:
         condition: service_completed_successfully
-    links:
-      - inventory-migrator
     restart: on-failure
   inventory-web:
     image: quay.io/cloudservices/insights-inventory:latest
@@ -232,8 +219,6 @@ services:
     depends_on:
       inventory-migrator:
         condition: service_completed_successfully
-    links:
-      - inventory-migrator
   compliance-ssg:
     image: quay.io/cloudservices/compliance-ssg
     platform: linux/amd64
@@ -270,8 +255,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    links:
-      - db
     environment:
       - POSTGRESQL_TEST_DATABASE=compliance_test
       - ACG_CONFIG=/opt/app-root/src/devel.json
@@ -361,10 +344,6 @@ services:
         condition: service_started
       kafka:
         condition: service_started
-    links:
-      - db
-      - rbac
-      - kafka
   sidekiq:
     image: localhost/compliance-backend-rails
     platform: linux/amd64
@@ -379,9 +358,6 @@ services:
         condition: service_started
       rbac:
         condition: service_started
-    links:
-      - redis
-      - rbac
     command: bundle exec sidekiq
     environment:
       - MALLOC_ARENA_MAX=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,7 @@ services:
   # Feel free to comment them out for subsequent use
   #
   build-rails-db:
-    image: compliance-backend-rails
+    image: localhost/compliance-backend-rails
     platform: linux/amd64
     entrypoint: ''
     command: sh -c '
@@ -270,7 +270,7 @@ services:
       - POSTGRESQL_TEST_DATABASE=compliance_test
       - ACG_CONFIG=/opt/app-root/src/devel.json
   import-ssg:
-    image: compliance-backend-rails
+    image: localhost/compliance-backend-rails
     platform: linux/amd64
     entrypoint: ''
     command: 'bundle exec rake ssg:import_rhel_supported'
@@ -301,7 +301,7 @@ services:
       args:
         - prod=false
         - extras=$EXTRA_PACKAGES
-    image: compliance-backend-rails
+    image: localhost/compliance-backend-rails
     entrypoint: '/opt/app-root/src/devel.entrypoint.sh'
     command: 'bundle exec rails s -b 0.0.0.0'
     tty: true
@@ -333,7 +333,7 @@ services:
       - rbac
       - compliance-ssg
   inventory-consumer:
-    image: compliance-backend-rails
+    image: localhost/compliance-backend-rails
     platform: linux/amd64
     restart: on-failure
     entrypoint: ''
@@ -359,7 +359,7 @@ services:
       - rbac
       - kafka
   sidekiq:
-    image: compliance-backend-rails
+    image: localhost/compliance-backend-rails
     platform: linux/amd64
     restart: on-failure
     tmpfs:


### PR DESCRIPTION
This way it will work with podman compose.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [x] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updates localdev `docker-compose.yml` to prefix Rails image references with `localhost/` (podman-compose compatibility)
- Replaces legacy service `links` with condition-based `depends_on` to enforce correct startup/readiness order
- Adds readiness/completion gating for Kafka topic bootstrap (`createtopics`) and downstream services (`puptoo`, `ingress`)
- Gates MinIO bucket initialization (`createbuckets`) on MinIO health before dependent services start
- Updates RBAC and inventory startup wiring so Rails-side services wait for required DB/Redis/RBAC/Kafka prerequisites (including `inventory-migrator` completion)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->