### PR TITLE
fix(Kafka): store only required system fields

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -2,6 +2,8 @@
 
 # Receives messages from the Kafka topic, dispatches them to the appropriate service
 class InventoryEventsConsumer < ApplicationConsumer
+  NON_INSIGHTS_ID = '00000000-0000-0000-0000-000000000000'
+
   def consume_one
     case message_type
     when 'delete'
@@ -16,7 +18,7 @@ class InventoryEventsConsumer < ApplicationConsumer
   private
 
   def handle_created_updated
-    Kafka::SystemImporter.new(payload, logger).import
+    Kafka::SystemImporter.new(payload, logger).import if importable_host?
     Kafka::PolicySystemImporter.new(payload, logger).import if policy_id
     Kafka::ReportParser.new(payload, logger).parse_reports if service == 'compliance'
   end
@@ -39,6 +41,23 @@ class InventoryEventsConsumer < ApplicationConsumer
 
   def message_type
     payload.dig('type')
+  end
+
+  def importable_host?
+    insights_host? && !excluded_host_type?
+  end
+
+  def insights_host?
+    insights_id = payload.dig('host', 'insights_id')
+    insights_id.present? && insights_id != NON_INSIGHTS_ID
+  end
+
+  def excluded_host_type?
+    profile = payload.dig('host', 'system_profile') || {}
+
+    profile['host_type'] == 'edge' ||
+      profile.dig('operating_system', 'name')&.match?(/centos/i) ||
+      profile.dig('bootc_status', 'booted', 'image_digest').present?
   end
 
   def policy_id

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -35,10 +35,17 @@ module Kafka
       {
         id: id, account: payload.dig('account'), org_id: payload.dig('org_id'),
         display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
-        tags: payload.dig('tags') || [], system_profile: payload.dig('system_profile'),
+        tags: payload.dig('tags') || [], system_profile: relevant_system_profile(payload),
         stale_timestamp: payload.dig('stale_timestamp'), created: payload.dig('created'),
         updated: updated, insights_id: payload.dig('insights_id')
       }
+    end
+
+    def relevant_system_profile(payload)
+      full_profile = payload.dig('system_profile')
+      return {} unless full_profile.is_a?(Hash)
+
+      full_profile.slice('operating_system', 'owner_id')
     end
 
     def upsert_system(id, payload, updated)

--- a/lib/tasks/systems_backfill.rake
+++ b/lib/tasks/systems_backfill.rake
@@ -67,8 +67,12 @@ class SystemsBackfiller
     <<-SQL
       WITH batch AS (
         SELECT h.id, h.account, h.org_id, h.display_name, h.tags, h.updated,
-               h.created, h.stale_timestamp, h.system_profile, h.groups,
-               h.insights_id
+               h.created, h.stale_timestamp,
+               jsonb_strip_nulls(jsonb_build_object(
+                 'operating_system', h.system_profile->'operating_system',
+                 'owner_id', h.system_profile->'owner_id'
+               )) AS system_profile,
+               h.groups, h.insights_id
         FROM inventory.hosts h
         LEFT JOIN systems s ON h.id = s.id
         WHERE h.org_id = '#{safe_org_id}'

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -11,7 +11,11 @@ describe InventoryEventsConsumer do
 
   let(:message) do
     {
-      'type' => type
+      'type' => type,
+      'host' => {
+        'id' => SecureRandom.uuid,
+        'insights_id' => SecureRandom.uuid
+      }
     }
   end
 
@@ -124,6 +128,58 @@ describe InventoryEventsConsumer do
             end
           end
         end
+      end
+    end
+
+    context 'when host is not importable' do
+      let(:type) { 'created' }
+      let(:host_overrides) { {} }
+      let(:message) do
+        {
+          'type' => type,
+          'host' => {
+            'id' => SecureRandom.uuid,
+            'insights_id' => SecureRandom.uuid
+          }.merge(host_overrides)
+        }
+      end
+
+      shared_examples 'skips SystemImporter' do
+        before { allow_any_instance_of(Kafka::SystemImporter).to receive(:import) }
+
+        it 'does not call SystemImporter' do
+          expect(Kafka::SystemImporter).not_to receive(:new)
+          consumer.consume
+        end
+      end
+
+      context 'with blank insights_id' do
+        let(:host_overrides) { { 'insights_id' => nil } }
+        include_examples 'skips SystemImporter'
+      end
+
+      context 'with null UUID insights_id' do
+        let(:host_overrides) { { 'insights_id' => described_class::NON_INSIGHTS_ID } }
+        include_examples 'skips SystemImporter'
+      end
+
+      context 'with edge host_type' do
+        let(:host_overrides) { { 'system_profile' => { 'host_type' => 'edge' } } }
+        include_examples 'skips SystemImporter'
+      end
+
+      context 'with CentOS operating_system' do
+        let(:host_overrides) do
+          { 'system_profile' => { 'operating_system' => { 'name' => 'CentOS Linux' } } }
+        end
+        include_examples 'skips SystemImporter'
+      end
+
+      context 'with bootc image digest' do
+        let(:host_overrides) do
+          { 'system_profile' => { 'bootc_status' => { 'booted' => { 'image_digest' => 'sha256:abc' } } } }
+        end
+        include_examples 'skips SystemImporter'
       end
     end
 

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -103,6 +103,26 @@ RSpec.describe Kafka::SystemImporter do
       end
     end
 
+    context 'when system_profile contains extra fields' do
+      before do
+        message['host']['system_profile'] = {
+          'operating_system' => { 'major' => 9, 'minor' => 4 },
+          'owner_id' => SecureRandom.uuid,
+          'arch' => 'x86_64',
+          'bios_vendor' => 'SeaBIOS',
+          'cpu_model' => 'Intel Xeon',
+          'network_interfaces' => [{ 'name' => 'eth0' }]
+        }
+      end
+
+      it 'stores only operating_system and owner_id' do
+        service.import
+        system = KafkaSystem.find(message['host']['id'])
+        expect(system.system_profile.keys).to match_array(%w[operating_system owner_id])
+        expect(system.system_profile['operating_system']).to eq({ 'major' => 9, 'minor' => 4 })
+      end
+    end
+
     context 'when payload lacks optional fields like groups' do
       before { message['host'].delete('groups') }
 


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [x] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Kafka host imports now persist only the required `system_profile` fields (`operating_system` and `owner_id`) instead of storing the full payload.
- Kafka system backfill job was updated to rebuild `system_profile` from `operating_system` and `owner_id` only (stripping nulls).
- Added/updated tests to verify extra `system_profile` keys are dropped while allowed values are preserved.
- Inventory event consumer now runs Kafka system imports only for eligible hosts (`importable_host?`) rather than unconditionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->