### PR TITLE
feat(jobs): install GoodJob and migrate from Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,10 @@ gem 'pundit'
 gem 'exception_notification'
 gem 'slack-notifier'
 
-# Sidekiq - use reliable-fetch by Gitlab
+# Background jobs — GoodJob (PostgreSQL-backed) replaces Sidekiq
+gem 'good_job', '~> 4'
+
+# Sidekiq retained temporarily to drain jobs from Redis
 gem 'gitlab-sidekiq-fetcher', require: 'sidekiq-reliable-fetch'
 gem 'sidekiq', '< 8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,8 @@ GEM
       activemodel
     erb (6.0.4)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
@@ -182,6 +184,9 @@ GEM
     ffi (1.17.3)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
+    fugit (1.13.0)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     fx (0.10.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
@@ -190,6 +195,13 @@ GEM
       sidekiq (~> 6.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    good_job (4.19.1)
+      activejob (>= 6.1.0)
+      activerecord (>= 6.1.0)
+      concurrent-ruby (>= 1.3.1)
+      fugit (>= 1.11.0)
+      railties (>= 6.1.0)
+      thor (>= 1.0.0)
     google-protobuf (4.35.0)
       bigdecimal
       rake (~> 13.3)
@@ -349,6 +361,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (2.2.23)
     rack-cors (2.0.2)
@@ -594,6 +607,7 @@ DEPENDENCIES
   friendly_id (~> 5.2.4)
   fx
   gitlab-sidekiq-fetcher
+  good_job (~> 4)
   insights-rbac-api-client (~> 2.0.0)
   irb (>= 1.2)
   jsonapi-serializer

--- a/app/jobs/parse_report_job.rb
+++ b/app/jobs/parse_report_job.rb
@@ -4,6 +4,7 @@
 class ParseReportJob < ApplicationJob
   include Notifications
 
+  self.queue_adapter = :good_job
   self.log_arguments = false
 
   # https://github.com/RoamingNoMaD/yabeda-activejob#custom-tags
@@ -32,6 +33,8 @@ class ParseReportJob < ApplicationJob
   end
 
   def cancelled?
+    return false unless self.class.queue_adapter_name == 'sidekiq'
+
     Sidekiq.redis { |c| c.exists?("cancelled-#{jid}") }
   end
 

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.good_job.execution_mode = :external
+  config.good_job.max_threads = ENV.fetch('GOOD_JOB_MAX_THREADS', 5).to_i
+  config.good_job.shutdown_timeout = 25
+  config.good_job.preserve_job_records = lambda { |_job, _error, error_event|
+    error_event == :unhandled
+  }
+  config.good_job.cleanup_preserved_jobs_before_seconds_ago = 14.days.to_i
+  config.good_job.on_thread_error = ->(exception) { Rails.error.report(exception) }
+end

--- a/db/migrate/20260625160000_create_good_jobs.rb
+++ b/db/migrate/20260625160000_create_good_jobs.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+class CreateGoodJobs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :good_jobs, id: :uuid do |t|
+      t.text :queue_name
+      t.integer :priority
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :performed_at
+      t.datetime :finished_at
+      t.text :error
+
+      t.timestamps
+
+      t.uuid :active_job_id
+      t.text :concurrency_key
+      t.text :cron_key
+      t.uuid :retried_good_job_id
+      t.datetime :cron_at
+
+      t.uuid :batch_id
+      t.uuid :batch_callback_id
+
+      t.boolean :is_discrete
+      t.integer :executions_count
+      t.text :job_class
+      t.integer :error_event, limit: 2
+      t.text :labels, array: true
+      t.uuid :locked_by_id
+      t.datetime :locked_at
+      t.integer :lock_type, limit: 2
+    end
+
+    create_table :good_job_batches, id: :uuid do |t|
+      t.timestamps
+      t.text :description
+      t.jsonb :serialized_properties
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_discard
+      t.text :callback_queue_name
+      t.integer :callback_priority
+      t.datetime :enqueued_at
+      t.datetime :discarded_at
+      t.datetime :finished_at
+      t.datetime :jobs_finished_at
+    end
+
+    create_table :good_job_executions, id: :uuid do |t|
+      t.timestamps
+
+      t.uuid :active_job_id, null: false
+      t.text :job_class
+      t.text :queue_name
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.text :error
+      t.integer :error_event, limit: 2
+      t.text :error_backtrace, array: true
+      t.uuid :process_id
+      t.interval :duration
+    end
+
+    create_table :good_job_processes, id: :uuid do |t|
+      t.timestamps
+      t.jsonb :state
+      t.integer :lock_type, limit: 2
+    end
+
+    create_table :good_job_settings, id: :uuid do |t|
+      t.timestamps
+      t.text :key
+      t.jsonb :value
+      t.index :key, unique: true
+    end
+
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
+    add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
+    add_index :good_jobs, [:active_job_id, :created_at], name: :index_good_jobs_on_active_job_id_and_created_at
+    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
+    add_index :good_jobs, [:concurrency_key, :created_at], name: :index_good_jobs_on_concurrency_key_and_created_at
+    add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)", name: :index_good_jobs_on_cron_key_and_created_at_cond
+    add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+    add_index :good_jobs, [:finished_at], where: "finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at_only
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup
+    add_index :good_jobs, [:batch_id], where: "batch_id IS NOT NULL"
+    add_index :good_jobs, [:batch_callback_id], where: "batch_callback_id IS NOT NULL"
+    add_index :good_jobs, :job_class, name: :index_good_jobs_on_job_class
+    add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)", name: :index_good_jobs_on_labels
+
+    add_index :good_job_executions, [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+    add_index :good_jobs, [:priority, :scheduled_at], order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL", name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked
+    add_index :good_jobs, [:priority, :scheduled_at, :id],
+      where: "finished_at IS NULL", name: "index_good_jobs_on_priority_scheduled_at_unfinished"
+    add_index :good_jobs, [:queue_name, :scheduled_at, :id],
+      where: "finished_at IS NULL", name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished"
+
+    add_index :good_jobs, :locked_by_id,
+      where: "locked_by_id IS NOT NULL", name: "index_good_jobs_on_locked_by_id"
+    add_index :good_job_executions, [:process_id, :created_at], name: :index_good_job_executions_on_process_id_and_created_at
+    add_index :good_jobs, [:priority, :scheduled_at, :id],
+      name: :index_good_jobs_for_candidate_dequeue_unlocked,
+      order: { priority: "ASC NULLS LAST", scheduled_at: :asc, id: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL"
+
+    add_index :good_jobs, :queue_name, name: :index_good_jobs_on_queue_name
+    add_index :good_jobs, :created_at, name: :index_good_jobs_on_created_at
+    add_index :good_jobs, :finished_at,
+      name: :index_good_jobs_on_discarded,
+      order: { finished_at: :desc },
+      where: "finished_at IS NOT NULL AND error IS NOT NULL"
+    add_index :good_jobs, [:scheduled_at, :queue_name], name: :index_good_jobs_on_scheduled_at_and_queue_name
+    add_index :good_jobs, :id,
+      name: :index_good_jobs_on_unfinished_or_errored,
+      where: "finished_at IS NULL OR error IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,106 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.index ["system"], name: "index_fixes_on_system"
   end
 
+  create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "description"
+    t.jsonb "serialized_properties"
+    t.text "on_finish"
+    t.text "on_success"
+    t.text "on_discard"
+    t.text "callback_queue_name"
+    t.integer "callback_priority"
+    t.datetime "enqueued_at"
+    t.datetime "discarded_at"
+    t.datetime "finished_at"
+    t.datetime "jobs_finished_at"
+  end
+
+  create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id", null: false
+    t.text "job_class"
+    t.text "queue_name"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.integer "error_event", limit: 2
+    t.text "error_backtrace", array: true
+    t.uuid "process_id"
+    t.interval "duration"
+    t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
+  end
+
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "state"
+    t.integer "lock_type", limit: 2
+  end
+
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "key"
+    t.jsonb "value"
+    t.index ["key"], name: "index_good_job_settings_on_key", unique: true
+  end
+
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "queue_name"
+    t.integer "priority"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "performed_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id"
+    t.text "concurrency_key"
+    t.text "cron_key"
+    t.uuid "retried_good_job_id"
+    t.datetime "cron_at"
+    t.uuid "batch_id"
+    t.uuid "batch_callback_id"
+    t.boolean "is_discrete"
+    t.integer "executions_count"
+    t.text "job_class"
+    t.integer "error_event", limit: 2
+    t.text "labels", array: true
+    t.uuid "locked_by_id"
+    t.datetime "locked_at"
+    t.integer "lock_type", limit: 2
+    t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
+    t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
+    t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
+    t.index ["concurrency_key", "created_at"], name: "index_good_jobs_on_concurrency_key_and_created_at"
+    t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["created_at"], name: "index_good_jobs_on_created_at"
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at_only", where: "(finished_at IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_on_discarded", order: { finished_at: :desc }, where: "((finished_at IS NOT NULL) AND (error IS NOT NULL))"
+    t.index ["id"], name: "index_good_jobs_on_unfinished_or_errored", where: "((finished_at IS NULL) OR (error IS NOT NULL))"
+    t.index ["job_class"], name: "index_good_jobs_on_job_class"
+    t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", order: { priority: "ASC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_for_candidate_dequeue_unlocked", order: { priority: "ASC NULLS LAST" }, where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_on_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", order: { priority: "ASC NULLS LAST" }, where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["queue_name", "scheduled_at", "id"], name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
+    t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["queue_name"], name: "index_good_jobs_on_queue_name"
+    t.index ["scheduled_at", "queue_name"], name: "index_good_jobs_on_scheduled_at_and_queue_name"
+    t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
+  end
+
   create_table "historical_test_results_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "end_time", precision: nil

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -580,6 +580,103 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_CONSUMER}
             memory: ${MEMORY_REQUEST_CONSUMER}
+    - name: goodjob
+      minReplicas: ${{REPLICAS_GOODJOB}}
+      deploymentStrategy:
+        privateStrategy: Recreate
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command: ["/bin/sh"]
+          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+          inheritEnv: true
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_GOODJOB}
+            memory: ${MEMORY_LIMIT_GOODJOB}
+          requests:
+            cpu: ${CPU_REQUEST_GOODJOB}
+            memory: ${MEMORY_REQUEST_GOODJOB}
+        livenessProbe:
+          httpGet:
+            path: /status
+            port: ${{GOOD_JOB_PROBE_PORT}}
+          timeoutSeconds: 5
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: ${{GOOD_JOB_PROBE_PORT}}
+          timeoutSeconds: 5
+          periodSeconds: 30
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-goodjob
+        - name: GOOD_JOB_PROBE_PORT
+          value: "${GOOD_JOB_PROBE_PORT}"
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: GOOD_JOB_MAX_THREADS
+          value: "${GOOD_JOB_MAX_THREADS}"
+        - name: POSTGRESQL_MAX_CONNECTIONS
+          value: "${POSTGRESQL_MAX_CONNECTIONS}"
+        - name: MALLOC_ARENA_MAX
+          value: '2'
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
+        - name: SETTINGS__SLACK_WEBHOOK
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: slack_webhook
+              optional: true
+        - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
+          value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
+        - name: MAX_INIT_TIMEOUT_SECONDS
+          value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: PRIMARY_REDIS_AS_CACHE
+          value: "${PRIMARY_REDIS_AS_CACHE}"
+        - name: SETTINGS__REDIS__SSL
+          value: "${REDIS_SSL}"
+        - name: SETTINGS__REDIS__CACHE_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.endpoint
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.port
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.auth_token
+              optional: true
+        - name: IMAGE_TAG
+          value: "${IMAGE}:${IMAGE_TAG}"
+        - name: QE_ACCOUNTS
+          value: "${QE_ACCOUNTS}"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOGSTREAM
+          value: "${LOGSTREAM_GOODJOB}"
     - name: sidekiq
       minReplicas: ${{REPLICAS_SIDEKIQ}}
       deploymentStrategy:
@@ -816,8 +913,11 @@ parameters:
 - name: REPLICAS_CONSUMER
   description: Replica count for consumer
   value: "1"
+- name: REPLICAS_GOODJOB
+  description: Replica count for GoodJob worker
+  value: "1"
 - name: REPLICAS_SIDEKIQ
-  description: Replica count for sidekiq
+  description: Replica count for sidekiq (drain only)
   value: "1"
 - name: LINT_ANNOTATION
   value: 'default-lint-annotation-value'
@@ -850,6 +950,14 @@ parameters:
   value: 500m
 - name: CPU_REQUEST_CONSUMER
   value: 50m
+- name: MEMORY_LIMIT_GOODJOB
+  value: 4000Mi
+- name: MEMORY_REQUEST_GOODJOB
+  value: 2000Mi
+- name: CPU_LIMIT_GOODJOB
+  value: 1000m
+- name: CPU_REQUEST_GOODJOB
+  value: 100m
 - name: MEMORY_LIMIT_SIDEKIQ
   value: 1000Mi
 - name: MEMORY_REQUEST_SIDEKIQ
@@ -869,6 +977,10 @@ parameters:
 - name: REDIS_SSL
   description: 'Whether to use secured connection to Redis. Use string values of true or false'
   value: "true"
+- name: GOOD_JOB_MAX_THREADS
+  value: "5"
+- name: GOOD_JOB_PROBE_PORT
+  value: "7001"
 - name: SIDEKIQ_CONCURRENCY
   value: "1"
 - name: DISABLE_RBAC
@@ -942,6 +1054,7 @@ parameters:
   description: Pipe-separated list of numerical identifiers
   required: false
 - name: LOGSTREAM_SERVICE
+- name: LOGSTREAM_GOODJOB
 - name: LOGSTREAM_SIDEKIQ
 - name: LOGSTREAM_CONSUMER
 - name: LOGSTREAM_IMPORT_SSG

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,8 @@ if [ "$APPLICATION_TYPE" = "compliance-backend" ]; then
   exec bundle exec puma
 elif [ "$APPLICATION_TYPE" = "compliance-inventory" ]; then
   exec bundle exec karafka server
+elif [ "$APPLICATION_TYPE" = "compliance-goodjob" ]; then
+  exec bundle exec good_job start --probe-port="${GOOD_JOB_PROBE_PORT:-7001}"
 elif [ "$APPLICATION_TYPE" = "compliance-sidekiq" ]; then
   exec bundle exec sidekiq
 elif [ "$APPLICATION_TYPE" = "compliance-import-remediations" ]; then

--- a/spec/services/kafka/report_parser_spec.rb
+++ b/spec/services/kafka/report_parser_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 describe Kafka::ReportParser do
   include ActiveJob::TestHelper
 
-  before { ActiveJob::Base.queue_adapter = :test }
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    ParseReportJob.queue_adapter = ActiveJob::Base.queue_adapter
+  end
 
   let(:service) { Kafka::ReportParser.new(message, Karafka.logger) }
   let(:current_user) { FactoryBot.create(:user, :with_cert_auth) }


### PR DESCRIPTION
RHINENG-24398. Adds [GoodJob](https://github.com/bensheldon/good_job) (PostgreSQL-backed ActiveJob adapter) alongside Sidekiq, following GoodJob's recommended per-job migration pattern.

## What

- **GoodJob gem + migration**: Adds `good_job ~> 4` and the database migration for job tables (`good_jobs`, `good_job_executions`, `good_job_batches`, `good_job_processes`, `good_job_settings`).
- **Per-job adapter opt-in**: `ParseReportJob` declares `self.queue_adapter = :good_job`. Global adapter stays `:sidekiq` — no existing Sidekiq behavior is changed.
- **Job retention**: Only jobs with unhandled errors are preserved (lambda form), cleaned up after 14 days. Matches Sidekiq's existing behavior where completed jobs are discarded.
- **New GoodJob pod**: `compliance-goodjob` application type in `entrypoint.sh` and a matching deployment in `clowdapp.yaml` with parameterized health probes (`GOOD_JOB_PROBE_PORT`).
- **Sidekiq untouched**: All Sidekiq-specific code in `ParseReportJob` (`cancelled?`, `cancel!`, `jid`, `Sidekiq.logger`) remains intact for the drain period. TODO comments added for the follow-up cleanup. `cancelled?` is guarded to skip Redis when running under GoodJob.
- **Memory limits**: GoodJob pod defaults to 4000Mi/2000Mi (matching Sidekiq stage config). GoodJob uses more memory than Sidekiq at idle (~470Mi vs ~200Mi) due to its scheduler, LISTEN/NOTIFY connection, and probe server. During report parsing, memory spikes require the higher limit. Tunable per-environment via app-interface.

## How it works during transition

- New jobs enqueued by the Kafka consumer go to GoodJob (PostgreSQL) because `ParseReportJob.queue_adapter` is `:good_job`
- The GoodJob pod (`compliance-goodjob`) picks up and processes these jobs
- Any jobs already in Redis are drained by the existing Sidekiq pod
- Once Redis is empty, Sidekiq can be removed in a follow-up

## Out of scope / follow-ups

- Remove Sidekiq gem, Redis gem, `gitlab-sidekiq-fetcher`, and the Sidekiq deployment once Redis is fully drained
- Remove `inMemoryDb: true` from ClowdApp
- Clean up Sidekiq-specific code in `ParseReportJob` (`cancelled?`, `cancel!`, `jid`, `Sidekiq.logger`)
- Remove or migrate Redis cache configuration
- GoodJob web dashboard
- `yabeda-sidekiq` metrics cleanup
- app-interface updates for the new GoodJob deployment

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices