### PR TITLE
feat(kafka): add Inventory update and delete events consumer

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -3,17 +3,21 @@
 # Receives messages from the Kafka topic, dispatches them to the appropriate service
 class InventoryEventsConsumer < ApplicationConsumer
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def consume_one
     if message_type == 'delete'
       Kafka::DeletedSystemCleaner.new(payload, logger).cleanup_system
+    elsif %w[created updated].include?(message_type)
+      Kafka::SystemImporter.new(payload, logger).import
+      Kafka::PolicySystemImporter.new(payload, logger).import if policy_id
+      Kafka::ReportParser.new(payload, logger).parse_reports if service == 'compliance'
     elsif service == 'compliance'
       Kafka::ReportParser.new(payload, logger).parse_reports
-    elsif policy_id && %w[created updated].include?(message_type)
-      Kafka::PolicySystemImporter.new(payload, logger).import
     else
       logger.debug "Skipped message of type '#{message_type}'"
     end
   end
+  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 
   private

--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -2,25 +2,32 @@
 
 # Receives messages from the Kafka topic, dispatches them to the appropriate service
 class InventoryEventsConsumer < ApplicationConsumer
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def consume_one
-    if message_type == 'delete'
+    case message_type
+    when 'delete'
       Kafka::DeletedSystemCleaner.new(payload, logger).cleanup_system
-    elsif %w[created updated].include?(message_type)
-      Kafka::SystemImporter.new(payload, logger).import
-      Kafka::PolicySystemImporter.new(payload, logger).import if policy_id
-      Kafka::ReportParser.new(payload, logger).parse_reports if service == 'compliance'
-    elsif service == 'compliance'
+    when 'created', 'updated'
+      handle_created_updated
+    else
+      handle_other
+    end
+  end
+
+  private
+
+  def handle_created_updated
+    Kafka::SystemImporter.new(payload, logger).import
+    Kafka::PolicySystemImporter.new(payload, logger).import if policy_id
+    Kafka::ReportParser.new(payload, logger).parse_reports if service == 'compliance'
+  end
+
+  def handle_other
+    if service == 'compliance'
       Kafka::ReportParser.new(payload, logger).parse_reports
     else
       logger.debug "Skipped message of type '#{message_type}'"
     end
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
-
-  private
 
   def payload
     JSON.parse(@message.raw_payload)

--- a/app/models/kafka_system.rb
+++ b/app/models/kafka_system.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Temporary model for ingesting inventory data directly to compliance db
+class KafkaSystem < ApplicationRecord
+  self.table_name = 'systems'
+end

--- a/app/services/kafka/deleted_system_cleaner.rb
+++ b/app/services/kafka/deleted_system_cleaner.rb
@@ -22,10 +22,13 @@ module Kafka
     private
 
     def remove_related
-      [
-        remove_related_test_results,
-        remove_related_policy_systems
-      ].sum
+      ActiveRecord::Base.transaction do
+        [
+          remove_related_test_results,
+          remove_related_policy_systems,
+          remove_kafka_system
+        ].sum
+      end
     end
 
     def remove_related_test_results
@@ -38,6 +41,10 @@ module Kafka
 
     def remove_related_policy_systems
       V2::PolicySystem.where(system_id: @id).delete_all
+    end
+
+    def remove_kafka_system
+      KafkaSystem.where(id: @id).delete_all
     end
 
     def audit_fail(error)

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -14,8 +14,6 @@ module Kafka
 
       id, updated = payload.values_at('id', 'updated')
 
-      return if existing_message_stale?(id, updated)
-
       upsert_system(id, payload, updated)
     rescue StandardError => e
       failed_id = id || payload&.dig('id') || 'unknown'
@@ -31,15 +29,6 @@ module Kafka
         return false
       end
       true
-    end
-
-    def existing_message_stale?(id, updated)
-      existing = KafkaSystem.find_by(id: id)
-      if existing && stale_message?(existing, updated)
-        @logger.info("[Kafka::SystemImporter] Ignored stale message for system #{id}")
-        return true
-      end
-      false
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -65,14 +54,20 @@ module Kafka
 
       # rubocop:disable Rails/SkipsModelValidations
       # rubocop:disable Layout/LineLength
