### PR TITLE
feat(Renovate): automate image digest and RPM lockfile updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
+  ],
   "ignorePaths": [
     ".pre-commit-config.yaml"
   ],


### PR DESCRIPTION
This way we could get rid of the GH Action we have.

Based on [konflux-ci/refresh-rpm-lockfiles](https://github.com/konflux-ci/refresh-rpm-lockfiles#manual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added Renovate automation for Dockerfile image digest updates, scheduled to run before 6am on weekdays.
- Configured post-upgrade tasks to refresh affected RPM lockfiles automatically after digest updates.
- Prepared this to replace the existing GitHub Action-based update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->