### PR TITLE
DO NOT MERGE - testing of CI ephemeral db behaviour

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -59,6 +59,35 @@ objects:
           join: "LEFT JOIN hbi.system_profiles_static sps ON sps.org_id = h.org_id AND sps.host_id = h.id"
           where: "sps.bootc_status->'booted'->>'image_digest' IS NULL"
     jobs:
+    - name: db-migrate
+      restartPolicy: OnFailure
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        command: ["/bin/sh", "-c"]
+        args: ["for i in {1..30}; do bundle exec rake db:migrate && exit 0; echo 'DB not ready, waiting...'; sleep 2; done; exit 1"]
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
+          requests:
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-db-migrate
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
     - name: import-ssg
       schedule: ${IMPORT_SSG_SCHEDULE}
       concurrencyPolicy: Forbid
@@ -591,6 +620,18 @@ objects:
               fieldPath: metadata.namespace
         - name: LOGSTREAM
           value: "${LOGSTREAM_SIDEKIQ}"
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    annotations:
+      clowder.redhat.com/expected-image-tag: ${IMAGE_TAG}
+    name: db-migrate-${IMAGE_TAG}
+  spec:
+    appName: "${APP_NAME}"
+    jobs:
+      - db-migrate
+    runOnNotReady: true
 
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -58,214 +58,214 @@ objects:
           if: "record.headers().lastWithName('is_bootc').value() == 'False'"
           join: "LEFT JOIN hbi.system_profiles_static sps ON sps.org_id = h.org_id AND sps.host_id = h.id"
           where: "sps.bootc_status->'booted'->>'image_digest' IS NULL"
