### PR TITLE
refactor(ReportParsing): eliminate double download and validate in consumer

### DIFF
--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -4,8 +4,10 @@
 class ParseReportJob < ApplicationJob
   include Notifications
 
+  self.log_arguments = false
+
   # https://github.com/RoamingNoMaD/yabeda-activejob#custom-tags
-  def yabeda_tags(_idx, message)
+  def yabeda_tags(_report_blob, message)
     { qe: OpenshiftEnvironment.qe_account?(message['org_id']) }
   end
 
@@ -14,7 +16,7 @@ class ParseReportJob < ApplicationJob
     provider_job_id || job_id
   end
 
-  def perform(idx, message)
+  def perform(report_blob, message)
     return if cancelled?
 
     @msg_value = message
@@ -23,7 +25,8 @@ class ParseReportJob < ApplicationJob
       "system #{@msg_value['id']}"
     )
 
-    @file = retrieve_file(idx)
+    @file = resolve_report(report_blob)
+    return unless @file
 
     parse_and_save_report
   end
@@ -38,18 +41,22 @@ class ParseReportJob < ApplicationJob
 
   private
 
-  def retrieve_file(idx)
-    @file = SafeDownloader.download_reports(
-      @msg_value['url'],
-      ssl_only: Settings.report_download_ssl_only
-    )[idx]
-  rescue SafeDownloader::DownloadError => e
+  def resolve_report(report_blob)
+    if report_blob.is_a?(Integer)
+      SafeDownloader.download_reports(
+        @msg_value['url'], ssl_only: Settings.report_download_ssl_only
+      )[report_blob]
+    else
+      ReportArtifact.unpack(report_blob)
+    end
+  rescue ArgumentError, NoMethodError, Zlib::GzipFile::Error, SafeDownloader::DownloadError => e
     handle_error(e)
+    nil
   end
 
   def parse_and_save_report
     notify_payload_tracker(:processing, "Job #{jid} is now processing")
-    compliance_notification_wrapper { parser.save_all }
+    compliance_notification_wrapper { parser.persist! }
     notify_remediation
     audit_success
     notify_payload_tracker(:success, "Job #{jid} has completed successfully")

--- a/app/services/kafka/report_parser.rb
+++ b/app/services/kafka/report_parser.rb
@@ -13,30 +13,35 @@ module Kafka
       @logger = logger
     end
 
-    # rubocop:disable Metrics/MethodLength
     def parse_reports
-      # Map successfuly parsed (validated) reports by scanned profile
-      parsed_reports = downloaded_reports.map do |xml|
-        [parse(xml).test_result_file.test_result.profile_id, xml]
-      end
-      # Evaluate each report individually and notify about the result
-      parsed_reports.each_with_index do |(profile_id, _report), idx|
-        job = enqueue_parsing(profile_id, idx)
-        notify_report_success(profile_id, job.jid)
-      end
-      produce_validation_message('success')
+      @enqueued = []
+      @failed = false
+      downloaded_reports.each { |xml| validate_and_enqueue(xml) }
+      notify_enqueued_reports
+      produce_validation_message('success') unless @failed
     rescue EntitlementError, ReportParseError => e
       parse_error(e)
     rescue SafeDownloader::DownloadError => e
       parse_error(e)
       raise
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 
-    def enqueue_parsing(profile_id, idx)
-      ParseReportJob.perform_later(idx, metadata) or
+    def validate_and_enqueue(xml)
+      parser = XccdfReportParser.new(xml, metadata)
+      parser.validate!
+      profile_id = parser.test_result_file.test_result.profile_id
+      job = enqueue_parsing(profile_id, xml)
+      @enqueued << "#{profile_id}:#{job.jid}"
+      notify_payload_tracker(:received, "File of #{profile_id} is valid. Job #{job.jid} enqueued")
+    rescue *XccdfReportParser::ERRORS => e
+      @failed = true
+      parse_error(e, notify_tracker: true)
+    end
+
+    def enqueue_parsing(profile_id, xml)
+      ParseReportJob.perform_later(ReportArtifact.pack(xml), metadata) or
         raise ReportParseError, "Failed to enqueue parsing of #{profile_id}"
     end
 
