### PR TITLE
fix(CI): use ephemeral deployer script for Kessel deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,37 +59,27 @@ pipeline {
                         curl -s ${CICD_URL}/bootstrap.sh > .cicd_bootstrap.sh
                         source ./.cicd_bootstrap.sh
 
-                        COMPLIANCE_SHA=$(git rev-parse HEAD | cut -f1)
-                        COMPLIANCE_SHORT_SHA=${COMPLIANCE_SHA:0:7}
-
                         RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
                         RBAC_SHORT_SHA=${RBAC_SHA:0:7}
 
-                        NAMESPACE=$(bonfire namespace reserve --duration 1h)
-                        oc project $NAMESPACE
+                        export APP_NAME="host-inventory kessel rbac compliance"
+                        export IMAGE_TAG="${GIT_COMMIT:0:7}"
+                        export OPTIONAL_DEPS_METHOD="all"
+                        export EXTRA_DEPLOY_ARGS="
+                            --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA}
+                            --set-template-ref rbac=${RBAC_SHA}
+                            -p rbac/NOTIFICATIONS_RH_ENABLED=False
+                            -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST=approval
+                            -p rbac/ROLE_CREATE_ALLOW_LIST=remediations,inventory,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc
+                            -p rbac/REPLICATION_TO_RELATION_ENABLED=True
+                            -p rbac/PARITY_CHECK_INTERVAL_SECONDS=300
+                            -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s
+                            -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0
+                            -p host-inventory/BYPASS_RBAC=false
+                            -p host-inventory/BYPASS_KESSEL=false
+                        "
+                        source "${CICD_ROOT}/deploy_ephemeral_env.sh"
 
-                        bonfire deploy host-inventory kessel rbac compliance \
-                            --source appsre \
-                            --ref-env insights-production \
-                            --timeout 900 \
-                            --optional-deps-method all \
-                            --frontends false \
-                            --set-image-tag quay.io/cloudservices/compliance-backend=${COMPLIANCE_SHORT_SHA} \
-                            --set-template-ref compliance=${COMPLIANCE_SHA} \
-                            --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA} \
-                            --set-template-ref rbac=${RBAC_SHA} \
-                            -p rbac/NOTIFICATIONS_RH_ENABLED=False \
-                            -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST="approval" \
-                            -p rbac/ROLE_CREATE_ALLOW_LIST="remediations,inventory,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc" \
-                            -p rbac/REPLICATION_TO_RELATION_ENABLED=True \
-                            -p rbac/PARITY_CHECK_INTERVAL_SECONDS=300 \
-                            -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s \
-                            -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0 \
-                            -p host-inventory/BYPASS_RBAC=false \
-                            -p host-inventory/BYPASS_KESSEL=false \
-                            -n $NAMESPACE
-
-                        export NAMESPACE
                         source "${CICD_ROOT}/cji_smoke_test.sh"
 
                         # Update IQE plugin config to run floorist plugin tests.


### PR DESCRIPTION
**Fix ephemeral namespace not released after QE smoke tests**

- The Kessel deploy stage was manually reserving a namespace and running `bonfire deploy` inline, bypassing `deploy_ephemeral_env.sh` — which means `_common_deploy_logic.sh` was never sourced and its `teardown` trap (`trap teardown EXIT ERR SIGINT SIGTERM`) was never registered, leaving the ephemeral namespace alive after the job finished
- Replace the inline namespace reservation + `bonfire deploy` block with `deploy_ephemeral_env.sh`, which handles both deployment and guaranteed namespace cleanup on exit (pass or fail)
- All Kessel-specific deploy arguments are expressed through the script's supported env vars:
  - `APP_NAME` — deploys the full Kessel stack (`host-inventory kessel rbac compliance`)
  - `IMAGE` / `IMAGE_TAG` — compliance-backend image (pipeline env + short SHA override)
  - `COMPONENT_NAME` — drives `--set-template-ref compliance=<sha>` via `_common_deploy_logic.sh`
  - `OPTIONAL_DEPS_METHOD=all`
  - `EXTRA_DEPLOY_ARGS` — carries the RBAC image/template refs and all `-p` params for rbac, kessel-relations, and host-inventory
  
[RHINENG-26954](https://redhat.atlassian.net/browse/RHINENG-26954)

[RHINENG-26954]: https://redhat.atlassian.net/browse/RHINENG-26954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