-    jobs:
-    - name: import-ssg
-      schedule: ${IMPORT_SSG_SCHEDULE}
-      concurrencyPolicy: Forbid
-      podSpec:
-        image: ${IMAGE}:${IMAGE_TAG}
-        initContainers:
-        - command: ["/bin/sh"]
-          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
-          inheritEnv: true
-        resources:
-          limits:
-            cpu: ${CPU_LIMIT_IMPORT_SSG}
-            memory: ${MEMORY_LIMIT_IMPORT_SSG}
-          requests:
-            cpu: ${CPU_REQUEST_IMPORT_SSG}
-            memory: ${MEMORY_REQUEST_IMPORT_SSG}
-        env:
-        - name: APPLICATION_TYPE
-          value: compliance-import-ssg
-        - name: RAILS_ENV
-          value: "${RAILS_ENV}"
-        - name: RAILS_LOG_TO_STDOUT
-          value: "${RAILS_LOG_TO_STDOUT}"
-        - name: PATH_PREFIX
-          value: "${PATH_PREFIX}"
-        - name: RUBY_YJIT_ENABLE
-          value: "${RUBY_YJIT_ENABLE}"
-        - name: APP_NAME
-          value: "${APP_NAME}"
-        - name: SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              name: compliance-backend
-              key: secret_key_base
-        - name: SETTINGS__SLACK_WEBHOOK
-          valueFrom:
-            secretKeyRef:
-              name: compliance-backend
-              key: slack_webhook
-              optional: true
-        - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
-          value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
-        - name: SETTINGS__FORCE_IMPORT_SSGS
-          value: "${SETTINGS__FORCE_IMPORT_SSGS}"
-        - name: MAX_INIT_TIMEOUT_SECONDS
-          value: "${MAX_INIT_TIMEOUT_SECONDS}"
-        - name: SETTINGS__REDIS__SSL
-          value: "${REDIS_SSL}"
-        - name: PRIMARY_REDIS_AS_CACHE
-          value: "${PRIMARY_REDIS_AS_CACHE}"
-        - name: SETTINGS__REDIS__CACHE_HOSTNAME
-          valueFrom:
-            secretKeyRef:
-              name: compliance-rails-cache
-              key: db.endpoint
-              optional: true
-        - name: SETTINGS__REDIS__CACHE_PORT
-          valueFrom:
-            secretKeyRef:
-              name: compliance-rails-cache
-              key: db.port
-              optional: true
-        - name: SETTINGS__REDIS__CACHE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: compliance-rails-cache
-              key: db.auth_token
-              optional: true
-        - name: IMAGE_TAG
-          value: "${IMAGE}:${IMAGE_TAG}"
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: LOGSTREAM
-          value: "${LOGSTREAM_IMPORT_SSG}"
-        livenessProbe:
-          exec:
-            command: ["pgrep" ,"-f", "rake"]
-    - name: backfill-systems
-      schedule: ${BACKFILL_SYSTEMS_SCHEDULE}
-      concurrencyPolicy: Forbid
-      podSpec:
-        image: ${IMAGE}:${IMAGE_TAG}
-        initContainers:
-        - command: ["/bin/sh"]
-          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
-          inheritEnv: true
-        resources:
-          limits:
-            cpu: ${CPU_LIMIT_SERVICE}
-            memory: ${MEMORY_LIMIT_SERVICE}
-          requests:
-            cpu: ${CPU_REQUEST_SERVICE}
-            memory: ${MEMORY_REQUEST_SERVICE}
-        env:
-        - name: APPLICATION_TYPE
-          value: compliance-backfill-systems
-        - name: RAILS_ENV
-          value: "${RAILS_ENV}"
-        - name: RAILS_LOG_TO_STDOUT
-          value: "${RAILS_LOG_TO_STDOUT}"
-        - name: PATH_PREFIX
-          value: "${PATH_PREFIX}"
-        - name: RUBY_YJIT_ENABLE
-          value: "${RUBY_YJIT_ENABLE}"
-        - name: APP_NAME
-          value: "${APP_NAME}"
-        - name: BATCH_SIZE
-          value: "${BACKFILL_BATCH_SIZE}"
-        - name: MAX_ROWS_PER_RUN
-          value: "${BACKFILL_MAX_ROWS_PER_RUN}"
-        - name: SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              name: compliance-backend
-              key: secret_key_base
-        - name: MAX_INIT_TIMEOUT_SECONDS
-          value: "${MAX_INIT_TIMEOUT_SECONDS}"
-        - name: IMAGE_TAG
-          value: "${IMAGE}:${IMAGE_TAG}"
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: LOGSTREAM
-          value: "${LOGSTREAM_BACKFILL_SYSTEMS}"
-        livenessProbe:
-          exec:
-            command: ["pgrep" ,"-f", "rake"]
-    - name: reindex-db
-      schedule: ${REINDEX_DB_SCHEDULE}
-      concurrencyPolicy: Forbid
-      podSpec:
-        image: ${IMAGE}:${IMAGE_TAG}
-        initContainers:
-        - command: ["/bin/sh"]
-          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
-          inheritEnv: true
-        resources: # same limits and requests as for the service
-          limits:
-            cpu: ${CPU_LIMIT_SERVICE}
-            memory: ${MEMORY_LIMIT_SERVICE}
-          requests:
-            cpu: ${CPU_REQUEST_SERVICE}
-            memory: ${MEMORY_REQUEST_SERVICE}
-        env:
-        - name: APPLICATION_TYPE
-          value: compliance-reindex-db
-        - name: RAILS_ENV
-          value: "${RAILS_ENV}"
-        - name: RAILS_LOG_TO_STDOUT
-          value: "${RAILS_LOG_TO_STDOUT}"
-        - name: PATH_PREFIX
-          value: "${PATH_PREFIX}"
-        - name: RUBY_YJIT_ENABLE
-          value: "${RUBY_YJIT_ENABLE}"
-        - name: APP_NAME
-          value: "${APP_NAME}"
-        - name: SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              name: compliance-backend
-              key: secret_key_base
-        - name: SETTINGS__SLACK_WEBHOOK
-          valueFrom:
-            secretKeyRef:
-              name: compliance-backend
-              key: slack_webhook
-              optional: true
-        - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
-          value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
-        - name: MAX_INIT_TIMEOUT_SECONDS
-          value: "${MAX_INIT_TIMEOUT_SECONDS}"
-        - name: SETTINGS__REDIS__SSL
-          value: "${REDIS_SSL}"
-        - name: PRIMARY_REDIS_AS_CACHE
-          value: "${PRIMARY_REDIS_AS_CACHE}"
-        - name: SETTINGS__REDIS__CACHE_HOSTNAME
-          valueFrom:
-            secretKeyRef:
-              name: compliance-rails-cache
-              key: db.endpoint
-              optional: true
-        - name: SETTINGS__REDIS__CACHE_PORT
-          valueFrom:
-            secretKeyRef:
-              name: compliance-rails-cache
-              key: db.port
-              optional: true
-        - name: SETTINGS__REDIS__CACHE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: compliance-rails-cache
-              key: db.auth_token
-              optional: true
-        - name: IMAGE_TAG
-          value: "${IMAGE}:${IMAGE_TAG}"
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: LOGSTREAM
-          value: "${LOGSTREAM_REINDEX_DB}"
-        livenessProbe:
-          exec:
-            command: ["pgrep" ,"-f", "rake"]
+#     jobs:
+#     - name: import-ssg
+#       schedule: ${IMPORT_SSG_SCHEDULE}
+#       concurrencyPolicy: Forbid
+#       podSpec:
+#         image: ${IMAGE}:${IMAGE_TAG}
+#         initContainers:
+#         - command: ["/bin/sh"]
+#           args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+#           inheritEnv: true
+#         resources:
+#           limits:
+#             cpu: ${CPU_LIMIT_IMPORT_SSG}
+#             memory: ${MEMORY_LIMIT_IMPORT_SSG}
+#           requests:
+#             cpu: ${CPU_REQUEST_IMPORT_SSG}
+#             memory: ${MEMORY_REQUEST_IMPORT_SSG}
+#         env:
+#         - name: APPLICATION_TYPE
+#           value: compliance-import-ssg
+#         - name: RAILS_ENV
+#           value: "${RAILS_ENV}"
+#         - name: RAILS_LOG_TO_STDOUT
+#           value: "${RAILS_LOG_TO_STDOUT}"
+#         - name: PATH_PREFIX
+#           value: "${PATH_PREFIX}"
+#         - name: RUBY_YJIT_ENABLE
+#           value: "${RUBY_YJIT_ENABLE}"
+#         - name: APP_NAME
+#           value: "${APP_NAME}"
+#         - name: SECRET_KEY_BASE
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-backend
+#               key: secret_key_base
+#         - name: SETTINGS__SLACK_WEBHOOK
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-backend
+#               key: slack_webhook
+#               optional: true
+#         - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
+#           value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
+#         - name: SETTINGS__FORCE_IMPORT_SSGS
+#           value: "${SETTINGS__FORCE_IMPORT_SSGS}"
+#         - name: MAX_INIT_TIMEOUT_SECONDS
+#           value: "${MAX_INIT_TIMEOUT_SECONDS}"
+#         - name: SETTINGS__REDIS__SSL
+#           value: "${REDIS_SSL}"
+#         - name: PRIMARY_REDIS_AS_CACHE
+#           value: "${PRIMARY_REDIS_AS_CACHE}"
+#         - name: SETTINGS__REDIS__CACHE_HOSTNAME
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-rails-cache
+#               key: db.endpoint
+#               optional: true
+#         - name: SETTINGS__REDIS__CACHE_PORT
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-rails-cache
+#               key: db.port
+#               optional: true
+#         - name: SETTINGS__REDIS__CACHE_PASSWORD
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-rails-cache
+#               key: db.auth_token
+#               optional: true
+#         - name: IMAGE_TAG
+#           value: "${IMAGE}:${IMAGE_TAG}"
+#         - name: NAMESPACE
+#           valueFrom:
+#             fieldRef:
+#               fieldPath: metadata.namespace
+#         - name: LOGSTREAM
+#           value: "${LOGSTREAM_IMPORT_SSG}"
+#         livenessProbe:
+#           exec:
+#             command: ["pgrep" ,"-f", "rake"]
+#     - name: backfill-systems
+#       schedule: ${BACKFILL_SYSTEMS_SCHEDULE}
+#       concurrencyPolicy: Forbid
+#       podSpec:
+#         image: ${IMAGE}:${IMAGE_TAG}
+#         initContainers:
+#         - command: ["/bin/sh"]
+#           args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+#           inheritEnv: true
+#         resources:
+#           limits:
+#             cpu: ${CPU_LIMIT_SERVICE}
+#             memory: ${MEMORY_LIMIT_SERVICE}
+#           requests:
+#             cpu: ${CPU_REQUEST_SERVICE}
+#             memory: ${MEMORY_REQUEST_SERVICE}
+#         env:
+#         - name: APPLICATION_TYPE
+#           value: compliance-backfill-systems
+#         - name: RAILS_ENV
+#           value: "${RAILS_ENV}"
+#         - name: RAILS_LOG_TO_STDOUT
+#           value: "${RAILS_LOG_TO_STDOUT}"
+#         - name: PATH_PREFIX
+#           value: "${PATH_PREFIX}"
+#         - name: RUBY_YJIT_ENABLE
+#           value: "${RUBY_YJIT_ENABLE}"
+#         - name: APP_NAME
+#           value: "${APP_NAME}"
+#         - name: BATCH_SIZE
+#           value: "${BACKFILL_BATCH_SIZE}"
+#         - name: MAX_ROWS_PER_RUN
+#           value: "${BACKFILL_MAX_ROWS_PER_RUN}"
+#         - name: SECRET_KEY_BASE
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-backend
+#               key: secret_key_base
+#         - name: MAX_INIT_TIMEOUT_SECONDS
+#           value: "${MAX_INIT_TIMEOUT_SECONDS}"
+#         - name: IMAGE_TAG
+#           value: "${IMAGE}:${IMAGE_TAG}"
+#         - name: NAMESPACE
+#           valueFrom:
+#             fieldRef:
+#               fieldPath: metadata.namespace
+#         - name: LOGSTREAM
+#           value: "${LOGSTREAM_BACKFILL_SYSTEMS}"
+#         livenessProbe:
+#           exec:
+#             command: ["pgrep" ,"-f", "rake"]
+#     - name: reindex-db
+#       schedule: ${REINDEX_DB_SCHEDULE}
+#       concurrencyPolicy: Forbid
+#       podSpec:
+#         image: ${IMAGE}:${IMAGE_TAG}
+#         initContainers:
+#         - command: ["/bin/sh"]
+#           args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+#           inheritEnv: true
+#         resources: # same limits and requests as for the service
+#           limits:
+#             cpu: ${CPU_LIMIT_SERVICE}
+#             memory: ${MEMORY_LIMIT_SERVICE}
+#           requests:
+#             cpu: ${CPU_REQUEST_SERVICE}
+#             memory: ${MEMORY_REQUEST_SERVICE}
+#         env:
+#         - name: APPLICATION_TYPE
+#           value: compliance-reindex-db
+#         - name: RAILS_ENV
+#           value: "${RAILS_ENV}"
+#         - name: RAILS_LOG_TO_STDOUT
+#           value: "${RAILS_LOG_TO_STDOUT}"
+#         - name: PATH_PREFIX
+#           value: "${PATH_PREFIX}"
+#         - name: RUBY_YJIT_ENABLE
+#           value: "${RUBY_YJIT_ENABLE}"
+#         - name: APP_NAME
+#           value: "${APP_NAME}"
+#         - name: SECRET_KEY_BASE
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-backend
+#               key: secret_key_base
+#         - name: SETTINGS__SLACK_WEBHOOK
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-backend
+#               key: slack_webhook
+#               optional: true
+#         - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
+#           value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
+#         - name: MAX_INIT_TIMEOUT_SECONDS
+#           value: "${MAX_INIT_TIMEOUT_SECONDS}"
+#         - name: SETTINGS__REDIS__SSL
+#           value: "${REDIS_SSL}"
+#         - name: PRIMARY_REDIS_AS_CACHE
+#           value: "${PRIMARY_REDIS_AS_CACHE}"
+#         - name: SETTINGS__REDIS__CACHE_HOSTNAME
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-rails-cache
+#               key: db.endpoint
+#               optional: true
+#         - name: SETTINGS__REDIS__CACHE_PORT
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-rails-cache
+#               key: db.port
+#               optional: true
+#         - name: SETTINGS__REDIS__CACHE_PASSWORD
+#           valueFrom:
+#             secretKeyRef:
+#               name: compliance-rails-cache
+#               key: db.auth_token
+#               optional: true
+#         - name: IMAGE_TAG
+#           value: "${IMAGE}:${IMAGE_TAG}"
+#         - name: NAMESPACE
+#           valueFrom:
+#             fieldRef:
+#               fieldPath: metadata.namespace
+#         - name: LOGSTREAM
+#           value: "${LOGSTREAM_REINDEX_DB}"
+#         livenessProbe:
+#           exec:
+#             command: ["pgrep" ,"-f", "rake"]
     deployments:
     - name: service
       minReplicas: ${{REPLICAS_BACKEND}}
