### PR TITLE
fix(migration): remove dependency on model from old migration

### DIFF
--- a/db/migrate/20210609114653_add_cached_counts.rb
+++ b/db/migrate/20210609114653_add_cached_counts.rb
@@ -5,7 +5,7 @@ class AddCachedCounts < ActiveRecord::Migration[5.2]
     add_column :policies, :compliant_host_count, :integer, null: false, default: 0
     add_column :policies, :unsupported_host_count, :integer, null: false, default: 0
 
-    Policy.find_each(&:update_counters!)
+    # Policy.find_each(&:update_counters!)
   end
 
   def down


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Removed the old migration’s dependency on `Policy` by eliminating the cached host counters backfill/update step during `up`.
- The migration continues to add and remove the cached count columns, but no longer iterates existing policies to refresh those counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->