### PR TITLE
fix(Kafka): guard PolicySystemImporter with importable_host? check

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -18,8 +18,10 @@ class InventoryEventsConsumer < ApplicationConsumer
   private
 
   def handle_created_updated
-    Kafka::SystemImporter.new(payload, logger).import if importable_host?
-    Kafka::PolicySystemImporter.new(payload, logger).import if policy_id
+    if importable_host?
+      Kafka::SystemImporter.new(payload, logger).import
+      Kafka::PolicySystemImporter.new(payload, logger).import if policy_id
+    end
     Kafka::ReportParser.new(payload, logger).parse_reports if service == 'compliance'
   end
 

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -144,42 +144,59 @@ describe InventoryEventsConsumer do
         }
       end
 
-      shared_examples 'skips SystemImporter' do
+      shared_examples 'skips importers' do
         before { allow_any_instance_of(Kafka::SystemImporter).to receive(:import) }
 
         it 'does not call SystemImporter' do
           expect(Kafka::SystemImporter).not_to receive(:new)
           consumer.consume
         end
+
+        it 'does not call PolicySystemImporter' do
+          expect(Kafka::PolicySystemImporter).not_to receive(:new)
+          consumer.consume
+        end
       end
 
       context 'with blank insights_id' do
         let(:host_overrides) { { 'insights_id' => nil } }
-        include_examples 'skips SystemImporter'
+        include_examples 'skips importers'
       end
 
       context 'with null UUID insights_id' do
         let(:host_overrides) { { 'insights_id' => described_class::NON_INSIGHTS_ID } }
-        include_examples 'skips SystemImporter'
+        include_examples 'skips importers'
       end
 
       context 'with edge host_type' do
         let(:host_overrides) { { 'system_profile' => { 'host_type' => 'edge' } } }
-        include_examples 'skips SystemImporter'
+        include_examples 'skips importers'
       end
 
       context 'with CentOS operating_system' do
         let(:host_overrides) do
           { 'system_profile' => { 'operating_system' => { 'name' => 'CentOS Linux' } } }
         end
-        include_examples 'skips SystemImporter'
+        include_examples 'skips importers'
       end
 
       context 'with bootc image digest' do
         let(:host_overrides) do
           { 'system_profile' => { 'bootc_status' => { 'booted' => { 'image_digest' => 'sha256:abc' } } } }
         end
-        include_examples 'skips SystemImporter'
+        include_examples 'skips importers'
+      end
+
+      context 'with edge host_type and compliance_policy_id' do
+        let(:host_overrides) do
+          {
+            'system_profile' => {
+              'host_type' => 'edge',
+              'image_builder' => { 'compliance_policy_id' => SecureRandom.uuid }
+            }
+          }
+        end
+        include_examples 'skips importers'
       end
     end
 


### PR DESCRIPTION
## Summary

- Non-importable hosts (edge, CentOS, bootc, no insights_id) with a `compliance_policy_id` from Image Builder would skip `SystemImporter` (guarded by `importable_host?` in #2840) but still trigger `PolicySystemImporter`
- `PolicySystemImporter#sources_exist?` raises `ActiveRecord::RecordNotFound` because the system was never created
- The exception also prevents `ReportParser` from running on the same message
- After 3 retries, the message is discarded

## Changes

- Add `importable_host?` guard to the `PolicySystemImporter` call in `handle_created_updated`
- Add test asserting `PolicySystemImporter` is not called for non-importable hosts
- Add test for the specific case: edge host with `compliance_policy_id`

## Test plan

- [ ] Existing consumer specs pass
- [ ] New spec verifies PolicySystemImporter is skipped for all non-importable host types
- [ ] New spec verifies edge host with compliance_policy_id does not crash the consumer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Guarded `PolicySystemImporter` in `InventoryEventsConsumer#handle_created_updated` so it only runs for importable hosts with a `compliance_policy_id`.
- Prevented non-importable hosts (including edge hosts with Image Builder policy IDs) from triggering `PolicySystemImporter`, avoiding `RecordNotFound` errors and message retries/discards.
- Expanded consumer specs to cover non-importable host cases and verify `PolicySystemImporter` is not instantiated when the system import is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->