### PR TITLE
build(image): specify IoP image name for backend

### DIFF
--- a/.github/workflows/iop-container-publish.yaml
+++ b/.github/workflows/iop-container-publish.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: quay.io
-  IMAGE_NAME: "iop/compliance"
+  IMAGE_NAME: "iop/compliance-backend"
 
 jobs:
   build:


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated the iop container publish workflow to publish the backend-specific image name (`iop/compliance-backend`) instead of `iop/compliance`.
- Docker metadata/build-push now computes and uses tags for `quay.io/iop/compliance-backend` based on the updated `IMAGE_NAME`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->