### PR TITLE
fix(metrics): set dropped database table size to 0 in Yabeda

### DIFF
--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -18,11 +18,21 @@ module Compliance
       end
 
       # Remove metrics for tables that no longer exist (best-effort for in-memory adapters)
-      # Note: In production with yabeda-prometheus-mmap, stale labels are completely purged
-      # only upon container/process restart when the shared mmap .db files are cleared.
+      #
+      # LIMITATION NOTE (Multi-Process / mmap-backed environment):
+      # In production, we use `yabeda-prometheus-mmap` which stores values in shared memory-mapped
+      # files (under `/tmp/*.db`). The underlying `prometheus-client-mmap` gem does not natively
+      # support deleting specific label sets/keys from these .db files while the application is running.
+      # Calling `metric.values.delete` only removes the key from the local worker's in-memory hash.
+      # To prevent dropped tables from continuing to report their last-known non-zero size in Grafana
+      # indefinitely, we explicitly set their value to 0 first. This forces the metric in scrapes to 0
+      # until the shared mmap files are fully wiped/regenerated on the next pod restart (during deployment).
       metric = Yabeda.compliance_db_table_size_bytes
       metric.values.keys.each do |tags|
-        metric.values.delete(tags) unless current_tables.include?(tags[:table])
+        unless current_tables.include?(tags[:table])
+          metric.set(tags, 0)
+          metric.values.delete(tags)
+        end
       end
     rescue StandardError => e
       Rails.logger.error("Failed to collect DB table size metrics: #{e.full_message}")

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -2,6 +2,34 @@
 
 require 'clowder-common-ruby'
 
+module Compliance
+  class TableSizeCollector
+    def self.collect
+      current_tables = []
+
+      ActiveRecord::Base.connection.execute(<<~SQL).each do |row|
+        SELECT relname AS table_name, pg_total_relation_size(relid) AS size_bytes
+        FROM pg_catalog.pg_statio_user_tables
+        ORDER BY size_bytes DESC
+      SQL
+        table_name = row['table_name']
+        current_tables << table_name
+        Yabeda.compliance_db_table_size_bytes.set({ table: table_name }, row['size_bytes'].to_i)
+      end
+
+      # Remove metrics for tables that no longer exist (best-effort for in-memory adapters)
+      # Note: In production with yabeda-prometheus-mmap, stale labels are completely purged
+      # only upon container/process restart when the shared mmap .db files are cleared.
+      metric = Yabeda.compliance_db_table_size_bytes
+      metric.values.keys.each do |tags|
+        metric.values.delete(tags) unless current_tables.include?(tags[:table])
+      end
+    rescue StandardError => e
+      Rails.logger.error("Failed to collect DB table size metrics: #{e.full_message}")
+    end
+  end
+end
+
 # Metrics configuration
 Yabeda.configure do
   default_tag :application, 'compliance'
@@ -15,27 +43,7 @@ Yabeda.configure do
         tags: %i[table]
 
   collect do
-    current_tables = []
-
-    ActiveRecord::Base.connection.execute(<<~SQL).each do |row|
-      SELECT relname AS table_name, pg_total_relation_size(relid) AS size_bytes
-      FROM pg_catalog.pg_statio_user_tables
-      ORDER BY size_bytes DESC
-    SQL
-      table_name = row['table_name']
-      current_tables << table_name
-      compliance_db_table_size_bytes.set({ table: table_name }, row['size_bytes'].to_i)
-    end
-
-    # Remove metrics for tables that no longer exist
-    metric = Yabeda.compliance_db_table_size_bytes
-    existing_tags = metric.values.keys.map { |tags| tags[:table] }
-
-    (existing_tags - current_tables).each do |dropped_table|
-      metric.values.delete({ table: dropped_table, application: 'compliance', qe: 0, source: 'basic' })
-    end
-  rescue StandardError => e
-    Rails.logger.error("Failed to collect DB table size metrics: #{e.message}")
+    Compliance::TableSizeCollector.collect
   end
 end
 

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'clowder-common-ruby'
 
 # Metrics configuration
@@ -13,12 +15,24 @@ Yabeda.configure do
         tags: %i[table]
 
   collect do
