### PR TITLE
feat(kafka): add Inventory update events consumer

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -8,8 +8,9 @@ class InventoryEventsConsumer < ApplicationConsumer
       Kafka::DeletedSystemCleaner.new(payload, logger).cleanup_system
     elsif service == 'compliance'
       Kafka::ReportParser.new(payload, logger).parse_reports
-    elsif policy_id && %w[created updated].include?(message_type)
-      Kafka::PolicySystemImporter.new(payload, logger).import
+    elsif %w[created updated].include?(message_type)
+      Kafka::SystemImporter.new(payload, logger).import
+      Kafka::PolicySystemImporter.new(payload, logger).import if policy_id
     else
       logger.debug "Skipped message of type '#{message_type}'"
     end

--- a/app/models/kafka_system.rb
+++ b/app/models/kafka_system.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Temporary model for ingesting inventory data directly to compliance db
+class KafkaSystem < ApplicationRecord
+  self.table_name = 'systems'
+end

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Kafka
+  # Imports host events from Inventory into the temporary KafkaSystem table
+  class SystemImporter
+    def initialize(message, logger = Rails.logger)
+      @message = message
+      @logger = logger
+    end
+
+    def import
+      payload = @message.dig('host') || @message
+      return unless payload_valid_for_import?(payload)
+
+      id, updated = payload.values_at('id', 'updated')
+
+      return if existing_message_stale?(id, updated)
+
+      upsert_system(id, payload, updated)
+    rescue StandardError => e
+      failed_id = payload&.dig('id') || 'unknown'
+      @logger.error("[Kafka::SystemImporter] Failed to import system #{failed_id}: #{e.message}")
+    end
+
+    private
+
+    def payload_valid_for_import?(payload)
+      unless valid_payload?(payload)
+        @logger.error('[Kafka::SystemImporter] Ignored invalid message: missing host id or malformed tags')
+        return false
+      end
+      true
+    end
+
+    def existing_message_stale?(id, updated)
+      existing = KafkaSystem.find_by(id: id)
+      if existing && stale_message?(existing, updated)
+        @logger.info("[Kafka::SystemImporter] Ignored stale message for system #{id}")
+        return true
+      end
+      false
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def system_attributes(id, payload, updated)
+      {
+        id: id,
+        account: payload.dig('account'),
+        org_id: payload.dig('org_id'),
+        display_name: payload.dig('display_name'),
+        groups: payload.dig('groups') || [],
+        tags: payload.dig('tags') || [],
+        system_profile: payload.dig('system_profile'),
+        stale_timestamp: payload.dig('stale_timestamp'),
+        created: payload.dig('created'),
+        updated: updated,
+        insights_id: payload.dig('insights_id')
+      }
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def upsert_system(id, payload, updated)
+      attrs = system_attributes(id, payload, updated)
+
+      # rubocop:disable Rails/SkipsModelValidations
+      KafkaSystem.upsert(attrs, unique_by: :id)
+      # rubocop:enable Rails/SkipsModelValidations
+      @logger.info("[Kafka::SystemImporter] Imported system #{id}")
+    end
+
+    def valid_payload?(payload)
+      payload.present? &&
+        payload.dig('id').present? &&
+        valid_tags?(payload.dig('tags'))
+    end
+
+    def valid_tags?(tags)
+      return true if tags.blank?
+
+      tags.is_a?(Array) && tags.all?(Hash)
+    end
+
+    def stale_message?(existing, updated)
+      existing.updated.present? && updated.present? && existing.updated.to_time >= updated.to_time
+    end
+  end
+end

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -51,19 +51,33 @@ describe InventoryEventsConsumer do
       )
     end
 
-    it 'logs a debug message and skips processing' do
-      expect(Karafka.logger).to receive(:debug).with("Skipped message of type '#{type}'")
+    before do
+      @system_importer_service = instance_double(Kafka::SystemImporter)
+      allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
+      allow(@system_importer_service).to receive(:import)
+    end
+
+    it 'delegates to SystemImporter service and skips PolicySystemImporter' do
+      expect(@system_importer_service).to receive(:import)
+      expect(Kafka::PolicySystemImporter).not_to receive(:new)
 
       consumer.consume
     end
   end
 
   describe 'handling messages without policy ID' do
+    before do
+      @system_importer_service = instance_double(Kafka::SystemImporter)
+      allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
+      allow(@system_importer_service).to receive(:import)
+    end
+
     context 'message is created' do
       let(:type) { 'created' }
 
-      it 'logs a debug message and skips processing' do
-        expect(Karafka.logger).to receive(:debug).with("Skipped message of type '#{type}'")
+      it 'delegates to SystemImporter service but not PolicySystemImporter' do
+        expect(@system_importer_service).to receive(:import)
+        expect(Kafka::PolicySystemImporter).not_to receive(:new)
 
         consumer.consume
       end
@@ -72,8 +86,9 @@ describe InventoryEventsConsumer do
     context 'message is updated' do
       let(:type) { 'updated' }
 