@@ -498,7 +498,7 @@ objects:
             cpu: ${CPU_REQUEST_CONSUMER}
             memory: ${MEMORY_REQUEST_CONSUMER}
     - name: sidekiq
-      minReplicas: ${{REPLICAS_SIDEKIQ}}
+      minReplicas: 0
       deploymentStrategy:
         privateStrategy: Recreate
       podSpec:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -58,214 +58,214 @@ objects:
           if: "record.headers().lastWithName('is_bootc').value() == 'False'"
           join: "LEFT JOIN hbi.system_profiles_static sps ON sps.org_id = h.org_id AND sps.host_id = h.id"
           where: "sps.bootc_status->'booted'->>'image_digest' IS NULL"
-#     jobs:
-#     - name: import-ssg
-#       schedule: ${IMPORT_SSG_SCHEDULE}
-#       concurrencyPolicy: Forbid
-#       podSpec:
-#         image: ${IMAGE}:${IMAGE_TAG}
-#         initContainers:
-#         - command: ["/bin/sh"]
-#           args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
-#           inheritEnv: true
-#         resources:
-#           limits:
-#             cpu: ${CPU_LIMIT_IMPORT_SSG}
-#             memory: ${MEMORY_LIMIT_IMPORT_SSG}
-#           requests:
-#             cpu: ${CPU_REQUEST_IMPORT_SSG}
-#             memory: ${MEMORY_REQUEST_IMPORT_SSG}
-#         env:
-#         - name: APPLICATION_TYPE
-#           value: compliance-import-ssg
-#         - name: RAILS_ENV
-#           value: "${RAILS_ENV}"
-#         - name: RAILS_LOG_TO_STDOUT
-#           value: "${RAILS_LOG_TO_STDOUT}"
-#         - name: PATH_PREFIX
-#           value: "${PATH_PREFIX}"
-#         - name: RUBY_YJIT_ENABLE
-#           value: "${RUBY_YJIT_ENABLE}"
-#         - name: APP_NAME
-#           value: "${APP_NAME}"
-#         - name: SECRET_KEY_BASE
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-backend
-#               key: secret_key_base
-#         - name: SETTINGS__SLACK_WEBHOOK
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-backend
-#               key: slack_webhook
-#               optional: true
-#         - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
-#           value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
-#         - name: SETTINGS__FORCE_IMPORT_SSGS
-#           value: "${SETTINGS__FORCE_IMPORT_SSGS}"
-#         - name: MAX_INIT_TIMEOUT_SECONDS
-#           value: "${MAX_INIT_TIMEOUT_SECONDS}"
-#         - name: SETTINGS__REDIS__SSL
-#           value: "${REDIS_SSL}"
-#         - name: PRIMARY_REDIS_AS_CACHE
-#           value: "${PRIMARY_REDIS_AS_CACHE}"
-#         - name: SETTINGS__REDIS__CACHE_HOSTNAME
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-rails-cache
-#               key: db.endpoint
-#               optional: true
-#         - name: SETTINGS__REDIS__CACHE_PORT
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-rails-cache
-#               key: db.port
-#               optional: true
-#         - name: SETTINGS__REDIS__CACHE_PASSWORD
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-rails-cache
-#               key: db.auth_token
-#               optional: true
-#         - name: IMAGE_TAG
-#           value: "${IMAGE}:${IMAGE_TAG}"
-#         - name: NAMESPACE
-#           valueFrom:
-#             fieldRef:
-#               fieldPath: metadata.namespace
-#         - name: LOGSTREAM
-#           value: "${LOGSTREAM_IMPORT_SSG}"
-#         livenessProbe:
-#           exec:
-#             command: ["pgrep" ,"-f", "rake"]
-#     - name: backfill-systems
-#       schedule: ${BACKFILL_SYSTEMS_SCHEDULE}
-#       concurrencyPolicy: Forbid
-#       podSpec:
-#         image: ${IMAGE}:${IMAGE_TAG}
-#         initContainers:
-#         - command: ["/bin/sh"]
-#           args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
-#           inheritEnv: true
-#         resources:
-#           limits:
-#             cpu: ${CPU_LIMIT_SERVICE}
-#             memory: ${MEMORY_LIMIT_SERVICE}
-#           requests:
-#             cpu: ${CPU_REQUEST_SERVICE}
-#             memory: ${MEMORY_REQUEST_SERVICE}
-#         env:
-#         - name: APPLICATION_TYPE
-#           value: compliance-backfill-systems
-#         - name: RAILS_ENV
-#           value: "${RAILS_ENV}"
-#         - name: RAILS_LOG_TO_STDOUT
-#           value: "${RAILS_LOG_TO_STDOUT}"
-#         - name: PATH_PREFIX
-#           value: "${PATH_PREFIX}"
-#         - name: RUBY_YJIT_ENABLE
-#           value: "${RUBY_YJIT_ENABLE}"
-#         - name: APP_NAME
-#           value: "${APP_NAME}"
-#         - name: BATCH_SIZE
-#           value: "${BACKFILL_BATCH_SIZE}"
-#         - name: MAX_ROWS_PER_RUN
-#           value: "${BACKFILL_MAX_ROWS_PER_RUN}"
-#         - name: SECRET_KEY_BASE
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-backend
-#               key: secret_key_base
-#         - name: MAX_INIT_TIMEOUT_SECONDS
-#           value: "${MAX_INIT_TIMEOUT_SECONDS}"
-#         - name: IMAGE_TAG
-#           value: "${IMAGE}:${IMAGE_TAG}"
-#         - name: NAMESPACE
-#           valueFrom:
-#             fieldRef:
-#               fieldPath: metadata.namespace
-#         - name: LOGSTREAM
-#           value: "${LOGSTREAM_BACKFILL_SYSTEMS}"
-#         livenessProbe:
-#           exec:
-#             command: ["pgrep" ,"-f", "rake"]
-#     - name: reindex-db
-#       schedule: ${REINDEX_DB_SCHEDULE}
-#       concurrencyPolicy: Forbid
-#       podSpec:
-#         image: ${IMAGE}:${IMAGE_TAG}
-#         initContainers:
-#         - command: ["/bin/sh"]
-#           args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
-#           inheritEnv: true
-#         resources: # same limits and requests as for the service
-#           limits:
-#             cpu: ${CPU_LIMIT_SERVICE}
-#             memory: ${MEMORY_LIMIT_SERVICE}
-#           requests:
-#             cpu: ${CPU_REQUEST_SERVICE}
-#             memory: ${MEMORY_REQUEST_SERVICE}
-#         env:
-#         - name: APPLICATION_TYPE
-#           value: compliance-reindex-db
-#         - name: RAILS_ENV
-#           value: "${RAILS_ENV}"
-#         - name: RAILS_LOG_TO_STDOUT
-#           value: "${RAILS_LOG_TO_STDOUT}"
-#         - name: PATH_PREFIX
-#           value: "${PATH_PREFIX}"
-#         - name: RUBY_YJIT_ENABLE
-#           value: "${RUBY_YJIT_ENABLE}"
-#         - name: APP_NAME
-#           value: "${APP_NAME}"
-#         - name: SECRET_KEY_BASE
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-backend
-#               key: secret_key_base
-#         - name: SETTINGS__SLACK_WEBHOOK
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-backend
-#               key: slack_webhook
-#               optional: true
-#         - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
-#           value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
-#         - name: MAX_INIT_TIMEOUT_SECONDS
-#           value: "${MAX_INIT_TIMEOUT_SECONDS}"
-#         - name: SETTINGS__REDIS__SSL
-#           value: "${REDIS_SSL}"
-#         - name: PRIMARY_REDIS_AS_CACHE
-#           value: "${PRIMARY_REDIS_AS_CACHE}"
-#         - name: SETTINGS__REDIS__CACHE_HOSTNAME
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-rails-cache
-#               key: db.endpoint
-#               optional: true
-#         - name: SETTINGS__REDIS__CACHE_PORT
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-rails-cache
-#               key: db.port
-#               optional: true
-#         - name: SETTINGS__REDIS__CACHE_PASSWORD
-#           valueFrom:
-#             secretKeyRef:
-#               name: compliance-rails-cache
-#               key: db.auth_token
-#               optional: true
-#         - name: IMAGE_TAG
-#           value: "${IMAGE}:${IMAGE_TAG}"
-#         - name: NAMESPACE
-#           valueFrom:
-#             fieldRef:
-#               fieldPath: metadata.namespace
-#         - name: LOGSTREAM
-#           value: "${LOGSTREAM_REINDEX_DB}"
-#         livenessProbe:
-#           exec:
-#             command: ["pgrep" ,"-f", "rake"]
+    jobs:
+    - name: import-ssg
+      schedule: ${IMPORT_SSG_SCHEDULE}
+      concurrencyPolicy: Forbid
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command: ["/bin/sh"]
+          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+          inheritEnv: true
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_IMPORT_SSG}
+            memory: ${MEMORY_LIMIT_IMPORT_SSG}
+          requests:
+            cpu: ${CPU_REQUEST_IMPORT_SSG}
+            memory: ${MEMORY_REQUEST_IMPORT_SSG}
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-import-ssg
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
+        - name: SETTINGS__SLACK_WEBHOOK
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: slack_webhook
+              optional: true
+        - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
+          value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
+        - name: SETTINGS__FORCE_IMPORT_SSGS
+          value: "${SETTINGS__FORCE_IMPORT_SSGS}"
+        - name: MAX_INIT_TIMEOUT_SECONDS
+          value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: SETTINGS__REDIS__SSL
+          value: "${REDIS_SSL}"
+        - name: PRIMARY_REDIS_AS_CACHE
+          value: "${PRIMARY_REDIS_AS_CACHE}"
+        - name: SETTINGS__REDIS__CACHE_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.endpoint
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.port
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.auth_token
+              optional: true
+        - name: IMAGE_TAG
+          value: "${IMAGE}:${IMAGE_TAG}"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOGSTREAM
+          value: "${LOGSTREAM_IMPORT_SSG}"
+        livenessProbe:
+          exec:
+            command: ["pgrep" ,"-f", "rake"]
+    - name: backfill-systems
+      schedule: ${BACKFILL_SYSTEMS_SCHEDULE}
+      concurrencyPolicy: Forbid
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command: ["/bin/sh"]
+          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+          inheritEnv: true
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
+          requests:
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-backfill-systems
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: BATCH_SIZE
+          value: "${BACKFILL_BATCH_SIZE}"
+        - name: MAX_ROWS_PER_RUN
+          value: "${BACKFILL_MAX_ROWS_PER_RUN}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
+        - name: MAX_INIT_TIMEOUT_SECONDS
+          value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: IMAGE_TAG
+          value: "${IMAGE}:${IMAGE_TAG}"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOGSTREAM
+          value: "${LOGSTREAM_BACKFILL_SYSTEMS}"
+        livenessProbe:
+          exec:
+            command: ["pgrep" ,"-f", "rake"]
+    - name: reindex-db
+      schedule: ${REINDEX_DB_SCHEDULE}
+      concurrencyPolicy: Forbid
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command: ["/bin/sh"]
+          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+          inheritEnv: true
+        resources: # same limits and requests as for the service
+          limits:
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
+          requests:
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-reindex-db
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
+        - name: SETTINGS__SLACK_WEBHOOK
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: slack_webhook
+              optional: true
+        - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
+          value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
+        - name: MAX_INIT_TIMEOUT_SECONDS
+          value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: SETTINGS__REDIS__SSL
+          value: "${REDIS_SSL}"
+        - name: PRIMARY_REDIS_AS_CACHE
+          value: "${PRIMARY_REDIS_AS_CACHE}"
+        - name: SETTINGS__REDIS__CACHE_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.endpoint
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.port
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.auth_token
+              optional: true
+        - name: IMAGE_TAG
+          value: "${IMAGE}:${IMAGE_TAG}"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOGSTREAM
+          value: "${LOGSTREAM_REINDEX_DB}"
+        livenessProbe:
+          exec:
+            command: ["pgrep" ,"-f", "rake"]
     deployments:
     - name: service
       minReplicas: ${{REPLICAS_BACKEND}}
