### PR TITLE
feat(fx): specify alphabetic ordering of functions and triggers

### DIFF
--- a/config/initializers/fx.rb
+++ b/config/initializers/fx.rb
@@ -1,0 +1,13 @@
+class SortedFxAdapter < Fx::Adapters::Postgres
+  def functions
+    super.sort_by { |fn| [fn.name, fn.definition] }
+  end
+
+  def triggers
+    super.sort_by { |tr| [tr.name, tr.definition] }
+  end
+end
+
+Fx.configure do |config|
+  config.database = SortedFxAdapter.new
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_21_112129) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_27_152250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -417,6 +417,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_112129) do
             GROUP BY historical_test_results_1.tailoring_id, historical_test_results_1.system_id) tr ON (((historical_test_results.tailoring_id = tr.tailoring_id) AND (historical_test_results.system_id = tr.system_id) AND (historical_test_results.end_time = tr.end_time))));
   SQL
 
+  create_function :test_results_delete, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.test_results_delete()
+       RETURNS trigger
+       LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+          DELETE FROM "historical_test_results" WHERE "id" = OLD."id";
+          RETURN OLD;
+      END
+      $function$
+  SQL
+
   create_function :test_results_insert, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.test_results_insert()
        RETURNS trigger
@@ -450,18 +462,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_112129) do
 
           NEW."id" := "result_id";
           RETURN NEW;
-      END
-      $function$
-  SQL
-
-  create_function :test_results_delete, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.test_results_delete()
-       RETURNS trigger
-       LANGUAGE plpgsql
-      AS $function$
-      BEGIN
-          DELETE FROM "historical_test_results" WHERE "id" = OLD."id";
-          RETURN OLD;
       END
       $function$
   SQL


### PR DESCRIPTION
Dependent on: 
* https://github.com/RedHatInsights/compliance-backend/pull/2832
* https://github.com/RedHatInsights/compliance-backend/pull/2852

Inspired by https://github.com/teoljungberg/fx#customizing-schema-dump-order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Ensure deterministic, alphabetic ordering of exported Postgres schema objects in FX dumps by sorting functions and triggers (via `SortedFxAdapter`).
- Regenerate `db/schema.rb` to apply the new dump ordering, including updating the schema version and re-emitting the `test_results_delete` trigger function definition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->