-      it 'logs a debug message and skips processing' do
-        expect(Karafka.logger).to receive(:debug).with("Skipped message of type '#{type}'")
+      it 'delegates to SystemImporter service but not PolicySystemImporter' do
+        expect(@system_importer_service).to receive(:import)
+        expect(Kafka::PolicySystemImporter).not_to receive(:new)
 
         consumer.consume
       end
@@ -137,13 +152,19 @@ describe InventoryEventsConsumer do
         )
       end
 
+      before do
+        @system_importer_service = instance_double(Kafka::SystemImporter)
+        allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
+        allow(@system_importer_service).to receive(:import)
+        allow(@service).to receive(:import)
+      end
+
       context 'message is created' do
         let(:type) { 'created' }
 
-        it 'delegates to PolicySystemImporter service' do
-          allow(@service).to receive(:import)
-
+        it 'delegates to both PolicySystemImporter and SystemImporter services' do
           expect(@service).to receive(:import)
+          expect(@system_importer_service).to receive(:import)
 
           consumer.consume
         end
@@ -152,10 +173,9 @@ describe InventoryEventsConsumer do
       context 'message is updated' do
         let(:type) { 'updated' }
 
-        it 'delegates to PolicySystemImporter service' do
-          allow(@service).to receive(:import)
-
+        it 'delegates to both PolicySystemImporter and SystemImporter services' do
           expect(@service).to receive(:import)
+          expect(@system_importer_service).to receive(:import)
 
           consumer.consume
         end