-      KafkaSystem.upsert(
+      result = KafkaSystem.upsert(
         attrs,
         unique_by: :id,
+        returning: %w[id],
         on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id WHERE systems.updated IS NULL OR systems.updated < EXCLUDED.updated')
       )
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations
-      @logger.audit_success("[Kafka::SystemImporter] Imported system #{id}")
+
+      if result.rows.empty?
+        @logger.info("[Kafka::SystemImporter] Ignored stale message for system #{id}")
+      else
+        @logger.audit_success("[Kafka::SystemImporter] Imported system #{id}")
+      end
     end
 
     def valid_payload?(payload)
@@ -85,10 +80,6 @@ module Kafka
       return true if tags.blank?
 
       tags.is_a?(Array) && tags.all?(Hash)
-    end
-
-    def stale_message?(existing, updated)
-      existing.updated.present? && updated.present? && existing.updated.to_time >= updated.to_time
     end
   end
 end

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -31,26 +31,18 @@ module Kafka
       true
     end
 
-    # rubocop:disable Metrics/MethodLength
-    def system_attributes(id, payload, updated)
+    def extract_system_attrs(id, payload, updated)
       {
-        id: id,
-        account: payload.dig('account'),
-        org_id: payload.dig('org_id'),
-        display_name: payload.dig('display_name'),
-        groups: payload.dig('groups') || [],
-        tags: payload.dig('tags') || [],
-        system_profile: payload.dig('system_profile'),
-        stale_timestamp: payload.dig('stale_timestamp'),
-        created: payload.dig('created'),
-        updated: updated,
-        insights_id: payload.dig('insights_id')
+        id: id, account: payload.dig('account'), org_id: payload.dig('org_id'),
+        display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
+        tags: payload.dig('tags') || [], system_profile: payload.dig('system_profile'),
+        stale_timestamp: payload.dig('stale_timestamp'), created: payload.dig('created'),
+        updated: updated, insights_id: payload.dig('insights_id')
       }
     end
-    # rubocop:enable Metrics/MethodLength
 
     def upsert_system(id, payload, updated)
-      attrs = system_attributes(id, payload, updated)
+      attrs = extract_system_attrs(id, payload, updated)
 
       # rubocop:disable Rails/SkipsModelValidations
       # rubocop:disable Layout/LineLength
@@ -63,6 +55,10 @@ module Kafka
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations
 
+      log_upsert_result(result, id)
+    end
+
+    def log_upsert_result(result, id)
       if result.rows.empty?
         @logger.info("[Kafka::SystemImporter] Ignored stale message for system #{id}")
       else

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Kafka
-  # Imports host events from Inventory into the temporary KafkaSystem table
+  # Imports host events from Inventory into the systems table
   class SystemImporter
     def initialize(message, logger = Rails.logger)
       @message = message
@@ -9,7 +9,7 @@ module Kafka
     end
 
     def import
-      payload = @message.dig('host') || @message
+      payload = @message.dig('host')
       return unless payload_valid_for_import?(payload)
 
       id, updated = payload.values_at('id', 'updated')
@@ -18,8 +18,8 @@ module Kafka
 
       upsert_system(id, payload, updated)
     rescue StandardError => e
-      failed_id = payload&.dig('id') || 'unknown'
-      @logger.error("[Kafka::SystemImporter] Failed to import system #{failed_id}: #{e.message}")
+      failed_id = id || payload&.dig('id') || 'unknown'
+      @logger.audit_fail("[Kafka::SystemImporter] Failed to import system #{failed_id}: #{e.message}")
       raise e
     end
 
@@ -72,7 +72,7 @@ module Kafka
       )
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations
-      @logger.info("[Kafka::SystemImporter] Imported system #{id}")
+      @logger.audit_success("[Kafka::SystemImporter] Imported system #{id}")
     end
 
     def valid_payload?(payload)

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Kafka
+  # Imports host events from Inventory into the temporary KafkaSystem table
+  class SystemImporter
+    def initialize(message, logger = Rails.logger)
+      @message = message
+      @logger = logger
+    end
+
+    def import
+      payload = @message.dig('host') || @message
+      return unless payload_valid_for_import?(payload)
+
+      id, updated = payload.values_at('id', 'updated')
+
+      return if existing_message_stale?(id, updated)
+
+      upsert_system(id, payload, updated)
+    rescue StandardError => e
+      failed_id = payload&.dig('id') || 'unknown'
+      @logger.error("[Kafka::SystemImporter] Failed to import system #{failed_id}: #{e.message}")
+      raise e
+    end
+
+    private
+
+    def payload_valid_for_import?(payload)
+      unless valid_payload?(payload)
+        @logger.error('[Kafka::SystemImporter] Ignored invalid message: missing host id or malformed tags')
+        return false
+      end
+      true
+    end
+
+    def existing_message_stale?(id, updated)
+      existing = KafkaSystem.find_by(id: id)
+      if existing && stale_message?(existing, updated)
+        @logger.info("[Kafka::SystemImporter] Ignored stale message for system #{id}")
+        return true
+      end
+      false
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def system_attributes(id, payload, updated)
+      {
+        id: id,
+        account: payload.dig('account'),
+        org_id: payload.dig('org_id'),
+        display_name: payload.dig('display_name'),
+        groups: payload.dig('groups') || [],
+        tags: payload.dig('tags') || [],
+        system_profile: payload.dig('system_profile'),
+        stale_timestamp: payload.dig('stale_timestamp'),
+        created: payload.dig('created'),
+        updated: updated,
+        insights_id: payload.dig('insights_id')
+      }
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def upsert_system(id, payload, updated)
+      attrs = system_attributes(id, payload, updated)
+
+      # rubocop:disable Rails/SkipsModelValidations
+      # rubocop:disable Layout/LineLength
+      KafkaSystem.upsert(
+        attrs,
+        unique_by: :id,
+        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id WHERE systems.updated IS NULL OR systems.updated < EXCLUDED.updated')
+      )
+      # rubocop:enable Layout/LineLength
+      # rubocop:enable Rails/SkipsModelValidations
+      @logger.info("[Kafka::SystemImporter] Imported system #{id}")
+    end
+
+    def valid_payload?(payload)
+      payload.present? &&
+        payload.dig('id').present? &&
+        valid_tags?(payload.dig('tags'))
+    end
+
+    def valid_tags?(tags)
+      return true if tags.blank?
+
+      tags.is_a?(Array) && tags.all?(Hash)
+    end
+
+    def stale_message?(existing, updated)
+      existing.updated.present? && updated.present? && existing.updated.to_time >= updated.to_time
+    end
+  end
+end

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -39,71 +39,95 @@ describe InventoryEventsConsumer do
     end
   end
 
-  describe 'handling updated messages for different service' do
-    let(:type) { 'updated' }
-    let(:message) do
-      super().deep_merge(
-        {
-          'platform_metadata' => {
-            'service' => 'non-compliance'
-          }
-        }
-      )
-    end
+  describe 'handling messages by type' do
+    context 'when message is delete' do
+      let(:type) { 'delete' }
 