+    current_tables = []
+
     ActiveRecord::Base.connection.execute(<<~SQL).each do |row|
       SELECT relname AS table_name, pg_total_relation_size(relid) AS size_bytes
       FROM pg_catalog.pg_statio_user_tables
       ORDER BY size_bytes DESC
     SQL
-      compliance_db_table_size_bytes.set({ table: row['table_name'] }, row['size_bytes'].to_i)
+      table_name = row['table_name']
+      current_tables << table_name
+      compliance_db_table_size_bytes.set({ table: table_name }, row['size_bytes'].to_i)
+    end
+
+    # Remove metrics for tables that no longer exist
+    metric = Yabeda.compliance_db_table_size_bytes
+    existing_tags = metric.values.keys.map { |tags| tags[:table] }
+
+    (existing_tags - current_tables).each do |dropped_table|
+      metric.values.delete({ table: dropped_table, application: 'compliance', qe: 0, source: 'basic' })
     end
   rescue StandardError => e
     Rails.logger.error("Failed to collect DB table size metrics: #{e.message}")
@@ -26,7 +40,7 @@ Yabeda.configure do
 end
 
 # Start the metrics server for sidekiq and karafka
-if %w[sidekiq karafka].any? { |p| $0.include?(p) }
+if %w[sidekiq karafka].any? { |p| $PROGRAM_NAME.include?(p) }
   if ClowderCommonRuby::Config.clowder_enabled?
     ENV['PROMETHEUS_EXPORTER_PORT'] = ClowderCommonRuby::Config.load.metricsPort.to_s
   else