@@ -47,10 +52,11 @@ module Kafka
       reports
     end
 
-    def notify_report_success(profile_id, job)
-      msg = "Enqueued report parsing of #{profile_id} from request #{request_id} as a job #{job}"
+    def notify_enqueued_reports
+      return if @enqueued.empty?
+
+      msg = "Enqueued #{@enqueued.size} report(s) from request #{request_id}: #{@enqueued.join(', ')}"
       @logger.audit_success("[#{org_id}] #{msg}")
-      notify_payload_tracker(:received, "File of #{profile_id} is valid. Job #{job} enqueued")
     end
 
     def notify_payload_tracker(status, status_msg = '')
@@ -73,7 +79,6 @@ module Kafka
       (@message.dig('platform_metadata', 'metadata') || {}).merge(
         'id' => id,
         'b64_identity' => b64_identity,
-        'url' => url,
         'request_id' => request_id,
         'org_id' => org_id
       )
@@ -103,14 +108,6 @@ module Kafka
       @message.dig('platform_metadata', 'url')
     end
 
-    def parse(xml)
-      XccdfReportParser.new(xml, metadata)
-    rescue PG::Error, ActiveRecord::StatementInvalid => e
-      parse_error(e)
-    rescue StandardError
-      raise ReportParseError, 'Report parsing failed'
-    end
-
     def produce_validation_message(result)
       return if Settings.kafka.topics.upload_compliance.blank?
 
@@ -121,17 +118,15 @@ module Kafka
       )
     end
 
-    def parse_error(exception)
+    def parse_error(exception, notify_tracker: false)
       msg = "[#{org_id}] #{exception_message(exception)}"
-      @logger.error msg
-      @logger.audit_fail msg
-
+      @logger.error(msg)
+      @logger.audit_fail(msg)
       ReportUploadFailed.deliver(
         system: V2::System.find_by(id: id, org_id: org_id),
-        request_id: request_id,
-        error: exception_message(exception),
-        org_id: org_id
+        request_id: request_id, error: exception_message(exception), org_id: org_id
       )
+      notify_payload_tracker(:error, msg) if notify_tracker
       produce_validation_message('failure')
     end
 
@@ -144,7 +139,7 @@ module Kafka
       when 'Kafka::ReportParser::ReportParseError'
         "Invalid report: #{exception.message}"
       else
-        "Error parsing report: #{request_id} - #{exception.message}"
+        "Error parsing report: #{request_id} - #{exception.class.to_s.demodulize}"
       end
     end
   end

--- a/app/services/report_artifact.rb
+++ b/app/services/report_artifact.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Packs/unpacks a report XML so it can travel as a background-job argument
+# instead of being re-downloaded by the job (eliminating the double download).
+#
+# * gzip  -> XCCDF compresses ~10-20x, keeping the job argument small
+# * base64 -> keeps the payload a JSON-safe ASCII string for the job backend
+#             (Redis today, PostgreSQL once we move to GoodJob — RHINENG-24397)
+module ReportArtifact
+  module_function
+
+  def pack(xml)
+    Base64.strict_encode64(ActiveSupport::Gzip.compress(xml))
+  end
+
+  def unpack(blob)
+    ActiveSupport::Gzip.decompress(Base64.strict_decode64(blob))
+  end
+end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -125,11 +125,13 @@ class XccdfReportParser
     check_for_missing_rules
   end
 
-  def save_all
+  def validate!
     check_os_version
     check_for_external_reports
     check_for_missing_benchmark_info
+  end
 
+  def persist!
     V2::System.transaction do
       save_all_test_result_info
     end

--- a/spec/jobs/parse_report_job_spec.rb
+++ b/spec/jobs/parse_report_job_spec.rb
@@ -26,11 +26,9 @@ describe ParseReportJob, type: :job do
     double(:test_result_file, test_result: double(:test_result, profile_id: profile_ref_id))
   end
   let(:sidekiq_logger) { instance_double(Logger, error: nil, info: nil) }
+  let(:report_blob) { ReportArtifact.pack('<xml/>') }
 
   before do