-    before do
-      @system_importer_service = instance_double(Kafka::SystemImporter)
-      allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
-      allow(@system_importer_service).to receive(:import)
-    end
-
-    it 'delegates to SystemImporter service and skips PolicySystemImporter' do
-      expect(@system_importer_service).to receive(:import)
-      expect(Kafka::PolicySystemImporter).not_to receive(:new)
-
-      consumer.consume
-    end
-  end
-
-  describe 'handling messages without policy ID' do
-    before do
-      @system_importer_service = instance_double(Kafka::SystemImporter)
-      allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
-      allow(@system_importer_service).to receive(:import)
-    end
-
-    context 'message is created' do
-      let(:type) { 'created' }
-
-      it 'delegates to SystemImporter service but not PolicySystemImporter' do
-        expect(@system_importer_service).to receive(:import)
-        expect(Kafka::PolicySystemImporter).not_to receive(:new)
+      it 'delegates to DeletedSystemCleaner service' do
+        service = instance_double(Kafka::DeletedSystemCleaner)
+        allow(Kafka::DeletedSystemCleaner).to receive(:new).and_return(service)
+        expect(service).to receive(:cleanup_system)
 
         consumer.consume
       end
     end
 
-    context 'message is updated' do
-      let(:type) { 'updated' }
+    context 'when message is created or updated' do
+      before do
+        @system_importer_service = instance_double(Kafka::SystemImporter)
+        allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
+        allow(@system_importer_service).to receive(:import)
+      end
 
-      it 'delegates to SystemImporter service but not PolicySystemImporter' do
-        expect(@system_importer_service).to receive(:import)
-        expect(Kafka::PolicySystemImporter).not_to receive(:new)
+      %w[created updated].each do |msg_type|
+        context "with #{msg_type} message" do
+          let(:type) { msg_type }
 
-        consumer.consume
+          context 'without policy_id and not compliance service' do
+            it 'delegates to SystemImporter service only' do
+              expect(@system_importer_service).to receive(:import)
+              expect(Kafka::PolicySystemImporter).not_to receive(:new)
+              expect(Kafka::ReportParser).not_to receive(:new)
+
+              consumer.consume
+            end
+          end
+
+          context 'with policy_id' do
+            let(:message) do
+              super().deep_merge(
+                {
+                  'host' => {
+                    'system_profile' => {
+                      'image_builder' => {
+                        'compliance_policy_id' => 'policy_id'
+                      }
+                    }
+                  }
+                }
+              )
+            end
+
+            it 'delegates to SystemImporter and PolicySystemImporter' do
+              policy_importer_service = instance_double(Kafka::PolicySystemImporter)
+              allow(Kafka::PolicySystemImporter).to receive(:new).and_return(policy_importer_service)
+
+              expect(@system_importer_service).to receive(:import)
+              expect(policy_importer_service).to receive(:import)
+              expect(Kafka::ReportParser).not_to receive(:new)
+
+              consumer.consume
+            end
+          end
+
+          context 'with compliance service' do
+            let(:message) do
+              super().deep_merge(
+                {
+                  'platform_metadata' => {
+                    'service' => 'compliance'
+                  }
+                }
+              )
+            end
+
+            it 'delegates to SystemImporter and ReportParser' do
+              report_parser_service = instance_double(Kafka::ReportParser)
+              allow(Kafka::ReportParser).to receive(:new).and_return(report_parser_service)
+
+              expect(@system_importer_service).to receive(:import)
+              expect(report_parser_service).to receive(:parse_reports)
+              expect(Kafka::PolicySystemImporter).not_to receive(:new)
+
+              consumer.consume
+            end
+          end
+        end
       end
     end
-  end
 
