### PR TITLE
feat(Renovate): improve update grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,10 +20,14 @@
   ],
   "packageRules": [
     {
-      "description": "Group docker GitHub Actions updates",
+      "description": "Group all GitHub Actions updates into one PR",
       "matchManagers": ["github-actions"],
-      "matchPackagePrefixes": ["docker/"],
-      "groupName": "docker GitHub Actions"
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Group all Rust (hermetic lockfile) updates into one PR",
+      "matchManagers": ["cargo"],
+      "groupName": "Rust dependencies"
     },
     {
       "description": "Pin postgres Docker image to v16",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Broadened Renovate grouping for GitHub Actions updates into a single “GitHub Actions” PR.
- Added a separate “Rust dependencies” group for cargo/hermetic lockfile updates.
- Removed the previous Docker-specific GitHub Actions grouping rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->