-    allow(SafeDownloader).to receive(:download_reports)
-      .with('', ssl_only: Settings.report_download_ssl_only)
-      .and_return([Faker::Lorem.word])
     allow(Sidekiq).to receive(:redis).and_return(false)
     allow(job).to receive(:jid).and_return('1')
     allow(Sidekiq).to receive(:logger).and_return(sidekiq_logger)
@@ -50,7 +48,7 @@ describe ParseReportJob, type: :job do
   describe '#perform' do
     context 'when parsing succeeds' do
       before do
-        allow(parser).to receive(:save_all)
+        allow(parser).to receive(:persist!)
         allow(job).to receive(:remediation_issue_ids).and_return([issue_id])
         allow(PayloadTracker).to receive(:deliver)
         allow(RemediationUpdates).to receive(:deliver)
@@ -68,7 +66,7 @@ describe ParseReportJob, type: :job do
           status_msg: 'Job 1 has completed successfully', org_id: user.org_id
         )
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
 
       it 'audits the successful report' do
@@ -78,7 +76,7 @@ describe ParseReportJob, type: :job do
           )
         )
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
 
       it 'notifies the remediation service with failed issue ids' do
@@ -87,13 +85,13 @@ describe ParseReportJob, type: :job do
           issue_ids: [issue_id]
         )
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
     end
 
     context 'when parsing fails with a known XccdfReportParser error' do
       before do
-        allow(parser).to receive(:save_all).and_raise(
+        allow(parser).to receive(:persist!).and_raise(
           XccdfReportParser::WrongFormatError, 'Wrong format or benchmark'
         )
         allow(PayloadTracker).to receive(:deliver)
@@ -114,7 +112,7 @@ describe ParseReportJob, type: :job do
           ), org_id: user.org_id
         )
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
 
       it 'audits the failure' do
@@ -122,7 +120,7 @@ describe ParseReportJob, type: :job do
           a_string_matching(/\[#{user.org_id}\] Failed to parse report #{profile_ref_id} from system #{system.id}/)
         )
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
 
       context 'when the system is found' do
@@ -136,7 +134,7 @@ describe ParseReportJob, type: :job do
             org_id: user.org_id
           )
 
-          job.perform(0, msg_value)
+          job.perform(report_blob, msg_value)
         end
       end
 
@@ -154,7 +152,7 @@ describe ParseReportJob, type: :job do
             org_id: user.org_id
           )
 
-          job.perform(0, msg_value)
+          job.perform(report_blob, msg_value)
         end
       end
     end