-  describe 'routing to the appropriate service' do
-    before do
-      @service = instance_double(service_class)
-      allow(service_class).to receive(:new).and_return(@service)
-    end
-
-    context 'received compliance message' do
-      let(:service_class) { Kafka::ReportParser }
-      let(:type) { 'updated' }
+    context 'when message is for compliance service but unknown type' do
+      let(:type) { 'unknown_type' }
       let(:message) do
         super().deep_merge(
           {
@@ -114,71 +138,14 @@ describe InventoryEventsConsumer do
         )
       end
 
-      it 'delegates to ReportParser service' do
-        allow(@service).to receive(:parse_reports)
+      it 'delegates to ReportParser and skips SystemImporter' do
+        report_parser_service = instance_double(Kafka::ReportParser)
+        allow(Kafka::ReportParser).to receive(:new).and_return(report_parser_service)
 
-        expect(@service).to receive(:parse_reports)
-
-        consumer.consume
-      end
-    end
-
-    context 'received delete message' do
-      let(:service_class) { Kafka::DeletedSystemCleaner }
-      let(:type) { 'delete' }
-
-      it 'delegates to DeletedSystemCleaner service' do
-        allow(@service).to receive(:cleanup_system)
-
-        expect(@service).to receive(:cleanup_system)
+        expect(report_parser_service).to receive(:parse_reports)
+        expect(Kafka::SystemImporter).not_to receive(:new)
 
         consumer.consume
-      end
-    end
-
-    context 'receives message with a policy ID' do
-      let(:service_class) { Kafka::PolicySystemImporter }
-      let(:message) do
-        super().deep_merge(
-          {
-            'host' => {
-              'system_profile' => {
-                'image_builder' => {
-                  'compliance_policy_id' => 'policy_id'
-                }
-              }
-            }
-          }
-        )
-      end
-
-      before do
-        @system_importer_service = instance_double(Kafka::SystemImporter)
-        allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
-        allow(@system_importer_service).to receive(:import)
-        allow(@service).to receive(:import)
-      end
-
-      context 'message is created' do
-        let(:type) { 'created' }
-
-        it 'delegates to both PolicySystemImporter and SystemImporter services' do
-          expect(@service).to receive(:import)
-          expect(@system_importer_service).to receive(:import)
-
-          consumer.consume
-        end
-      end
-
-      context 'message is updated' do
-        let(:type) { 'updated' }
-
-        it 'delegates to both PolicySystemImporter and SystemImporter services' do
-          expect(@service).to receive(:import)
-          expect(@system_importer_service).to receive(:import)
-
-          consumer.consume
-        end
       end
     end
   end

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -44,9 +44,8 @@ describe InventoryEventsConsumer do
       let(:type) { 'delete' }
 
       it 'delegates to DeletedSystemCleaner service' do
-        service = instance_double(Kafka::DeletedSystemCleaner)
-        allow(Kafka::DeletedSystemCleaner).to receive(:new).and_return(service)
-        expect(service).to receive(:cleanup_system)
+        expect(Kafka::DeletedSystemCleaner).to receive(:new).with(message, anything).and_call_original
+        expect_any_instance_of(Kafka::DeletedSystemCleaner).to receive(:cleanup_system)
 
         consumer.consume
       end
@@ -54,9 +53,7 @@ describe InventoryEventsConsumer do
 
     context 'when message is created or updated' do
       before do
-        @system_importer_service = instance_double(Kafka::SystemImporter)
-        allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
-        allow(@system_importer_service).to receive(:import)
+        allow_any_instance_of(Kafka::SystemImporter).to receive(:import)
       end
 
       %w[created updated].each do |msg_type|
@@ -65,7 +62,9 @@ describe InventoryEventsConsumer do
 
           context 'without policy_id and not compliance service' do
             it 'delegates to SystemImporter service only' do
-              expect(@system_importer_service).to receive(:import)
+              expect(Kafka::SystemImporter).to receive(:new).with(message, anything).and_call_original
+              expect_any_instance_of(Kafka::SystemImporter).to receive(:import)
+
               expect(Kafka::PolicySystemImporter).not_to receive(:new)
               expect(Kafka::ReportParser).not_to receive(:new)
 
@@ -89,11 +88,12 @@ describe InventoryEventsConsumer do
             end
 
             it 'delegates to SystemImporter and PolicySystemImporter' do
-              policy_importer_service = instance_double(Kafka::PolicySystemImporter)
-              allow(Kafka::PolicySystemImporter).to receive(:new).and_return(policy_importer_service)
+              expect(Kafka::SystemImporter).to receive(:new).with(message, anything).and_call_original
+              expect_any_instance_of(Kafka::SystemImporter).to receive(:import)
 
-              expect(@system_importer_service).to receive(:import)
-              expect(policy_importer_service).to receive(:import)
+              expect(Kafka::PolicySystemImporter).to receive(:new).with(message, anything).and_call_original
+              expect_any_instance_of(Kafka::PolicySystemImporter).to receive(:import)
+
               expect(Kafka::ReportParser).not_to receive(:new)
 
               consumer.consume
@@ -112,11 +112,12 @@ describe InventoryEventsConsumer do
             end
 
             it 'delegates to SystemImporter and ReportParser' do
-              report_parser_service = instance_double(Kafka::ReportParser)
-              allow(Kafka::ReportParser).to receive(:new).and_return(report_parser_service)
+              expect(Kafka::SystemImporter).to receive(:new).with(message, anything).and_call_original
+              expect_any_instance_of(Kafka::SystemImporter).to receive(:import)
 
-              expect(@system_importer_service).to receive(:import)
-              expect(report_parser_service).to receive(:parse_reports)
+              expect(Kafka::ReportParser).to receive(:new).with(message, anything).and_call_original
+              expect_any_instance_of(Kafka::ReportParser).to receive(:parse_reports)
+
               expect(Kafka::PolicySystemImporter).not_to receive(:new)
 
               consumer.consume
@@ -139,10 +140,9 @@ describe InventoryEventsConsumer do
       end
 
       it 'delegates to ReportParser and skips SystemImporter' do
-        report_parser_service = instance_double(Kafka::ReportParser)
-        allow(Kafka::ReportParser).to receive(:new).and_return(report_parser_service)
+        expect(Kafka::ReportParser).to receive(:new).with(message, anything).and_call_original
+        expect_any_instance_of(Kafka::ReportParser).to receive(:parse_reports)
 
-        expect(report_parser_service).to receive(:parse_reports)
         expect(Kafka::SystemImporter).not_to receive(:new)
 
         consumer.consume

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -51,19 +51,33 @@ describe InventoryEventsConsumer do
       )
     end
 
-    it 'logs a debug message and skips processing' do
-      expect(Karafka.logger).to receive(:debug).with("Skipped message of type '#{type}'")
+    before do
+      @system_importer_service = instance_double(Kafka::SystemImporter)
+      allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
+      allow(@system_importer_service).to receive(:import)
+    end
+
+    it 'delegates to SystemImporter service and skips PolicySystemImporter' do
+      expect(@system_importer_service).to receive(:import)
+      expect(Kafka::PolicySystemImporter).not_to receive(:new)
 
       consumer.consume
     end
   end
 
   describe 'handling messages without policy ID' do
+    before do
+      @system_importer_service = instance_double(Kafka::SystemImporter)
+      allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
+      allow(@system_importer_service).to receive(:import)
+    end
+
     context 'message is created' do
       let(:type) { 'created' }
 
-      it 'logs a debug message and skips processing' do
-        expect(Karafka.logger).to receive(:debug).with("Skipped message of type '#{type}'")
+      it 'delegates to SystemImporter service but not PolicySystemImporter' do
+        expect(@system_importer_service).to receive(:import)
+        expect(Kafka::PolicySystemImporter).not_to receive(:new)
 
         consumer.consume
       end
@@ -72,8 +86,9 @@ describe InventoryEventsConsumer do
     context 'message is updated' do
       let(:type) { 'updated' }
 
-      it 'logs a debug message and skips processing' do
-        expect(Karafka.logger).to receive(:debug).with("Skipped message of type '#{type}'")
+      it 'delegates to SystemImporter service but not PolicySystemImporter' do
+        expect(@system_importer_service).to receive(:import)
+        expect(Kafka::PolicySystemImporter).not_to receive(:new)
 
         consumer.consume
       end
