### PR TITLE
 feat(kafka): implement soft delete logic for inventory events [RHINENG-23282]

### DIFF
--- a/app/models/kafka_system.rb
+++ b/app/models/kafka_system.rb
@@ -3,4 +3,6 @@
 # Temporary model for ingesting inventory data directly to compliance db
 class KafkaSystem < ApplicationRecord
   self.table_name = 'systems'
+
+  default_scope { where(deleted_at: nil) }
 end

--- a/app/services/kafka/deleted_system_cleaner.rb
+++ b/app/services/kafka/deleted_system_cleaner.rb
@@ -44,7 +44,10 @@ module Kafka
     end
 
     def remove_kafka_system
-      KafkaSystem.where(id: @id).delete_all
+      timestamp = @message.dig('timestamp') || Time.current
+      # rubocop:disable Rails/SkipsModelValidations
+      KafkaSystem.where(id: @id).update_all(deleted_at: timestamp)
+      # rubocop:enable Rails/SkipsModelValidations
     end
 
     def audit_fail(error)

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -37,7 +37,7 @@ module Kafka
         display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
         tags: payload.dig('tags') || [], system_profile: payload.dig('system_profile'),
         stale_timestamp: payload.dig('stale_timestamp'), created: payload.dig('created'),
-        updated: updated, insights_id: payload.dig('insights_id')
+        updated: updated, insights_id: payload.dig('insights_id'), deleted_at: nil
       }
     end
 
@@ -50,7 +50,7 @@ module Kafka
         attrs,
         unique_by: :id,
         returning: %w[id],
-        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id WHERE systems.updated IS NULL OR systems.updated < EXCLUDED.updated')
+        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id, deleted_at = EXCLUDED.deleted_at WHERE (systems.updated IS NULL OR systems.updated < EXCLUDED.updated) AND (systems.deleted_at IS NULL OR EXCLUDED.updated > systems.deleted_at)')
       )
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations

--- a/spec/services/kafka/deleted_system_cleaner_spec.rb
+++ b/spec/services/kafka/deleted_system_cleaner_spec.rb
@@ -16,7 +16,8 @@ describe Kafka::DeletedSystemCleaner do
     {
       'type' => type,
       'id' => system.id,
-      'org_id' => org_id
+      'org_id' => org_id,
+      'timestamp' => Time.current.to_s
     }
   end
 
@@ -28,7 +29,7 @@ describe Kafka::DeletedSystemCleaner do
     expect { service.cleanup_system }.to(
       change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
       .and(change { policy.systems.count }.from(1).to(0))
-      .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
+      .and(change { KafkaSystem.unscoped.find(system.id).deleted_at }.from(nil))
     )
   end
 
@@ -48,11 +49,11 @@ describe Kafka::DeletedSystemCleaner do
       expect { service.cleanup_system }.to(
         change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
         .and(change { policy.systems.count }.from(2).to(1))
-        .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
+        .and(change { KafkaSystem.unscoped.find(system.id).deleted_at }.from(nil))
       )
 
       expect(V2::HistoricalTestResult.where(system_id: extra_system.id).count).to eql(1)
-      expect(KafkaSystem.where(id: extra_system.id).count).to eql(1)
+      expect(KafkaSystem.unscoped.find(extra_system.id).deleted_at).to be_nil
     end
   end
 

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -103,6 +103,46 @@ RSpec.describe Kafka::SystemImporter do
       end
     end
 
+    context 'when system is deleted and new create message arrives' do
+      let!(:existing_system) do
+        FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id'],
+          updated: (Time.zone.parse(updated_time) - 2.days).iso8601,
+          deleted_at: (Time.zone.parse(updated_time) - 1.day).iso8601
+        )
+      end
+
+      it 'recreates the system and clears deleted_at' do
+        expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
+        expect { service.import }.not_to(change { KafkaSystem.unscoped.count })
+
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.deleted_at).to be_nil
+        expect(system.display_name).to eq(message.dig('host', 'display_name'))
+      end
+    end
+
+    context 'when system is deleted and update message is older' do
+      let!(:existing_system) do
+        FactoryBot.create(
+          :kafka_system,
+          id: message['host']['id'],
+          updated: (Time.zone.parse(updated_time) - 2.days).iso8601,
+          deleted_at: (Time.zone.parse(updated_time) + 1.day).iso8601
+        )
+      end
+
+      it 'ignores the update and leaves system deleted' do
+        expect(Karafka.logger).to receive(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+        expect { service.import }.not_to(change { KafkaSystem.unscoped.count })
+
+        system = KafkaSystem.unscoped.find(message['host']['id'])
+        expect(system.deleted_at).not_to be_nil
+        expect(system.display_name).to eq(existing_system.display_name)
+      end
+    end
+
     context 'when payload lacks optional fields like groups' do
       before { message['host'].delete('groups') }
 


### PR DESCRIPTION
## Jira Issue
[RHINENG-23282](https://issues.redhat.com/browse/RHINENG-23282)

## Summary
Replace hard deletes with `deleted_at` tombstones. Prevent out-of-order `create`/`update` Kafka messages from incorrectly recreating deleted systems.

## Changes
- **`KafkaSystem`**: Add `default_scope { where(deleted_at: nil) }` to hide tombstoned records.
- **`DeletedSystemCleaner`**: Change `delete_all` to `update_all(deleted_at: timestamp)` using Kafka message
timestamp.
- **`SystemImporter`**: Update `upsert` SQL constraint. Prevent upsert if `EXCLUDED.updated <
systems.deleted_at`. Set `deleted_at = nil` on valid recreate.
- **Tests**: Add specs for out-of-order deletes and create-after-delete scenarios.

## AI/LLM Usage
This PR was authored with the assistance of an AI coding agent (Gemini 3.1 Pro Preview via pi/unipi) to
scaffold the soft delete logic, upsert collision modifications, and RSpec testing for tombstone/resurrection
scenarios. All AI output was reviewed, tested, and modified by the human author.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


[RHINENG-23282]: https://redhat.atlassian.net/browse/RHINENG-23282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added soft-delete handling for Kafka-backed systems by default-scoping `KafkaSystem` to active records only.
- Changed deleted-system cleanup to tombstone rows with `deleted_at` from the Kafka event timestamp instead of hard-deleting them.
- Updated system import upserts to preserve tombstones, ignore stale events, and clear `deleted_at` when a valid recreation arrives.
- Added/updated tests for soft-delete cleanup and out-of-order create/update/delete scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->