### PR TITLE
fix(Konflux): revert hermetic builds

### DIFF
--- a/.tekton/compliance-backend-pull-request.yaml
+++ b/.tekton/compliance-backend-pull-request.yaml
@@ -38,13 +38,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
-  - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    value: '[{"type": "bundler", "path": "."}, {"type": "rpm", "path": "."}, {"type": "cargo", "path": ".hermetic_builds/cargo"}]'
-  - name: build-args
-    value:
-      - HERMETIC=true
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/compliance-backend-push.yaml
+++ b/.tekton/compliance-backend-push.yaml
@@ -26,13 +26,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
-  - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    value: '[{"type": "bundler", "path": "."}, {"type": "rpm", "path": "."}, {"type": "cargo", "path": ".hermetic_builds/cargo"}]'
-  - name: build-args
-    value:
-      - HERMETIC=true
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ARG extras=""
 ARG prod="true"
 ARG pgRepo="https://copr.fedorainfracloud.org/coprs/mmraka/postgresql-16/repo/epel-9/mmraka-postgresql-16-epel-9.repo"
 ARG BUNDLE_JOBS="4"
-ARG HERMETIC="false"
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:44bc70ef6e6ea9a70e353be97f4722e10358d09fbb9494ca943b2a641049690e AS build
 
@@ -15,7 +14,6 @@ ARG prod
 ARG pgRepo
 ARG IMAGE_TAG
 ARG BUNDLE_JOBS
-ARG HERMETIC
 
 USER 0
 
@@ -29,20 +27,21 @@ COPY ./.gemrc.prod /etc/gemrc
 COPY ./Gemfile.lock ./Gemfile /opt/app-root/src/
 COPY ./.hermetic_builds/cargo/config.toml .hermetic_builds/cargo/config.toml
 
-RUN ( [[ $HERMETIC == "true" ]] || microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $pgRepo ) && \
-    ( [[ $HERMETIC == "true" ]] || rpm -e --nodeps tzdata &>/dev/null )                                                             && \
-    microdnf module enable -y ruby:3.3                                                                    && \
-    microdnf install --nodocs -y $deps $devDeps $extras                                                   && \
-    chmod +t /tmp                                                                                         && \
-    ( [[ $HERMETIC != "true" ]] || (mkdir -p .cargo && cp .hermetic_builds/cargo/config.toml .cargo/config.toml) ) && \
-    ( [[ $prod != "true" ]] || bundle config set --local without 'development test' )                     && \
-    ( [[ $prod != "true" ]] || bundle config set --local deployment 'true' )                              && \
-    ( [[ $prod != "true" ]] || bundle config set --local path './.bundle' )                               && \
-    bundle config set --local retry '2'                                                                   && \
-    bundle config set --local force_ruby_platform true                                                    && \
-    bundle config set --local build.ffi --enable-system-libffi                                            && \
-    bundle install --jobs 6                                                                               && \
-    microdnf clean all -y                                                                                 && \
+RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $pgRepo) && \
+    rpm -e --nodeps tzdata &>/dev/null                                                            && \
+    microdnf module enable -y ruby:3.3                                                            && \
+    microdnf install --nodocs -y $deps $devDeps $extras                                           && \
+    chmod +t /tmp                                                                                 && \
+    gem update --system -N --install-dir=/usr/share/gems --bindir /usr/bin                        && \
+    gem install bundler                                                                           && \
+    ( [[ $prod != "true" ]] || bundle config set --local without 'development test' )             && \
+    ( [[ $prod != "true" ]] || bundle config set --local deployment 'true' )                      && \
+    ( [[ $prod != "true" ]] || bundle config set --local path './.bundle' )                       && \
+    bundle config set --local retry '2'                                                           && \
+    bundle config set --local force_ruby_platform true                                            && \
+    bundle config set --local build.ffi --enable-system-libffi                                    && \
+    bundle install --jobs 6                                                                       && \
+    microdnf clean all -y                                                                         && \
     ( [[ $prod != "true" ]] || bundle clean -V )
 
 LABEL BUILD_STAGE_OF=$IMAGE_TAG
@@ -55,20 +54,18 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:44bc70ef6e6ea9a70e353be9
 
 ARG deps
 ARG devDeps
-ARG HERMETIC
 
 WORKDIR /opt/app-root/src
 
 USER 0
 
-RUN ( [[ $HERMETIC == "true" ]] || rpm -e --nodeps tzdata &>/dev/null )                && \
-    microdnf module enable -y ruby:3.3                                                 && \
-    microdnf install --nodocs -y $deps                                                 && \
-    chmod +t /tmp                                                                      && \
-    ( [[ $HERMETIC == "true" ]] || gem update --system -N --install-dir=/usr/share/gems --bindir /usr/bin ) && \
-    ( [[ $HERMETIC == "true" ]] || gem install bundler )                               && \
-    microdnf clean all -y                                                              && \
-    chown 1001:root ./                                                                 && \
+RUN rpm -e --nodeps tzdata &>/dev/null                                     && \
+    microdnf module enable -y ruby:3.3                                     && \
+    microdnf install --nodocs -y $deps                                     && \
+    chmod +t /tmp                                                          && \
+    gem update --system -N --install-dir=/usr/share/gems --bindir /usr/bin && \
+    microdnf clean all -y                                                  && \
+    chown 1001:root ./                                                     && \
     install -v -d -m 1777 -o 1001 ./tmp ./log
 
 USER 1001


### PR DESCRIPTION
Reverts PRs:
- 2753
- 2822

This needs to be fixed in a PR separately so others are not blocked by it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Reverted hermetic build changes in Tekton compliance backend pull/push pipelines by removing hardcoded `hermetic`, `prefetch-input`, and `build-args` settings.
- Simplified the Dockerfile by removing `HERMETIC` build-arg logic and making the related package, tzdata, Ruby, and cargo setup steps always run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->