@@ -137,13 +152,19 @@ describe InventoryEventsConsumer do
         )
       end
 
+      before do
+        @system_importer_service = instance_double(Kafka::SystemImporter)
+        allow(Kafka::SystemImporter).to receive(:new).and_return(@system_importer_service)
+        allow(@system_importer_service).to receive(:import)
+        allow(@service).to receive(:import)
+      end
+
       context 'message is created' do
         let(:type) { 'created' }
 
-        it 'delegates to PolicySystemImporter service' do
-          allow(@service).to receive(:import)
-
+        it 'delegates to both PolicySystemImporter and SystemImporter services' do
           expect(@service).to receive(:import)
+          expect(@system_importer_service).to receive(:import)
 
           consumer.consume
         end
@@ -152,10 +173,9 @@ describe InventoryEventsConsumer do
       context 'message is updated' do
         let(:type) { 'updated' }
 
-        it 'delegates to PolicySystemImporter service' do
-          allow(@service).to receive(:import)
-
+        it 'delegates to both PolicySystemImporter and SystemImporter services' do
           expect(@service).to receive(:import)
+          expect(@system_importer_service).to receive(:import)
 
           consumer.consume
         end

--- a/spec/factories/kafka_system.rb
+++ b/spec/factories/kafka_system.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :kafka_system, parent: :system, class: 'KafkaSystem' do
+    # Override account association since KafkaSystem uses a string account, not a relation
+    account { Faker::Number.number(digits: 5).to_s }
+    org_id { Faker::Number.number(digits: 6).to_s }
+
+    # Disable the after(:create) callbacks from the parent :system factory
+    # because KafkaSystem does not have policy_systems or test_results associations
+    after(:create) { |sys, ev| }
+  end
+end

--- a/spec/factories/kafka_system.rb
+++ b/spec/factories/kafka_system.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :kafka_system, parent: :system, class: 'KafkaSystem' do
-    # Override account association since KafkaSystem uses a string account, not a relation
+  factory :kafka_system, class: 'KafkaSystem' do
+    id { Faker::Internet.uuid }
     account { Faker::Number.number(digits: 5).to_s }
     org_id { Faker::Number.number(digits: 6).to_s }
-
-    # Disable the after(:create) callbacks from the parent :system factory
-    # because KafkaSystem does not have policy_systems or test_results associations
-    after(:create) { |sys, ev| }
+    display_name { Faker::Internet.domain_name }
+    stale_timestamp { 10.years.since(Time.zone.now) }
+    updated { Time.zone.now }
+    created { Time.zone.now }
+    tags { [] }
+    groups { [] }
+    system_profile { {} }
   end
 end

--- a/spec/services/kafka/deleted_system_cleaner_spec.rb
+++ b/spec/services/kafka/deleted_system_cleaner_spec.rb
@@ -35,7 +35,8 @@ describe Kafka::DeletedSystemCleaner do
   context 'with multiple systems under a policy' do
     let(:extra_system) { FactoryBot.create(:system, account: user.account, policy_id: policy.id, os_minor_version: 0) }
     let!(:extra_kafka_system) do
-      FactoryBot.create(:kafka_system, id: extra_system.id, account: '12345', org_id: org_id)
+      FactoryBot.create(:kafka_system, id: extra_system.id, account: Faker::Number.number(digits: 5).to_s,
+                                       org_id: org_id)
     end
     let!(:extra_test_result) { FactoryBot.create(:v2_test_result, system: extra_system, report_id: policy.id) }
 

--- a/spec/services/kafka/deleted_system_cleaner_spec.rb
+++ b/spec/services/kafka/deleted_system_cleaner_spec.rb
@@ -25,13 +25,11 @@ describe Kafka::DeletedSystemCleaner do
       "[#{org_id}] Deleted related records for System #{system.id}"
     )
 
-    # rubocop:disable Layout/MultilineMethodCallIndentation
-    expect do
-      service.cleanup_system
-    end.to change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
-       .and(change { policy.systems.count }.from(1).to(0))
-       .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
-    # rubocop:enable Layout/MultilineMethodCallIndentation
+    expect { service.cleanup_system }.to(
+      change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
+      .and(change { policy.systems.count }.from(1).to(0))
+      .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
+    )
   end
 
   context 'with multiple systems under a policy' do
@@ -46,13 +44,11 @@ describe Kafka::DeletedSystemCleaner do
         "[#{org_id}] Deleted related records for System #{system.id}"
       )
 
-      # rubocop:disable Layout/MultilineMethodCallIndentation
-      expect do
-        service.cleanup_system
-      end.to change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
-         .and(change { policy.systems.count }.from(2).to(1))
-         .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
-      # rubocop:enable Layout/MultilineMethodCallIndentation
+      expect { service.cleanup_system }.to(
+        change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
+        .and(change { policy.systems.count }.from(2).to(1))
+        .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
+      )
 
       expect(V2::HistoricalTestResult.where(system_id: extra_system.id).count).to eql(1)
       expect(KafkaSystem.where(id: extra_system.id).count).to eql(1)

--- a/spec/services/kafka/deleted_system_cleaner_spec.rb
+++ b/spec/services/kafka/deleted_system_cleaner_spec.rb
@@ -75,6 +75,11 @@ describe Kafka::DeletedSystemCleaner do
       expect do
         service.cleanup_system
       end.not_to(change { KafkaSystem.count })
+
+      # Ensure it doesn't try to delete the view either
+      expect do
+        service.cleanup_system
+      end.not_to(change { V2::System.count })
     end
   end
 

--- a/spec/services/kafka/deleted_system_cleaner_spec.rb
+++ b/spec/services/kafka/deleted_system_cleaner_spec.rb
@@ -10,6 +10,7 @@ describe Kafka::DeletedSystemCleaner do
   let(:org_id) { user.org_id }
   let(:policy) { FactoryBot.create(:v2_policy, account: user.account, supports_minors: [0]) }
   let(:system) { FactoryBot.create(:system, account: user.account, policy_id: policy.id, os_minor_version: 0) }