@@ -498,7 +498,7 @@ objects:
             cpu: ${CPU_REQUEST_CONSUMER}
             memory: ${MEMORY_REQUEST_CONSUMER}
     - name: sidekiq
-      minReplicas: 0
+      minReplicas: ${{REPLICAS_SIDEKIQ}}
       deploymentStrategy:
         privateStrategy: Recreate
       podSpec:

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -2,28 +2,41 @@
 
 MAX_INIT_TIMEOUT_SECONDS=${MAX_INIT_TIMEOUT_SECONDS:-120}
 
+# Fetch the container name or hostname so we know who is logging
+POD_ID=$(hostname)
+
+log_time() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S.%3N')][$POD_ID] $1"
+}
+
 for ((i=1;i<=MAX_INIT_TIMEOUT_SECONDS;i++)); do
-    # Check if DB is pre-populated by verifying schema_migrations table
-    DB_STATE=$(bundle exec rails runner "
-      begin
-        if ActiveRecord::Base.connection.table_exists?('schema_migrations')
-          puts '[DB_STATE_CHECK] PRE_POPULATED_DB'
-        else
-          puts '[DB_STATE_CHECK] FRESH_DB'
-        end
-      rescue StandardError => e
-        puts '[DB_STATE_CHECK] PENDING_CONNECTION'
-      end
-    " 2>/dev/null)
+    log_time "=== Loop iteration $i ==="
+    
+    log_time "START db:debug"
+    bundle exec rake --trace db:debug
+    DB_DEBUG_EXIT=$?
+    log_time "DONE db:debug (exit $DB_DEBUG_EXIT)"
+    
+    log_time "START db:migrate"
+    bundle exec rake --trace db:migrate
+    DB_MIGRATE_EXIT=$?
+    log_time "DONE db:migrate (exit $DB_MIGRATE_EXIT)"
 
-    echo "$DB_STATE"
-
-    if [[ "$DB_STATE" != "[DB_STATE_CHECK] PENDING_CONNECTION" ]]; then
-        if bundle exec rake --trace db:debug db:migrate ssg:check_synced; then
+    if [ $DB_MIGRATE_EXIT -eq 0 ]; then
+        log_time "START ssg:check_synced"
+        bundle exec rake --trace ssg:check_synced
+        SSG_EXIT=$?
+        log_time "DONE ssg:check_synced (exit $SSG_EXIT)"
+        
+        if [ $SSG_EXIT -eq 0 ]; then
+            log_time "All init tasks succeeded. Exiting."
             exit 0
         fi
     fi
+
+    log_time "Tasks not fully synced/ready. Sleeping 1 second..."
     sleep 1
 done
 
+log_time "MAX_INIT_TIMEOUT_SECONDS reached. Exiting 1."
 exit 1

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -3,11 +3,29 @@
 MAX_INIT_TIMEOUT_SECONDS=${MAX_INIT_TIMEOUT_SECONDS:-120}
 
 for ((i=1;i<=MAX_INIT_TIMEOUT_SECONDS;i++)); do
-    if bundle exec rake --trace db:debug db:migrate ssg:check_synced; then
-        exit 0
-    else
-        sleep 1
+    # Check if DB is pre-populated by verifying schema_migrations table
+    DB_STATE=$(bundle exec ruby -e "
+      begin
+        require 'active_record'
+        ActiveRecord::Base.establish_connection
+        if ActiveRecord::Base.connection.table_exists?('schema_migrations')
+          puts '[DB_STATE_CHECK] PRE_POPULATED_DB'
+        else
+          puts '[DB_STATE_CHECK] FRESH_DB'
+        end
+      rescue StandardError => e
+        puts '[DB_STATE_CHECK] PENDING_CONNECTION'
+      end
+    " 2>/dev/null)
+
+    echo "$DB_STATE"
+
+    if [[ "$DB_STATE" != "[DB_STATE_CHECK] PENDING_CONNECTION" ]]; then
+        if bundle exec rake --trace db:debug db:migrate ssg:check_synced; then
+            exit 0
+        fi
     fi
+    sleep 1
 done
 
 exit 1

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -3,33 +3,11 @@
 MAX_INIT_TIMEOUT_SECONDS=${MAX_INIT_TIMEOUT_SECONDS:-120}
 
 for ((i=1;i<=MAX_INIT_TIMEOUT_SECONDS;i++)); do
-    echo "=== Loop iteration $i ==="
-    
-    echo "START db:debug"
-    bundle exec rake --trace db:debug
-    DB_DEBUG_EXIT=$?
-    echo "DONE db:debug (exit $DB_DEBUG_EXIT)"
-    
-    echo "START db:migrate"
-    bundle exec rake --trace db:migrate
-    DB_MIGRATE_EXIT=$?
-    echo "DONE db:migrate (exit $DB_MIGRATE_EXIT)"
-
-    if [ $DB_MIGRATE_EXIT -eq 0 ]; then
-        echo "START ssg:check_synced"
-        bundle exec rake --trace ssg:check_synced
-        SSG_EXIT=$?
-        echo "DONE ssg:check_synced (exit $SSG_EXIT)"
-        
-        if [ $SSG_EXIT -eq 0 ]; then
-            echo "All init tasks succeeded. Exiting."
-            exit 0
-        fi
+    if bundle exec rake --trace db:debug db:migrate ssg:check_synced; then
+        exit 0
+    else
+        sleep 1
     fi
-
-    echo "Tasks not fully synced/ready. Sleeping 1 second..."
-    sleep 1
 done
 
-echo "MAX_INIT_TIMEOUT_SECONDS reached. Exiting 1."
 exit 1

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -3,7 +3,7 @@
 MAX_INIT_TIMEOUT_SECONDS=${MAX_INIT_TIMEOUT_SECONDS:-120}
 
 for ((i=1;i<=MAX_INIT_TIMEOUT_SECONDS;i++)); do
-    if bundle exec rake --trace db:debug db:migrate ssg:check_synced; then
+    if bundle exec rake --trace db:debug db:abort_if_pending_migrations ssg:check_synced; then
         exit 0
     else
         sleep 1

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -4,10 +4,8 @@ MAX_INIT_TIMEOUT_SECONDS=${MAX_INIT_TIMEOUT_SECONDS:-120}
 
 for ((i=1;i<=MAX_INIT_TIMEOUT_SECONDS;i++)); do
     # Check if DB is pre-populated by verifying schema_migrations table
-    DB_STATE=$(bundle exec ruby -e "
+    DB_STATE=$(bundle exec rails runner "
       begin
-        require 'active_record'
-        ActiveRecord::Base.establish_connection
         if ActiveRecord::Base.connection.table_exists?('schema_migrations')
           puts '[DB_STATE_CHECK] PRE_POPULATED_DB'
         else

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -2,41 +2,34 @@
 
 MAX_INIT_TIMEOUT_SECONDS=${MAX_INIT_TIMEOUT_SECONDS:-120}
 
-# Fetch the container name or hostname so we know who is logging
-POD_ID=$(hostname)
-
-log_time() {
-    echo "[$(date +'%Y-%m-%d %H:%M:%S.%3N')][$POD_ID] $1"
-}
-
 for ((i=1;i<=MAX_INIT_TIMEOUT_SECONDS;i++)); do
-    log_time "=== Loop iteration $i ==="
+    echo "=== Loop iteration $i ==="
     
-    log_time "START db:debug"
+    echo "START db:debug"
     bundle exec rake --trace db:debug
     DB_DEBUG_EXIT=$?
-    log_time "DONE db:debug (exit $DB_DEBUG_EXIT)"
+    echo "DONE db:debug (exit $DB_DEBUG_EXIT)"
     
-    log_time "START db:migrate"
+    echo "START db:migrate"
     bundle exec rake --trace db:migrate
     DB_MIGRATE_EXIT=$?
-    log_time "DONE db:migrate (exit $DB_MIGRATE_EXIT)"
+    echo "DONE db:migrate (exit $DB_MIGRATE_EXIT)"
 
     if [ $DB_MIGRATE_EXIT -eq 0 ]; then
-        log_time "START ssg:check_synced"
+        echo "START ssg:check_synced"
         bundle exec rake --trace ssg:check_synced
         SSG_EXIT=$?
-        log_time "DONE ssg:check_synced (exit $SSG_EXIT)"
+        echo "DONE ssg:check_synced (exit $SSG_EXIT)"
         
         if [ $SSG_EXIT -eq 0 ]; then
-            log_time "All init tasks succeeded. Exiting."
+            echo "All init tasks succeeded. Exiting."
             exit 0
         fi
     fi
 
-    log_time "Tasks not fully synced/ready. Sleeping 1 second..."
+    echo "Tasks not fully synced/ready. Sleeping 1 second..."
     sleep 1
 done
 
-log_time "MAX_INIT_TIMEOUT_SECONDS reached. Exiting 1."
+echo "MAX_INIT_TIMEOUT_SECONDS reached. Exiting 1."
 exit 1

--- a/scripts/fetch_compliance_logs.sh
+++ b/scripts/fetch_compliance_logs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+# Ensure we are logged into oc and have a project selected
+if ! oc project &>/dev/null; then
+    echo "Error: Not logged into OpenShift or no project selected."
+    echo "Please run 'oc login' and 'oc project <project>' first."
+    exit 1
+fi
+
+CURRENT_PROJECT=$(oc project -q)
+echo "Current project: $CURRENT_PROJECT"
+
+# Ask user for source/context
+read -p "Enter source/context for these logs (e.g., jenkins, local-bonfire, no-sidekiq): " SOURCE
+if [[ -z "$SOURCE" ]]; then
+    SOURCE="unknown"
+fi
+
+# Create directory
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+OUT_DIR="$HOME/tmp/compliance-logs/${TIMESTAMP}-${SOURCE}"
+mkdir -p "$OUT_DIR"
+echo "Saving logs to: $OUT_DIR"
+
+# Find all compliance pods
+PODS=$(oc get pods -n "$CURRENT_PROJECT" -o name | grep "compliance")
+
+if [[ -z "$PODS" ]]; then
+    echo "No compliance pods found in project $CURRENT_PROJECT"
+    exit 0
+fi
+
+for POD in $PODS; do
+    POD_NAME=${POD#pod/}
+    echo "Fetching logs for pod: $POD_NAME"
+
+    # Get all containers in the pod (init containers + regular containers)
+    CONTAINERS=$(oc get pod "$POD_NAME" -n "$CURRENT_PROJECT" -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}{range .spec.containers[*]}{.name}{"\n"}{end}')
+
+    for CONTAINER in $CONTAINERS; do
+        LOG_FILE="$OUT_DIR/${POD_NAME}_${CONTAINER}.log"
+        echo "  -> Container: $CONTAINER"
+        
+        # Try fetching logs. If container hasn't started yet, oc logs might fail, so we ignore errors
+        oc logs "$POD_NAME" -c "$CONTAINER" -n "$CURRENT_PROJECT" > "$LOG_FILE" 2>/dev/null || echo "     (No logs available or container not started)"
+        
+        # Also grab previous logs if container restarted
+        PREV_LOG_FILE="$OUT_DIR/${POD_NAME}_${CONTAINER}_previous.log"
+        oc logs "$POD_NAME" -c "$CONTAINER" -n "$CURRENT_PROJECT" --previous > "$PREV_LOG_FILE" 2>/dev/null || rm -f "$PREV_LOG_FILE"
+    done
+done
+
+echo ""
+echo "Done! All logs saved to $OUT_DIR"
+
+TIMELINE_FILE="$OUT_DIR/00-merged-timeline.txt"
+echo "Creating merged timeline of init events..."
+# Extract our custom bash timestamp lines, which start with [2026- (or current year)
+# -h hides the filename prefix from grep so sort works strictly on the timestamp
+grep -h "^\[$(date +'%Y')" "$OUT_DIR"/*init.log | sort > "$TIMELINE_FILE"
+
+echo "Timeline saved to: $TIMELINE_FILE"
+ls -lh "$OUT_DIR"

--- a/scripts/fetch_compliance_logs.sh
+++ b/scripts/fetch_compliance_logs.sh
@@ -54,12 +54,14 @@ for POD in $PODS; do
         LOG_FILE="$OUT_DIR/${POD_NAME}_${CONTAINER}.log"
         echo "  -> Container: $CONTAINER"
         
-        # Try fetching logs. If container hasn't started yet, oc logs might fail, so we ignore errors
-        oc logs "$POD_NAME" -c "$CONTAINER" -n "$CURRENT_PROJECT" > "$LOG_FILE" 2>/dev/null || echo "     (No logs available or container not started)"
+        # Try fetching logs with strict timestamps
+        # We pipe to awk to inject the pod_name right after the timestamp so we know who logged it when we merge
+        # Format: 2026-06-26T14:50:42.123456Z [pod-name] original log line
+        oc logs "$POD_NAME" -c "$CONTAINER" -n "$CURRENT_PROJECT" --timestamps 2>/dev/null | awk -v pod="[$POD_NAME]" '{timestamp=$1; $1=""; print timestamp " " pod $0}' > "$LOG_FILE" || echo "     (No logs available or container not started)"
         
         # Also grab previous logs if container restarted
         PREV_LOG_FILE="$OUT_DIR/${POD_NAME}_${CONTAINER}_previous.log"
-        oc logs "$POD_NAME" -c "$CONTAINER" -n "$CURRENT_PROJECT" --previous > "$PREV_LOG_FILE" 2>/dev/null || rm -f "$PREV_LOG_FILE"
+        oc logs "$POD_NAME" -c "$CONTAINER" -n "$CURRENT_PROJECT" --previous --timestamps 2>/dev/null | awk -v pod="[$POD_NAME]" '{timestamp=$1; $1=""; print timestamp " " pod $0}' > "$PREV_LOG_FILE" || rm -f "$PREV_LOG_FILE"
     done
 done
 
@@ -67,10 +69,10 @@ echo ""
 echo "Done! All logs saved to $OUT_DIR"
 
 TIMELINE_FILE="$OUT_DIR/00-merged-timeline.txt"
-echo "Creating merged timeline of init events..."
-# Extract our custom bash timestamp lines, which start with [2026- (or current year)
-# -h hides the filename prefix from grep so sort works strictly on the timestamp
-grep -h "^\[$(date +'%Y')" "$OUT_DIR"/*init.log | sort > "$TIMELINE_FILE"
+echo "Creating merged timeline of all init events..."
+# Because all lines now start with the standard ISO8601 timestamp (e.g. 2026-06-26T...),
+# we can just cat all init logs and sort them. We use -h in grep (or just cat) to avoid filename prefixes.
+cat "$OUT_DIR"/*init.log 2>/dev/null | sort > "$TIMELINE_FILE"
 
 echo "Timeline saved to: $TIMELINE_FILE"
 ls -lh "$OUT_DIR"

--- a/scripts/fetch_compliance_logs.sh
+++ b/scripts/fetch_compliance_logs.sh
@@ -3,15 +3,25 @@
 # Exit on error
 set -e
 
-# Ensure we are logged into oc and have a project selected
-if ! oc project &>/dev/null; then
-    echo "Error: Not logged into OpenShift or no project selected."
-    echo "Please run 'oc login' and 'oc project <project>' first."
+# Ensure we are logged into oc
+if ! oc whoami &>/dev/null; then
+    echo "Error: Not logged into OpenShift."
+    echo "Please run 'oc login' first."
     exit 1
 fi
 
-CURRENT_PROJECT=$(oc project -q)
-echo "Current project: $CURRENT_PROJECT"
+if [ -n "$1" ]; then
+    CURRENT_PROJECT="$1"
+else
+    if ! oc project &>/dev/null; then
+        echo "Error: No project selected and no project provided."
+        echo "Usage: $0 [project_name]"
+        exit 1
+    fi
+    CURRENT_PROJECT=$(oc project -q)
+fi
+
+echo "Using project: $CURRENT_PROJECT"
 
 # Ask user for source/context
 read -p "Enter source/context for these logs (e.g., jenkins, local-bonfire, no-sidekiq): " SOURCE

--- a/scripts/fetch_compliance_logs.sh
+++ b/scripts/fetch_compliance_logs.sh
@@ -24,9 +24,12 @@ fi
 echo "Using project: $CURRENT_PROJECT"
 
 # Ask user for source/context
-read -p "Enter source/context for these logs (e.g., jenkins, local-bonfire, no-sidekiq): " SOURCE
-if [[ -z "$SOURCE" ]]; then
+read -p "Enter source/context for these logs (e.g., jenkins, local-bonfire, no-sidekiq): " RAW_SOURCE
+if [[ -z "$RAW_SOURCE" ]]; then
     SOURCE="unknown"
+else
+    # Slugify the input: convert to lowercase, replace non-alphanumeric chars with dashes, squeeze multiple dashes
+    SOURCE=$(echo "$RAW_SOURCE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/^-+|-+$//g')
 fi
 
 # Create directory


### PR DESCRIPTION
- **chore(db): detect and log db state before migrations**
- **chore(deploy): temporary simplification of clowdapp for db race condition testing**

DO NOT MERGE - testing

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added migration-state probing to init retry logic: `db:abort_if_pending_migrations` runs before `ssg:check_synced`, with bounded retries.
- Introduced a one-off `db-migrate` job in `deploy/clowdapp.yaml` to run `rake db:migrate` separately for race-condition testing.
- Updated init containers to wait for DB migrations to complete (instead of running migrations inline) to make CI behavior deterministic.
- Enhanced `scripts/fetch_compliance_logs.sh` to fetch timestamped OpenShift compliance pod logs (init/main/previous), tag pod names per line, and generate a merged sorted timeline for easier analysis.
- Added/triggered CI log collection for the ephemeral DB migration-race-condition testing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->