@@ -171,6 +169,30 @@ describe ParseReportJob, type: :job do
           a_string_matching(/\[#{user.org_id}\] Failed to parse report\s+from system #{system.id}/)
         )
 
+        job.perform(report_blob, msg_value)
+      end
+    end
+
+    context 'with a legacy report_blob' do
+      let(:xml) { '<xml/>' }
+      let(:legacy_url) { 'https://example.com/report.tar' }
+      let(:msg_value) { super().merge('url' => legacy_url) }
+
+      before do
+        allow(SafeDownloader).to receive(:download_reports)
+          .with(legacy_url, ssl_only: Settings.report_download_ssl_only)
+          .and_return([xml])
+        allow(parser).to receive(:persist!)
+        allow(job).to receive(:remediation_issue_ids).and_return([])
+        allow(PayloadTracker).to receive(:deliver)
+        allow(RemediationUpdates).to receive(:deliver)
+      end
+
+      it 'falls back to downloading by index' do
+        expect(XccdfReportParser).to receive(:new).with(xml, msg_value).and_return(parser)
+        expect(parser).to receive(:persist!)
+        expect(Rails.logger).to receive(:audit_success)
+
         job.perform(0, msg_value)
       end
     end
@@ -178,7 +200,7 @@ describe ParseReportJob, type: :job do
 
   describe 'non-compliance notifications' do
     before do
-      allow(parser).to receive(:save_all)
+      allow(parser).to receive(:persist!)
       allow(parser).to receive(:score).and_return(70) # below threshold of 80
       allow(job).to receive(:notify_payload_tracker)
       allow(job).to receive(:notify_remediation)
@@ -189,7 +211,7 @@ describe ParseReportJob, type: :job do
       it 'emits a non-compliance notification' do
         expect(SystemNonCompliant).to receive(:deliver)
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
     end
 
@@ -201,7 +223,7 @@ describe ParseReportJob, type: :job do
       it 'emits a non-compliance notification' do
         expect(SystemNonCompliant).to receive(:deliver)
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
     end
 
@@ -211,7 +233,7 @@ describe ParseReportJob, type: :job do
       it 'does not emit a non-compliance notification' do
         expect(SystemNonCompliant).not_to receive(:deliver)
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
     end
 
@@ -223,7 +245,7 @@ describe ParseReportJob, type: :job do
       it 'does not emit a non-compliance notification' do
         expect(SystemNonCompliant).not_to receive(:deliver)
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
     end
 
@@ -237,7 +259,7 @@ describe ParseReportJob, type: :job do
       it 'does not emit a non-compliance notification' do
         expect(SystemNonCompliant).not_to receive(:deliver)
 
-        job.perform(0, msg_value)
+        job.perform(report_blob, msg_value)
       end
     end
   end

--- a/spec/services/kafka/report_parser_spec.rb
+++ b/spec/services/kafka/report_parser_spec.rb
@@ -106,7 +106,7 @@ describe Kafka::ReportParser do
       expect(Karafka.logger)
         .to receive(:audit_fail)
         .with(
-          "[#{org_id}] Invalid report: Report parsing failed"
+          "[#{org_id}] Error parsing report: #{request_id} - WrongFormatError"
         )
       service.parse_reports
       expect(enqueued_jobs.size).to eq(0)
@@ -114,26 +114,38 @@ describe Kafka::ReportParser do
   end
 
   context 'with valid reports' do
+    let(:profile_id) { 'xccdf_org.ssgproject.content_profile_standard' }
+    let(:xml) { file_fixture('xccdf_report.xml').read }
+    let(:parser) do
+      instance_double(
+        XccdfReportParser,
+        validate!: nil,
+        test_result_file: double(test_result: double(profile_id: profile_id))
+      )
+    end
+
     before do
       allow(SafeDownloader).to receive(:download_reports)
         .with(nil, ssl_only: Settings.report_download_ssl_only)
-        .and_return([file_fixture('xccdf_report.xml').read])
+        .and_return([xml])
+      allow(XccdfReportParser).to receive(:new).and_return(parser)
     end
 
-    let(:profile_id) { 'xccdf_org.ssgproject.content_profile_standard' }
+    it 'validates each report and enqueues it as a packed payload' do
+      expect(parser).to receive(:validate!).once
 
-    it 'enqueues report parsing job' do
       expect(Karafka.logger)
         .to receive(:audit_success)
         .with(
           a_string_matching(
-            /\A\[#{org_id}\] Enqueued report parsing of #{profile_id} from request #{request_id} as a job \S+\z/
+            /\A\[#{org_id}\] Enqueued 1 report\(s\) from request #{request_id}: #{profile_id}:\S+\z/
           )
         )
 
       service.parse_reports
 
       expect(enqueued_jobs.size).to eq(1)
+      expect(ReportArtifact.unpack(enqueued_jobs.first[:args].first)).to eq(xml)
     end
   end
 end

--- a/spec/services/report_artifact_spec.rb
+++ b/spec/services/report_artifact_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ReportArtifact do
+  let(:xml) do
+    Array.new(200) do
+      %(<xml><TestResult id="#{Faker::Alphanumeric.alphanumeric(number: 8)}"/></xml>)
+    end.join
+  end
+
+  it 'round-trips the report through pack/unpack' do
+    expect(described_class.unpack(described_class.pack(xml))).to eq(xml)
+  end
+
+  it 'packs to a JSON/ASCII-safe payload (so it is a safe job argument)' do
+    expect(described_class.pack(xml)).to match(%r{\A[A-Za-z0-9+/=]+\z})
+  end
+
+  it 'compresses the payload well below the raw report size' do
+    expect(described_class.pack(xml).bytesize).to be < xml.bytesize
+  end
+end

--- a/spec/services/xccdf_report_parser_spec.rb
+++ b/spec/services/xccdf_report_parser_spec.rb
@@ -99,15 +99,14 @@ RSpec.describe XccdfReportParser do
     end
   end
 
-  describe '#save_all' do
-    context 'when a validation check raises' do
+  describe '#validate!' do
+    context 'when a validation check fails' do
       let(:system) { create(:system, account: user.account, os_major_version: unsupported_os_major_version) }
 
-      it 'aborts before saving the test result info' do
+      it 'raises and does not persist anything' do
         allow(parser).to receive(:save_all_test_result_info)
-        allow(V2::System).to receive(:transaction).and_yield
 
-        expect { parser.save_all }.to raise_error(described_class::OSVersionMismatch)
+        expect { parser.validate! }.to raise_error(described_class::OSVersionMismatch)
         expect(parser).not_to have_received(:save_all_test_result_info)
       end
     end
@@ -117,19 +116,29 @@ RSpec.describe XccdfReportParser do
         allow(parser).to receive(:check_os_version)
         allow(parser).to receive(:check_for_external_reports)
         allow(parser).to receive(:check_for_missing_benchmark_info)
-        allow(parser).to receive(:save_all_test_result_info)
-        allow(V2::System).to receive(:transaction).and_yield
       end
 
-      it 'runs all validation checks and saves the test result info inside a transaction' do
-        parser.save_all
+      it 'runs all validation checks' do
+        parser.validate!
 
         expect(parser).to have_received(:check_os_version)
         expect(parser).to have_received(:check_for_external_reports)
         expect(parser).to have_received(:check_for_missing_benchmark_info)
-        expect(V2::System).to have_received(:transaction)
-        expect(parser).to have_received(:save_all_test_result_info)
       end
+    end
+  end
+
+  describe '#persist!' do
+    before do
+      allow(parser).to receive(:save_all_test_result_info)
+      allow(V2::System).to receive(:transaction).and_yield
+    end
+
+    it 'saves the test result info inside a transaction' do
+      parser.persist!
+
+      expect(V2::System).to have_received(:transaction)
+      expect(parser).to have_received(:save_all_test_result_info)
     end
   end
 end


### PR DESCRIPTION
RHINENG-18501. Builds on the merged #2705 (V2 models) + DB remodel. Scoped to the ParseReport simplification the ticket calls for — "services calling services… most validation should happen in the Kafka consumer, not during parsing."

## What

- **Eliminate the double download.** The consumer validates each report and hands it to the job as a packed payload (`ReportArtifact` — gzip + base64) instead of the job re-downloading the same artifact. Compression keeps the job argument small and JSON-safe.
- **Split `XccdfReportParser#save_all` into `validate!` and `persist!`.** `validate!` runs in the Kafka consumer, so invalid reports are rejected before a job is enqueued; `persist!` runs in the job and only writes. The validation logic itself (OS version, external, benchmark/profile/rules) is unchanged — just relocated.
- **Specs** updated for the new interface (`perform(report_blob, …)`, `parser.persist!`, consumer enqueues a packed payload) plus a `ReportArtifact` unit spec.

## Out of scope / follow-ups

The SSG-version `mismatched` flag and the deterministic-lookup tweak are intentionally not here. Most of the SSG-mismatch correctness — correct-tailoring attribution, dropping unattributable rules, the nil-tailoring guard, real deletion of superseded results — already landed on master via #2705's follow-ups. The remaining piece is the customer-facing `mismatched` signal (RHINENG-26234), which is FE-coupled and worth confirming scope on first.

> Draft: opened for early review — CI is the first full test run on this branch.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Refactored Kafka report parsing to validate each downloaded XML in the consumer and enqueue a job with a packed, gzip+base64 `ReportArtifact` payload (removes the double-download path).
- Split `XccdfReportParser` into `validate!` (runs unchanged validation checks) and `persist!` (does persistence only, wrapping `save_all_test_result_info` in a transaction).
- Updated `ParseReportJob` to accept `report_blob`, unpack it to recover the XML, and call `persist!` (replacing `save_all` / removed download-by-index logic).
- Reworked `Kafka::ReportParser#parse_reports` to enqueue per report using `profile_id`, issue per-report failure validation on `XccdfReportParser::ERRORS`, and send a batched success audit via `notify_enqueued_reports`.
- Updated specs: added `ReportArtifact` pack/unpack unit tests and adjusted consumer/job/parser specs to assert the new payload/enqueue flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->