### PR TITLE
feat(Konflux): group GH Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,12 @@
   ],
   "packageRules": [
     {
+      "description": "Group docker GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "matchPackagePrefixes": ["docker/"],
+      "groupName": "docker GitHub Actions"
+    },
+    {
       "description": "Pin postgres Docker image to v16",
       "matchPackageNames": ["postgres"],
       "allowedVersions": "<=16"


### PR DESCRIPTION
I want to get rid of the spam that we've gotten recently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Renovate: added a `packageRules` entry to group `github-actions` updates for `docker/`-prefixed dependencies under the “docker GitHub Actions” group name, reducing GitHub Actions update notification spam
<!-- end of auto-generated comment: release notes by coderabbit.ai -->