--- a/spec/factories/kafka_system.rb
+++ b/spec/factories/kafka_system.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :kafka_system, parent: :system, class: 'KafkaSystem' do
+    # Override account association since KafkaSystem uses a string account, not a relation
+    account { Faker::Number.number(digits: 5).to_s }
+    org_id { Faker::Number.number(digits: 6).to_s }
+
+    # Disable the after(:create) callbacks from the parent :system factory
+    # because KafkaSystem does not have policy_systems or test_results associations
+    after(:create) { |sys, ev| }
+  end
+end

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Kafka::SystemImporter do
+  let(:logger) { instance_double('Logger', info: true, error: true) }
+  let(:message) do
+    {
+      'host' => {
+        'id' => SecureRandom.uuid,
+        'account' => Faker::Number.number(digits: 5).to_s,
+        'org_id' => Faker::Number.number(digits: 6).to_s,
+        'display_name' => Faker::Internet.domain_word,
+        'groups' => [],
+        'tags' => [],
+        'system_profile' => {},
+        'stale_timestamp' => Time.now.utc.iso8601,
+        'created' => (Time.now.utc - 1.day).iso8601,
+        'updated' => Time.now.utc.iso8601,
+        'insights_id' => SecureRandom.uuid
+      }
+    }
+  end
+
+  subject { described_class.new(message, logger) }
+
+  describe '#import' do
+    context 'when payload is invalid (missing id)' do
+      before { message['host'].delete('id') }
+
+      it 'ignores the message and logs an error' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+      end
+    end
+
+    context 'when payload is invalid (malformed tags)' do
+      before { message['host']['tags'] = ['string_tag_not_hash'] }
+
+      it 'ignores the message and logs an error' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+      end
+    end
+
+    context 'when system is new' do
+      it 'upserts system' do
+        expect { subject.import }.to change { KafkaSystem.count }.by(1)
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Imported system/)
+      end
+    end
+
+    context 'when message is an update to an existing system' do
+      let!(:existing_system) do
+        system = FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id'],
+          display_name: 'old-name'
+        )
+        system.update!(updated: (Time.now.utc - 2.days).iso8601)
+        system
+      end
+
+      it 'updates the existing system attributes' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.display_name).to eq(message.dig('host', 'display_name'))
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Imported system/)
+      end
+    end
+
+    context 'when message is exactly the same age (repeated message)' do
+      let!(:existing_system) do
+        system = FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id'],
+          display_name: 'old-name'
+        )
+        system.update!(updated: message['host']['updated'])
+        system
+      end
+
+      it 'ignores the repeated message' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.display_name).to eq('old-name') # prove it was not updated
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+      end
+    end
+
+    context 'when message is strictly stale (older than DB)' do
+      before do
+        system = FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id']
+        )
+        system.update!(updated: (Time.now.utc + 1.day).iso8601)
+      end
+
+      it 'ignores the stale message' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+      end
+    end
+
+    context 'when payload lacks optional fields like groups' do
+      before { message['host'].delete('groups') }
+
+      it 'upserts using fallback defaults' do
+        subject.import
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.groups).to eq([])
+      end
+    end
+
+    context 'when exception occurs' do
+      before do
+        allow(KafkaSystem).to receive(:upsert).and_raise(ActiveRecord::ActiveRecordError, 'db down')
+      end
+
+      it 'logs error without crashing' do
+        expect { subject.import }.not_to raise_error
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Failed to import system.*db down/)
+      end
+    end
+
+    context 'when payload is entirely empty' do
+      let(:message) { {} }
+
+      it 'ignores the message and logs an error' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+      end
+    end
+
+    context 'when payload is flat (no host key)' do
+      let(:message) do
+        {
+          'id' => SecureRandom.uuid,
+          'account' => Faker::Number.number(digits: 5).to_s,
+          'org_id' => Faker::Number.number(digits: 6).to_s,
+          'display_name' => Faker::Internet.domain_word,
+          'tags' => [],
+          'system_profile' => {},
+          'stale_timestamp' => Time.now.utc.iso8601,
+          'created' => (Time.now.utc - 1.day).iso8601,
+          'updated' => Time.now.utc.iso8601
+        }
+      end
+
+      it 'upserts the system correctly by falling back to root message' do
+        expect { subject.import }.to change { KafkaSystem.count }.by(1)
+        system = KafkaSystem.find(message['id'])
+        expect(system.account).to eq(message['account'])
+        expect(system.groups).to eq([])
+      end
+    end
+
+    context 'when existing system has nil updated timestamp' do
+      # In reality, DB schema doesn't allow `updated` to be null (PG::NotNullViolation),
+      # so this context is mathematically impossible given the schema constraints.
+      # We skip it, but our ruby logic naturally defends against it via `.present?` checks.
+    end
+
+    context 'when message has nil updated timestamp' do
+      let(:message) do
+        {
+          'host' => {
+            'id' => SecureRandom.uuid,
+            'account' => '12345',
+            'org_id' => 'org123',
+            'display_name' => 'test-host',
+            'groups' => [],
+            'tags' => [],
+            'system_profile' => {},
+            'stale_timestamp' => Time.now.utc.iso8601,
+            'created' => (Time.now.utc - 1.day).iso8601,
+            'updated' => nil,
+            'insights_id' => SecureRandom.uuid
+          }
+        }
+      end
+
+      it 'catches DB validation error during upsert due to NOT NULL constraint' do
+        subject.import
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Failed to import system/)
+      end
+    end
+    context 'when exception occurs' do
+      before do
+        allow(KafkaSystem).to receive(:upsert).and_raise(ActiveRecord::ActiveRecordError, 'db down')
+      end
+
+      it 'logs error without crashing' do
+        expect { subject.import }.not_to raise_error
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Failed to import system.*db down/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**feat(kafka): add Inventory update events consumer [[RHINENG-23280](https://redhat.atlassian.net/browse/RHINENG-23280)]**

## Description
   Implements the Kafka consumer logic for Inventory `created`
 and `updated` events to populate the `systems` table,
 replacing the legacy Cyndi replication.

### Key Changes
   - **Model:** Added `KafkaSystem` to safely write to the
 `systems` table (bypassing the read-only `V2::System` view
 during migration).
   - **Service:** Created `Kafka::SystemImporter` to map event
 fields and perform safe `upsert` operations.
   - **Routing:** `InventoryEventsConsumer` now routes events
 to `SystemImporter` (and `PolicySystemImporter` when a policy
 ID is present).
   - **Protection:** Added staleness checks (drops
 out-of-order messages based on `updated` timestamp) and
 graceful error handling to prevent Karafka loop crashes.
   - **Testing:** Added a dedicated `kafka_system` factory and
 comprehensive RSpec coverage for all edge cases.

## Jira Issue
   - [RHINENG-23280](https://issues.redhat.com/browse/RHINENG-23280)

## AI/LLM Usage
   This PR was authored with the assistance of an AI coding
 agent (Gemini 3.1 Pro Preview via pi/unipi) to scaffold the
 `Kafka::SystemImporter` upsert logic, the `KafkaSystem`
 temporary model, inventory event routing, and comprehensive
 RSpec test suites including factory setups. All AI output was
 reviewed, tested, and modified by the human author.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


[RHINENG-23280]: https://redhat.atlassian.net/browse/RHINENG-23280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-23280]: https://redhat.atlassian.net/browse/RHINENG-23280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add temporary `KafkaSystem` ActiveRecord model (backed by `systems`) to ingest inventory data directly during migration from legacy Cyndi replication
- Introduce `Kafka::SystemImporter` to validate Kafka payloads and safely upsert `KafkaSystem`/`systems` with:
  - out-of-order protection via `updated` timestamp staleness checks
  - logging + swallow-on-failure error handling (no Karafka crash)
- Update `InventoryEventsConsumer` routing so `inventory` `created`/`updated` events always go through `Kafka::SystemImporter`, with `Kafka::PolicySystemImporter` only invoked when `policy_id` is present
- Add `:kafka_system` FactoryBot factory to isolate importer tests from legacy associations/side effects
- Expand RSpec coverage for importer validation, staleness rejection, optional-field defaults (e.g., `groups`), routing edge cases, and upsert/DB constraint error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->