### PR TITLE
fix(CI): add digests to GH Actions

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Install skopeo
         run: sudo apt-get install -y skopeo
       - name: Fetch latest base image digest

--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Install skopeo
         run: sudo apt-get install -y skopeo
       - name: Fetch latest base image digest
@@ -20,7 +20,7 @@ jobs:
             'microdnf update -y $(cat /opt/installedpackages) > /dev/null; rpm -q $(cat /opt/installedpackages) | sort | sha256sum | cut -d " " -f 1' \
             >> .baseimagedigest
       - name: Open or update pull request if digest changed
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           title: 'chore(image): update base image'
           branch: automation/base-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       with:
         fetch-depth: 0
     - name: Validate commit message format
-      uses: wagoid/commitlint-github-action@v6
+      uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed
       with:
         configFile: './.commitlint.yml'
     # FIXME: this is currently timing out
@@ -28,7 +28,7 @@ jobs:
     #  with:
     #    definition-file: swagger/v2/openapi.json
     - name: Setup Ruby and install gems
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       env:
         BUNDLE_JOBS: 4
       with:
@@ -40,7 +40,7 @@ jobs:
     - name: Brakeman
       run: bundle exec brakeman
     - name: ShellCheck
-      uses: ludeeus/action-shellcheck@2.0.0
+      uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
       with:
         ignore: vendor
         check_together: true
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
     - name: Set up the environment
       run: |
         cp .env.example .env
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up the environment
         run: |
           cp .env.example .env
@@ -77,9 +77,9 @@ jobs:
         ports: ["5432:5432"]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
     - name: Setup Ruby and install gems
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:
         bundler-cache: true
         rubygems: latest
@@ -149,7 +149,7 @@ jobs:
         RUBY_YJIT_ENABLE: 1
       run: bin/rake spec
     - name: Upload code coverage from RSpec
-      uses: codecov/codecov-action@v7.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -167,7 +167,7 @@ jobs:
         RUBY_YJIT_ENABLE: 1
       run: bin/rake test
     - name: Upload code coverage from minitest
-      uses: codecov/codecov-action@v7.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -184,9 +184,9 @@ jobs:
         ports: ["5432:5432"]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
     - name: Setup Ruby and install gems
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:
         bundler-cache: true
         rubygems: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Validate commit message format
       uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed
       with:
@@ -49,6 +50,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        persist-credentials: false
     - name: Set up the environment
       run: |
         cp .env.example .env
@@ -60,6 +63,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Set up the environment
         run: |
           cp .env.example .env
@@ -78,6 +83,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        persist-credentials: false
     - name: Setup Ruby and install gems
       uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:
@@ -185,6 +192,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        persist-credentials: false
     - name: Setup Ruby and install gems
       uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:

--- a/.github/workflows/iop-container-publish.yaml
+++ b/.github/workflows/iop-container-publish.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/.github/workflows/iop-container-publish.yaml
+++ b/.github/workflows/iop-container-publish.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/.github/workflows/platsec-security-scan.yml
+++ b/.github/workflows/platsec-security-scan.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   PlatSec-Security-Workflow:
-    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@4f800d206c9be42430f70e7c15f4de3962052f46
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.
     ## Additionally, if you have a Dockerfile you use as your BASE_IMG or you need to

--- a/.github/workflows/ruby-update.yml
+++ b/.github/workflows/ruby-update.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Fetch latest Ruby version from base image
         timeout-minutes: 10
         run: |
@@ -19,7 +19,7 @@ jobs:
             microdnf repoquery ruby --info | grep Version | awk '{ print \$3 }' | head -1 > .ruby-version;
             cat .ruby-version" > .ruby-version
       - name: Open or update pull request if Ruby version changed
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           title: 'chore(devel): update .ruby-version'
           branch: automation/ruby-version
@@ -34,16 +34,16 @@ jobs:
       BUNDLE_BUILD__FFI: "--enable-system-libffi"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           bundler-cache: true
           bundler: latest
       - name: Update Bundler to latest version
         run: bundle config set frozen false && bundle update --bundler
       - name: Open or update pull request if Bundler version changed
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           title: 'chore(deps): update bundler version'
           branch: automation/bundler-version

--- a/.github/workflows/ruby-update.yml
+++ b/.github/workflows/ruby-update.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Fetch latest Ruby version from base image
         timeout-minutes: 10
         run: |
@@ -35,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- checkimage: pin `actions/checkout` and `peter-evans/create-pull-request` to commit digests
- ci: pin `actions/checkout`, `wagoid/commitlint-github-action`, `ruby/setup-ruby`, `ludeeus/action-shellcheck`, and `codecov/codecov-action` to commit digests (plus `persist-credentials: false` on affected checkouts)
- iop-container-publish: pin `actions/checkout` to commit digest
- platsec-security-scan: pin reusable workflow reference to a commit digest instead of `master`
- ruby-update: pin `actions/checkout`, `peter-evans/create-pull-request`, and `ruby/setup-ruby` to commit digests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->