--- a/spec/initializers/yabeda_spec.rb
+++ b/spec/initializers/yabeda_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Yabeda table size metrics collect block' do
+  before do
+    # Mock connection
+    @mock_connection = instance_double(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+    allow(ActiveRecord::Base).to receive(:connection).and_return(@mock_connection)
+
+    # Seed initial data to simulate a previous run
+    metric = Yabeda.compliance_db_table_size_bytes
+    metric.set({ table: 'existing_table' }, 1000)
+    metric.set({ table: 'dropped_table' }, 500)
+  end
+
+  it 'removes metrics for tables that no longer exist in the database' do
+    # Simulate DB returning only 'existing_table'
+    mock_result = [
+      { 'table_name' => 'existing_table', 'size_bytes' => '1200' }
+    ]
+    allow(@mock_connection).to receive(:execute).and_return(mock_result)
+
+    # Trigger collect block
+    Yabeda.collectors.each(&:call)
+
+    # Verify Yabeda memory
+    metric = Yabeda.compliance_db_table_size_bytes
+
+    # dropped_table should be purged
+    expect(metric.values.keys.map { |tags| tags[:table] }).to include('existing_table')
+    expect(metric.values.keys.map { |tags| tags[:table] }).not_to include('dropped_table')
+
+    # existing_table should be updated
+    existing_tags = { application: 'compliance', qe: 0, source: 'basic', table: 'existing_table' }
+    expect(metric.values[existing_tags].value).to eq(1200)
+  end
+end

--- a/spec/initializers/yabeda_spec.rb
+++ b/spec/initializers/yabeda_spec.rb
@@ -2,7 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Yabeda table size metrics collect block' do
+RSpec.describe Compliance::TableSizeCollector do
+  let(:existing_table_name) { "table_#{Faker::Lorem.unique.word}" }
+  let(:dropped_table_name) { "table_#{Faker::Lorem.unique.word}" }
+  let(:initial_existing_size) { Faker::Number.between(from: 100, to: 10_000) }
+  let(:initial_dropped_size) { Faker::Number.between(from: 100, to: 10_000) }
+  let(:updated_existing_size) { Faker::Number.between(from: 10_001, to: 20_000) }
+
   before do
     # Mock connection
     @mock_connection = instance_double(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
@@ -10,29 +16,33 @@ RSpec.describe 'Yabeda table size metrics collect block' do
 
     # Seed initial data to simulate a previous run
     metric = Yabeda.compliance_db_table_size_bytes
-    metric.set({ table: 'existing_table' }, 1000)
-    metric.set({ table: 'dropped_table' }, 500)
+    metric.set({ table: existing_table_name }, initial_existing_size)
+    metric.set({ table: dropped_table_name }, initial_dropped_size)
+  end
+
+  after do
+    Yabeda.compliance_db_table_size_bytes.values.clear
   end
 
   it 'removes metrics for tables that no longer exist in the database' do
     # Simulate DB returning only 'existing_table'
     mock_result = [
-      { 'table_name' => 'existing_table', 'size_bytes' => '1200' }
+      { 'table_name' => existing_table_name, 'size_bytes' => updated_existing_size.to_s }
     ]
     allow(@mock_connection).to receive(:execute).and_return(mock_result)
 
-    # Trigger collect block
-    Yabeda.collectors.each(&:call)
+    # Trigger only the specific collector block
+    described_class.collect
 
     # Verify Yabeda memory
     metric = Yabeda.compliance_db_table_size_bytes
 
     # dropped_table should be purged
-    expect(metric.values.keys.map { |tags| tags[:table] }).to include('existing_table')
-    expect(metric.values.keys.map { |tags| tags[:table] }).not_to include('dropped_table')
+    expect(metric.values.keys.map { |tags| tags[:table] }).to include(existing_table_name)
+    expect(metric.values.keys.map { |tags| tags[:table] }).not_to include(dropped_table_name)
 
     # existing_table should be updated
-    existing_tags = { application: 'compliance', qe: 0, source: 'basic', table: 'existing_table' }
-    expect(metric.values[existing_tags].value).to eq(1200)
+    existing_tags = { application: 'compliance', qe: 0, source: 'basic', table: existing_table_name }
+    expect(metric.values[existing_tags].value).to eq(updated_existing_size)
   end
 end

--- a/spec/initializers/yabeda_spec.rb
+++ b/spec/initializers/yabeda_spec.rb
@@ -31,13 +31,22 @@ RSpec.describe Compliance::TableSizeCollector do
     ]
     allow(@mock_connection).to receive(:execute).and_return(mock_result)
 
+    # Spy on .set calls during the collection
+    allow(Yabeda.compliance_db_table_size_bytes).to receive(:set).and_call_original
+
     # Trigger only the specific collector block
     described_class.collect
+
+    # Verify that the dropped table was set to 0 before deletion
+    expect(Yabeda.compliance_db_table_size_bytes).to have_received(:set).with(
+      { application: 'compliance', qe: 0, source: 'basic', table: dropped_table_name },
+      0
+    )
 
     # Verify Yabeda memory
     metric = Yabeda.compliance_db_table_size_bytes
 
-    # dropped_table should be purged
+    # dropped_table should be purged from memory
     expect(metric.values.keys.map { |tags| tags[:table] }).to include(existing_table_name)
     expect(metric.values.keys.map { |tags| tags[:table] }).not_to include(dropped_table_name)
 


### PR DESCRIPTION
### 📝 Summary

Yabeda does not auto-clear tags from memory when they disappear. When a database table is dropped (e.g., during database migrations or Cyndi syncer table drops), its last-recorded size remains in the Prometheus exporter payload indefinitely.

To mitigate this, this PR:
1. **Isolates Collection:** Moves database metrics collection into `Compliance::TableSizeCollector.collect`.
2. **Handles Dropped Tables:** Diffs currently active PostgreSQL tables against Yabeda's registered keys. If a table is missing:
   * It explicitly **sets its size to `0`** so Grafana immediately drops the metric line to 0 (since multi-process `yabeda-prometheus-mmap` `.db` files on disk do not support dynamic key deletion).
   * It deletes the tag from the local Ruby VM memory as a best-effort cleanup.
3. **Improves Diagnostics & Process Checks:** Switches initializer Sidekiq/Karafka boot checks to use `$PROGRAM_NAME` and logs full backtraces with `Exception#full_message` on collection failures.
4. **Adds Unit Tests:** Adds a new, isolated RSpec suite in `spec/initializers/yabeda_spec.rb` utilizing `Faker` data and an `after` block registry teardown to prevent cross-spec pollution.

---

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

---

*Note: This contribution was co-authored with Gemini Flash (via opencode) and reviewed by the author.*