+  let!(:kafka_system) { FactoryBot.create(:kafka_system, id: system.id, account: '12345', org_id: org_id) }
   let!(:test_result) { FactoryBot.create(:v2_test_result, system: system, report_id: policy.id) }
   let(:message) do
     {
@@ -24,14 +25,20 @@ describe Kafka::DeletedSystemCleaner do
       "[#{org_id}] Deleted related records for System #{system.id}"
     )
 
+    # rubocop:disable Layout/MultilineMethodCallIndentation
     expect do
       service.cleanup_system
     end.to change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
-       .and change { policy.systems.count }.from(1).to(0)
+       .and(change { policy.systems.count }.from(1).to(0))
+       .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
+    # rubocop:enable Layout/MultilineMethodCallIndentation
   end
 
   context 'with multiple systems under a policy' do
     let(:extra_system) { FactoryBot.create(:system, account: user.account, policy_id: policy.id, os_minor_version: 0) }
+    let!(:extra_kafka_system) do
+      FactoryBot.create(:kafka_system, id: extra_system.id, account: '12345', org_id: org_id)
+    end
     let!(:extra_test_result) { FactoryBot.create(:v2_test_result, system: extra_system, report_id: policy.id) }
 
     it 'performs and logs cleanup for the specific system' do
@@ -39,12 +46,16 @@ describe Kafka::DeletedSystemCleaner do
         "[#{org_id}] Deleted related records for System #{system.id}"
       )
 
+      # rubocop:disable Layout/MultilineMethodCallIndentation
       expect do
         service.cleanup_system
       end.to change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
-         .and change { policy.systems.count }.from(2).to(1)
+         .and(change { policy.systems.count }.from(2).to(1))
+         .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
+      # rubocop:enable Layout/MultilineMethodCallIndentation
 
       expect(V2::HistoricalTestResult.where(system_id: extra_system.id).count).to eql(1)
+      expect(KafkaSystem.where(id: extra_system.id).count).to eql(1)
     end
   end
 
@@ -61,7 +72,9 @@ describe Kafka::DeletedSystemCleaner do
     it 'does not perform cleanup and does not log' do
       expect(Karafka.logger).not_to receive(:audit_success)
 
-      service.cleanup_system
+      expect do
+        service.cleanup_system
+      end.not_to(change { KafkaSystem.count })
     end
   end
 

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Kafka::SystemImporter do
+  let(:logger) { instance_double('Logger', info: true, error: true) }
+  let(:message) do
+    {
+      'host' => {
+        'id' => SecureRandom.uuid,
+        'account' => Faker::Number.number(digits: 5).to_s,
+        'org_id' => Faker::Number.number(digits: 6).to_s,
+        'display_name' => Faker::Internet.domain_word,
+        'groups' => [],
+        'tags' => [],
+        'system_profile' => {},
+        'stale_timestamp' => Time.now.utc.iso8601,
+        'created' => (Time.now.utc - 1.day).iso8601,
+        'updated' => Time.now.utc.iso8601,
+        'insights_id' => SecureRandom.uuid
+      }
+    }
+  end
+
+  subject { described_class.new(message, logger) }
+
+  describe '#import' do
+    context 'when payload is invalid (missing id)' do
+      before { message['host'].delete('id') }
+
+      it 'ignores the message and logs an error' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+      end
+    end
+
+    context 'when payload is invalid (malformed tags)' do
+      before { message['host']['tags'] = ['string_tag_not_hash'] }
+
+      it 'ignores the message and logs an error' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+      end
+    end
+
+    context 'when system is new' do
+      it 'upserts system' do
+        expect { subject.import }.to change { KafkaSystem.count }.by(1)
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Imported system/)
+      end
+    end
+
+    context 'when message is an update to an existing system' do
+      let!(:existing_system) do
+        system = FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id'],
+          display_name: 'old-name'
+        )
+        system.update!(updated: (Time.now.utc - 2.days).iso8601)
+        system
+      end
+
+      it 'updates the existing system attributes' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.display_name).to eq(message.dig('host', 'display_name'))
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Imported system/)
+      end
+    end
+
+    context 'when message is exactly the same age (repeated message)' do
+      let!(:existing_system) do
+        system = FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id'],
+          display_name: 'old-name'
+        )
+        system.update!(updated: message['host']['updated'])
+        system
+      end
+
+      it 'ignores the repeated message' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.display_name).to eq('old-name') # prove it was not updated
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+      end
+    end
+
+    context 'when message is strictly stale (older than DB)' do
+      before do
+        system = FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id']
+        )
+        system.update!(updated: (Time.now.utc + 1.day).iso8601)
+      end
+
+      it 'ignores the stale message' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+      end
+    end
+
+    context 'when payload lacks optional fields like groups' do
+      before { message['host'].delete('groups') }
+
+      it 'upserts using fallback defaults' do
+        subject.import
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.groups).to eq([])
+      end
+    end
+
+    context 'when exception occurs' do
+      before do
+        allow(KafkaSystem).to receive(:upsert).and_raise(ActiveRecord::ActiveRecordError, 'db down')
+      end
+
+      it 'logs error and re-raises it' do
+        expect { subject.import }.to raise_error(ActiveRecord::ActiveRecordError, 'db down')
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Failed to import system.*db down/)
+      end
+    end
+
+    context 'when payload is entirely empty' do
+      let(:message) { {} }
+
+      it 'ignores the message and logs an error' do
+        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+      end
+    end
+
+    context 'when payload is flat (no host key)' do
+      let(:message) do
+        {
+          'id' => SecureRandom.uuid,
+          'account' => Faker::Number.number(digits: 5).to_s,
+          'org_id' => Faker::Number.number(digits: 6).to_s,
+          'display_name' => Faker::Internet.domain_word,
+          'tags' => [],
+          'system_profile' => {},
+          'stale_timestamp' => Time.now.utc.iso8601,
+          'created' => (Time.now.utc - 1.day).iso8601,
+          'updated' => Time.now.utc.iso8601
+        }
+      end
+
+      it 'upserts the system correctly by falling back to root message' do
+        expect { subject.import }.to change { KafkaSystem.count }.by(1)
+        system = KafkaSystem.find(message['id'])
+        expect(system.account).to eq(message['account'])
+        expect(system.groups).to eq([])
+      end
+    end
+
+    # Empty context removed
+
+    context 'when message has nil updated timestamp' do
+      let(:message) do
+        {
+          'host' => {
+            'id' => SecureRandom.uuid,
+            'account' => '12345',
+            'org_id' => 'org123',
+            'display_name' => 'test-host',
+            'groups' => [],
+            'tags' => [],
+            'system_profile' => {},
+            'stale_timestamp' => Time.now.utc.iso8601,
+            'created' => (Time.now.utc - 1.day).iso8601,
+            'updated' => nil,
+            'insights_id' => SecureRandom.uuid
+          }
+        }
+      end
+
+      it 'catches DB validation error during upsert due to NOT NULL constraint' do
+        expect { subject.import }.to raise_error(ActiveRecord::NotNullViolation)
+        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Failed to import system/)
+      end
+    end
+  end
+end

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Kafka::SystemImporter do
-  let(:logger) { instance_double('Logger', info: true, error: true) }
+  let(:updated_time) { Time.now.utc.iso8601 }
   let(:message) do
     {
       'host' => {
@@ -14,23 +14,23 @@ RSpec.describe Kafka::SystemImporter do
         'groups' => [],
         'tags' => [],
         'system_profile' => {},
-        'stale_timestamp' => Time.now.utc.iso8601,
+        'stale_timestamp' => updated_time,
         'created' => (Time.now.utc - 1.day).iso8601,
-        'updated' => Time.now.utc.iso8601,
+        'updated' => updated_time,
         'insights_id' => SecureRandom.uuid
       }
     }
   end
 
