### PR TITLE
fix(Dockerfile): set BUNDLE_PATH env var in final image for hermetic build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ USER 1001
 COPY --chown=1001:0 . /opt/app-root/src
 COPY --chown=1001:0 --from=build /opt/app-root/src/.bundle /opt/app-root/src/.bundle
 
-ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=true HOME=/opt/app-root/src DEV_DEPS=$devDeps prometheus_multiproc_dir=/opt/app-root/src/tmp prometheus_rust_mmaped_file=false
+ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=true HOME=/opt/app-root/src DEV_DEPS=$devDeps prometheus_multiproc_dir=/opt/app-root/src/tmp prometheus_rust_mmaped_file=false \
+    BUNDLE_PATH=".bundle" BUNDLE_WITHOUT="development:test" BUNDLE_DEPLOYMENT="true" BUNDLE_VERSION="system" BUNDLE_DISABLE_VERSION_CHECK="true"
 
 CMD ["/opt/app-root/src/entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'yabeda-prometheus-mmap'
 gem 'yabeda-puma-plugin'
 gem 'yabeda-rails'
 gem 'yabeda-sidekiq'
-gem 'yabeda-activejob', github: 'RoamingNoMaD/yabeda-activejob', branch: 'add-custom-tagging'
+gem 'yabeda-activejob', '= 0.6.0'
 
 # Nokogiri
 gem 'nokogiri', force_ruby_platform: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/RoamingNoMaD/yabeda-activejob.git
-  revision: 1894d97a925dacdb930e9cfec1846a27234f4159
-  branch: add-custom-tagging
-  specs:
-    yabeda-activejob (0.6.0)
-      rails (>= 6.1)
-      yabeda (~> 0.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -552,6 +543,9 @@ GEM
       anyway_config (>= 1.0, < 3)
       concurrent-ruby
       dry-initializer
+    yabeda-activejob (0.6.0)
+      rails (>= 6.1)
+      yabeda (~> 0.6)
     yabeda-prometheus-mmap (0.4.0)
       prometheus-client-mmap
       yabeda (~> 0.10)
@@ -650,7 +644,7 @@ DEPENDENCIES
   webrick
   will_paginate
   yabeda
-  yabeda-activejob!
+  yabeda-activejob (= 0.6.0)
   yabeda-prometheus-mmap
   yabeda-puma-plugin
   yabeda-rails

--- a/config/initializers/yabeda-activejob_custom_tags.rb
+++ b/config/initializers/yabeda-activejob_custom_tags.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Patch for https://github.com/Fullscript/yabeda-activejob/pull/26
+#
+# We need custom tags on ActiveJob metrics (see ParseReportJob#yabeda_tags), but the
+# feature only exists on an unreleased fork (RoamingNoMaD/yabeda-activejob). Konflux
+# hermetic builds block network access and cannot install git-sourced gems, so using
+# that fork directly is not viable. This patch backports the two relevant changes from
+# the upstream PR into the released 0.6.0 gem until the PR is merged and released.
+#
+# NOTE: Released 0.6.0 does not have an EventHandler class (unlike the fork). The
+# perform.active_job subscription is an inline block inside install!. We patch install!
+# via prepend to replace that subscription with one that merges custom tags.
+#
+# This file is named yabeda-activejob_custom_tags.rb (with a hyphen) so that it sorts
+# before yabeda.rb alphabetically and loads before install! is called.
+#
+# Once that PR is merged and a new gem version is released:
+#   1. Delete this file.
+#   2. In Gemfile, bump yabeda-activejob to the version that includes the PR.
+#   3. Run `bundle install` to update Gemfile.lock.
+
+require 'yabeda/activejob'
+
+module Yabeda
+  module ActiveJob
+    def self.custom_tags(job)
+      return {} unless job.respond_to?(:yabeda_tags)
+
+      if job.method(:yabeda_tags).arity.zero?
+        job.yabeda_tags
+      else
+        job.yabeda_tags(*job.arguments)
+      end
+    end
+  end
+end
+
+Yabeda::ActiveJob.singleton_class.prepend(Module.new do
+  def install!
+    super
+    ActiveSupport::Notifications.notifier.listeners_for('perform.active_job').each do |listener|
+      ActiveSupport::Notifications.unsubscribe(listener)
+    end
+    ActiveSupport::Notifications.subscribe('perform.active_job') do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      job = event.payload[:job]
+      labels = {
+        activejob: job.class.to_s,
+        queue: job.queue_name.to_s,
+        executions: job.executions.to_s,
+      }.merge(Yabeda::ActiveJob.custom_tags(job))
+      if event.payload[:exception].present?
+        Yabeda.activejob_failed_total.increment(labels.merge(failure_reason: event.payload[:exception].first.to_s))
+      else
+        Yabeda.activejob_success_total.increment(labels)
+      end
+      Yabeda.activejob_executed_total.increment(labels)
+      Yabeda.activejob_runtime.measure(labels, Yabeda::ActiveJob.ms2s(event.duration))
+      Yabeda::ActiveJob.after_event_block.call(event) if Yabeda::ActiveJob.after_event_block.respond_to?(:call)
+    end
+  end
+end)


### PR DESCRIPTION
After the hermetic build was introduced, pods fail to start because bundler
cannot find any gems at runtime. Inspection of the running image shows gems
present in `.bundle/ruby/` but `.bundle/config` missing entirely, so bundler
falls back to the empty system GEM_PATH.

The root cause is unknown — the most likely explanation is that Cachi2 sets
`BUNDLE_APP_CONFIG` during the build, redirecting `bundle config set --local`
writes away from the project directory, but this was not directly verified.

Fix by setting `BUNDLE_PATH=".bundle"` in the image ENV, which is sufficient
regardless of why the config file is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fix Docker hermetic runtime image: set `BUNDLE_PATH=".bundle"` in the final image `ENV` so Bundler can find installed gems at pod startup even if `.bundle/config` is missing.
- Clean up production runtime Dockerfile `ENV` by consolidating Rails/logging/home/dev-deps and Prometheus settings into a single block.
- Update `yabeda-activejob` Gemfile entry to use the published gem version instead of a pinned GitHub repo/branch.
- Backport custom ActiveJob metric tag support into `yabeda-activejob` 0.6.0 via a Rails initializer (custom tag extraction + label merge for success/failure/executed/runtime counters).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->