### PR TITLE
fix(rbac): return 403 for users without compliance permissions

### DIFF
--- a/app/policies/v2/system_policy.rb
+++ b/app/policies/v2/system_policy.rb
@@ -4,7 +4,7 @@ module V2
   # Policies for accessing Systems
   class SystemPolicy < V2::ApplicationPolicy
     def index?
-      true # FIXME: this is handled in scoping
+      user.inventory_groups.present?
     end
 
     def show?

--- a/spec/policies/v2/system_policy_spec.rb
+++ b/spec/policies/v2/system_policy_spec.rb
@@ -113,4 +113,18 @@ describe V2::SystemPolicy do
       end
     end
   end
+
+  context 'no permissions' do
+    before do
+      allow(user).to receive(:inventory_groups).and_return([])
+    end
+
+    it 'denies access to index' do
+      expect { Pundit.authorize(user, V2::System, :index?) }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it 'allows scoping (returns empty scope)' do
+      expect(Pundit.policy_scope(user, V2::System).to_a).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Users without any Compliance RBAC permissions were incorrectly receiving a 200 response with an empty list when calling `GET /api/compliance/v2/systems`, instead of the expected 403 Forbidden.

This occurred because `V2::SystemPolicy#index?` always returned `true`, relying entirely on scoping to filter results. While scoping correctly returned an empty set for users without permissions, Pundit's authorization check passed, resulting in a 200 status.

**Changes:**
- Replace `V2::SystemPolicy#index?` logic from `true` to `user.inventory_groups.present?`
- Users without inventory groups now fail authorization and receive 403

**Tests:**
- Add spec coverage for users without permissions: verify 403 on `index?` and empty scope on `policy_scope`
- Existing specs confirm authorized users maintain current behavior

Resolves: RHINENG-26876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Return 403 for users without Compliance permissions**: Tightened `V2::SystemPolicy#index?` to require `user.inventory_groups.present?`, so `GET /api/compliance/v2/systems` now returns **403 Forbidden** (instead of **200** with an empty list).
- **Added regression coverage for the “no permissions” case**: Spec coverage stubs empty `inventory_groups`, asserts `:index?` authorization raises `Pundit::NotAuthorizedError`, and verifies policy scope returns an empty collection.
- **Improved local/dev startup reliability for Compliance services**: Updated `docker-compose.yml` to use explicit `depends_on` `condition` checks (Kafka/RBAC/DB/health/startup) and switched Compliance services to `localhost/compliance-backend-rails` images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->