### PR TITLE
fix(Dockerfile): restore gem/bundler setup in runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,14 @@ WORKDIR /opt/app-root/src
 
 USER 0
 
-RUN ( [[ $HERMETIC == "true" ]] || rpm -e --nodeps tzdata &>/dev/null ) && \
-    microdnf module enable -y ruby:3.3                                  && \
-    microdnf install --nodocs -y $deps                     && \
-    chmod +t /tmp                                          && \
-    microdnf clean all -y                                  && \
-    chown 1001:root ./                                     && \
+RUN ( [[ $HERMETIC == "true" ]] || rpm -e --nodeps tzdata &>/dev/null )                && \
+    microdnf module enable -y ruby:3.3                                                 && \
+    microdnf install --nodocs -y $deps                                                 && \
+    chmod +t /tmp                                                                      && \
+    ( [[ $HERMETIC == "true" ]] || gem update --system -N --install-dir=/usr/share/gems --bindir /usr/bin ) && \
+    ( [[ $HERMETIC == "true" ]] || gem install bundler )                               && \
+    microdnf clean all -y                                                              && \
+    chown 1001:root ./                                                                 && \
     install -v -d -m 1777 -o 1001 ./tmp ./log
 
 USER 1001


### PR DESCRIPTION
## Summary

- Restores `gem update --system` and `gem install bundler` to the runtime stage of the Dockerfile
- These lines were removed in PR #2753 (hermetic builds), which broke the runtime bundler environment
- Without them, init containers fail with `bundler: command not found: rake` because the system bundler cannot resolve gems in the deployment `.bundle/` path
- This is causing all new pods in `compliance-stage` to crash (CrashLoopBackOff / Init:Error), while old pods on the previous image (`3a5ed60`) remain healthy

## Root Cause

PR #2753 removed `gem update --system` and `gem install bundler` from both the build and runtime Dockerfile stages. The build stage works without them because `$devDeps` pulls in sufficient Ruby tooling. However, the runtime stage only installs `$deps`, which lacks a properly configured gem/bundler environment to find gems installed in `.bundle/`.

PR #2800 attempted to fix this by adding `gem 'rake'` to the Gemfile, but the issue is not a missing gem — it's that the runtime bundler cannot locate *any* gems in the deployment path.

## Test plan

- [ ] Build the Docker image and verify the init container (`check_migration_status_and_ssg_synced.sh`) completes successfully
- [ ] Verify `bundle exec rake --version` works inside the runtime container
- [ ] Deploy to stage and confirm pods start without Init:Error

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] General Coding Practices
- [x] System Configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Restored runtime Ruby tooling setup in the Dockerfile by running `gem update --system` and `gem install bundler` in the final image stage.
- Kept the rest of the runtime stage unchanged: install dependencies, adjust permissions, clean package manager cache, and `chown` the app directory.
- Goal: fix init container failures where the system bundler could not resolve gems from the deployed `.bundle/` path, causing `bundler: command not found: rake` and CrashLoopBackOffs in new pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->