-  subject { described_class.new(message, logger) }
+  let(:service) { described_class.new(message, Karafka.logger) }
 
   describe '#import' do
     context 'when payload is invalid (missing id)' do
       before { message['host'].delete('id') }
 
       it 'ignores the message and logs an error' do
-        expect { subject.import }.not_to(change { KafkaSystem.count })
-        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+        expect(Karafka.logger).to receive(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+        expect { service.import }.not_to(change { KafkaSystem.count })
       end
     end
 
@@ -38,70 +38,68 @@ RSpec.describe Kafka::SystemImporter do
       before { message['host']['tags'] = ['string_tag_not_hash'] }
 
       it 'ignores the message and logs an error' do
-        expect { subject.import }.not_to(change { KafkaSystem.count })
-        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+        expect(Karafka.logger).to receive(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
+        expect { service.import }.not_to(change { KafkaSystem.count })
       end
     end
 
     context 'when system is new' do
       it 'upserts system' do
-        expect { subject.import }.to change { KafkaSystem.count }.by(1)
-        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Imported system/)
+        expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
+        expect { service.import }.to change { KafkaSystem.count }.by(1)
       end
     end
 
     context 'when message is an update to an existing system' do
       let!(:existing_system) do
-        system = FactoryBot.create(
+        FactoryBot.create(
           :kafka_system,
           id: message['host']['id'],
-          display_name: 'old-name'
+          display_name: 'old-name',
+          updated: (Time.zone.parse(updated_time) - 2.days).iso8601
         )
-        system.update!(updated: (Time.now.utc - 2.days).iso8601)
-        system
       end
 
       it 'updates the existing system attributes' do
-        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
+        expect { service.import }.not_to(change { KafkaSystem.count })
 
         system = KafkaSystem.find(message['host']['id'])
         expect(system.display_name).to eq(message.dig('host', 'display_name'))
-        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Imported system/)
       end
     end
 
     context 'when message is exactly the same age (repeated message)' do
       let!(:existing_system) do
-        system = FactoryBot.create(
+        FactoryBot.create(
           :kafka_system,
           id: message['host']['id'],
-          display_name: 'old-name'
+          display_name: 'old-name',
+          updated: updated_time
         )
-        system.update!(updated: message['host']['updated'])
-        system
       end
 
       it 'ignores the repeated message' do
-        expect { subject.import }.not_to(change { KafkaSystem.count })
+        expect(Karafka.logger).to receive(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+        expect { service.import }.not_to(change { KafkaSystem.count })
 
         system = KafkaSystem.find(message['host']['id'])
-        expect(system.display_name).to eq('old-name') # prove it was not updated
-        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+        expect(system.display_name).to eq('old-name')
       end
     end
 
     context 'when message is strictly stale (older than DB)' do
       before do
-        system = FactoryBot.create(
+        FactoryBot.create(
           :kafka_system,
-          id: message['host']['id']
+          id: message['host']['id'],
+          updated: (Time.zone.parse(updated_time) + 1.day).iso8601
         )
-        system.update!(updated: (Time.now.utc + 1.day).iso8601)
       end
 
       it 'ignores the stale message' do
-        expect { subject.import }.not_to(change { KafkaSystem.count })
-        expect(logger).to have_received(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+        expect(Karafka.logger).to receive(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+        expect { service.import }.not_to(change { KafkaSystem.count })
       end
     end
 
@@ -109,7 +107,7 @@ RSpec.describe Kafka::SystemImporter do
       before { message['host'].delete('groups') }
 
       it 'upserts using fallback defaults' do
-        subject.import
+        service.import
         system = KafkaSystem.find(message['host']['id'])
         expect(system.groups).to eq([])
       end
@@ -121,44 +119,12 @@ RSpec.describe Kafka::SystemImporter do
       end
 
       it 'logs error and re-raises it' do
-        expect { subject.import }.to raise_error(ActiveRecord::ActiveRecordError, 'db down')
-        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Failed to import system.*db down/)
+        expect(Karafka.logger)
+          .to receive(:audit_fail)
+          .with(/\[Kafka::SystemImporter\] Failed to import system.*db down/)
+        expect { service.import }.to raise_error(ActiveRecord::ActiveRecordError, 'db down')
       end
     end
-
-    context 'when payload is entirely empty' do
-      let(:message) { {} }
-
-      it 'ignores the message and logs an error' do
-        expect { subject.import }.not_to(change { KafkaSystem.count })
-        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
-      end
-    end
-
-    context 'when payload is flat (no host key)' do
-      let(:message) do
-        {
-          'id' => SecureRandom.uuid,
-          'account' => Faker::Number.number(digits: 5).to_s,
-          'org_id' => Faker::Number.number(digits: 6).to_s,
-          'display_name' => Faker::Internet.domain_word,
-          'tags' => [],
-          'system_profile' => {},
-          'stale_timestamp' => Time.now.utc.iso8601,
-          'created' => (Time.now.utc - 1.day).iso8601,
-          'updated' => Time.now.utc.iso8601
-        }
-      end
-
-      it 'upserts the system correctly by falling back to root message' do
-        expect { subject.import }.to change { KafkaSystem.count }.by(1)
-        system = KafkaSystem.find(message['id'])
-        expect(system.account).to eq(message['account'])
-        expect(system.groups).to eq([])
-      end
-    end
-
-    # Empty context removed
 
     context 'when message has nil updated timestamp' do
       let(:message) do
@@ -171,7 +137,7 @@ RSpec.describe Kafka::SystemImporter do
             'groups' => [],
             'tags' => [],
             'system_profile' => {},
-            'stale_timestamp' => Time.now.utc.iso8601,
+            'stale_timestamp' => updated_time,
             'created' => (Time.now.utc - 1.day).iso8601,
             'updated' => nil,
             'insights_id' => SecureRandom.uuid
@@ -180,8 +146,8 @@ RSpec.describe Kafka::SystemImporter do
       end
 
       it 'catches DB validation error during upsert due to NOT NULL constraint' do
-        expect { subject.import }.to raise_error(ActiveRecord::NotNullViolation)
-        expect(logger).to have_received(:error).with(/\[Kafka::SystemImporter\] Failed to import system/)
+        expect(Karafka.logger).to receive(:audit_fail).with(/\[Kafka::SystemImporter\] Failed to import system/)
+        expect { service.import }.to raise_error(ActiveRecord::NotNullViolation)
       end
     end
   end


### PR DESCRIPTION
## Description
  Implements the Kafka consumer logic for Inventory `created`, `updated`, and `delete` events to populate and
clean up the `systems` table, replacing the legacy Cyndi replication.

### Key Changes
  - **Model:** Added `KafkaSystem` to safely write to the `systems` table (bypassing the read-only
`V2::System` view during migration).
  - **Service (Upsert):** Created `Kafka::SystemImporter` to map event fields and perform safe `upsert`
operations.
  - **Service (Delete):** Enhanced `Kafka::DeletedSystemCleaner` to explicitly delete `KafkaSystem` records
alongside related `V2::HistoricalTestResult` and `V2::TestResult` (with its cascaded `V2::RuleResult` records).
  - **Transaction Safety:** Wrapped the deletion flow in an `ActiveRecord::Base.transaction` to ensure atomic
cleanup.
  - **Routing:** `InventoryEventsConsumer` routes `created`/`updated` events to `SystemImporter` (and
`PolicySystemImporter` when a policy ID is present), and `delete` events to the enhanced `DeletedSystemCleaner`.
  - **Protection:** Added staleness checks (drops out-of-order messages based on `updated` timestamp) and
graceful error handling to prevent Karafka loop crashes.
  - **Testing:** Added a dedicated `kafka_system` factory and comprehensive RSpec coverage for creation,
updating, and deletion cascades.

## Jira Issue
  - [RHINENG-23280](https://issues.redhat.com/browse/RHINENG-23280)
  - [RHINENG-23282](https://issues.redhat.com/browse/RHINENG-23282)

## AI/LLM Usage
  This PR was authored with the assistance of an AI coding agent (Claude 3.7 Sonnet via pi/unipi) to scaffold
the `Kafka::SystemImporter` upsert logic, the `KafkaSystem` temporary model, inventory event routing,
transaction-safe deletion cascades in `Kafka::DeletedSystemCleaner`, and comprehensive RSpec test suites
including factory setups. All AI output was reviewed, tested, and modified by the human author.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practice


[RHINENG-23280]: https://redhat.atlassian.net/browse/RHINENG-23280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Routed Inventory Kafka `created`/`updated` events to a new temporary `KafkaSystem` ingest path via `Kafka::SystemImporter` (while `policy_id` payloads still go through `Kafka::PolicySystemImporter`).
- Updated `InventoryEventsConsumer` dispatch logic to separate `created`/`updated` handling from other message types (including compliance report parsing).
- Added `Kafka::SystemImporter` to validate payload shape, perform timestamp-aware/deduped upserts into `systems`, and log + re-raise on import failures.
- Enhanced `Kafka::DeletedSystemCleaner` to fully clean up on Inventory `delete` by deleting `KafkaSystem` plus related `V2::HistoricalTestResult`/`V2::TestResult` and cascaded `V2::RuleResult` records, wrapped in an atomic transaction.
- Expanded RSpec coverage with a new `kafka_system` factory to cover create/update/delete flows and importer staleness/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->