### PR TITLE
fix(db): remove unique constraint on systems.insights_id

### DIFF
--- a/db/migrate/20260615170354_remove_unique_constraint_from_systems_insights_id.rb
+++ b/db/migrate/20260615170354_remove_unique_constraint_from_systems_insights_id.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueConstraintFromSystemsInsightsId < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :systems, :insights_id, unique: true
+    add_index :systems, :insights_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_090600) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_170354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -293,7 +293,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_090600) do
     t.jsonb "system_profile", default: {}, null: false
     t.jsonb "tags", default: {}, null: false
     t.datetime "updated", null: false
-    t.index ["insights_id"], name: "index_systems_on_insights_id", unique: true
+    t.index ["insights_id"], name: "index_systems_on_insights_id"
   end
 
   create_table "tailoring_rules_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
The `systems` table was created with a unique index on `insights_id`.
However, the source of truth (`inventory.hosts`) does not enforce
uniqueness on `insights_id` and contains duplicate values across
different primary key `id`s.

This caused the `systems:backfill` rake task to crash with
`PG::UniqueViolation` when inserting records via `ON CONFLICT (id) DO UPDATE`,
as Postgres would reject the insert upon hitting the secondary unique index.

By making the `insights_id` index non-unique, the `systems` table schema
now correctly mirrors the behavior of `inventory.hosts`, allowing the
bulk backfill job to complete successfully.

Relates to: RHINENG-26774

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [x] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add Rails migration to drop the unique index on `systems.insights_id` and recreate it as a non-unique index to match upstream `inventory.hosts` behavior (duplicates allowed)
- Prevent `PG::UniqueViolation` failures during `systems:backfill` bulk upserts (RHINENG-26774)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->