### PR TITLE
feat(systems): add tombstoning and cleanup for inventory events

### DIFF
--- a/app/consumers/inventory_events_consumer.rb
+++ b/app/consumers/inventory_events_consumer.rb
@@ -7,6 +7,7 @@ class InventoryEventsConsumer < ApplicationConsumer
   def consume_one
     case message_type
     when 'delete'
+      Kafka::SystemRemover.new(payload, logger).remove_system
       Kafka::DeletedSystemCleaner.new(payload, logger).cleanup_system
     when 'created', 'updated'
       handle_created_updated

--- a/app/models/kafka_system.rb
+++ b/app/models/kafka_system.rb
@@ -3,4 +3,6 @@
 # Temporary model for ingesting inventory data directly to compliance db
 class KafkaSystem < ApplicationRecord
   self.table_name = 'systems'
+
+  default_scope { where(deleted_at: nil) }
 end

--- a/app/services/kafka/deleted_system_cleaner.rb
+++ b/app/services/kafka/deleted_system_cleaner.rb
@@ -25,8 +25,7 @@ module Kafka
       ActiveRecord::Base.transaction do
         [
           remove_related_test_results,
-          remove_related_policy_systems,
-          remove_kafka_system
+          remove_related_policy_systems
         ].sum
       end
     end
@@ -41,10 +40,6 @@ module Kafka
 
     def remove_related_policy_systems
       V2::PolicySystem.where(system_id: @id).delete_all
-    end
-
-    def remove_kafka_system
-      KafkaSystem.where(id: @id).delete_all
     end
 
     def audit_fail(error)

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -58,7 +58,7 @@ module Kafka
         attrs,
         unique_by: :id,
         returning: %w[id],
-        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id, deleted_at = EXCLUDED.deleted_at WHERE (systems.deleted_at IS NULL AND (systems.updated IS NULL OR systems.updated < EXCLUDED.updated)) OR (systems.deleted_at IS NOT NULL AND systems.deleted_at < EXCLUDED.updated)')
+        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id, deleted_at = EXCLUDED.deleted_at WHERE COALESCE(systems.deleted_at, systems.updated) < EXCLUDED.updated')
       )
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -37,7 +37,8 @@ module Kafka
         display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
         tags: payload.dig('tags') || [], system_profile: relevant_system_profile(payload),
         stale_timestamp: payload.dig('stale_timestamp'), created: payload.dig('created'),
-        updated: updated, insights_id: payload.dig('insights_id')
+        updated: updated, insights_id: payload.dig('insights_id'),
+        deleted_at: nil
       }
     end
 
@@ -57,7 +58,7 @@ module Kafka
         attrs,
         unique_by: :id,
         returning: %w[id],
-        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id WHERE systems.updated IS NULL OR systems.updated < EXCLUDED.updated')
+        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id, deleted_at = EXCLUDED.deleted_at WHERE (systems.deleted_at IS NULL AND (systems.updated IS NULL OR systems.updated < EXCLUDED.updated)) OR (systems.deleted_at IS NOT NULL AND systems.deleted_at < EXCLUDED.updated)')
       )
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations

--- a/app/services/kafka/system_remover.rb
+++ b/app/services/kafka/system_remover.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Kafka
+  # Service for marking a KafkaSystem as soft-deleted (tombstoned) in the systems table
+  class SystemRemover
+    def initialize(message, logger)
+      @message = message
+      @logger = logger
+      @id = @message.dig('id')
+      @org_id = @message.dig('org_id')
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def remove_system
+      computed_timestamp = delete_timestamp
+      # rubocop:disable Rails/SkipsModelValidations
+      result = KafkaSystem.where(id: @id)
+                          .where('updated IS NULL OR updated < ?', computed_timestamp)
+                          .update_all(deleted_at: computed_timestamp)
+      # rubocop:enable Rails/SkipsModelValidations
+
+      if result.zero?
+        @logger.info("[Kafka::SystemRemover] Ignored stale delete event or no active system found for ID #{@id}")
+      else
+        @logger.audit_success("[Kafka::SystemRemover] Soft-deleted system #{@id}")
+      end
+    rescue StandardError => e
+      @logger.audit_fail("[Kafka::SystemRemover] Failed to soft-delete system #{@id}: #{e.message}")
+      raise e
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    # rubocop:disable Metrics/MethodLength
+    def delete_timestamp
+      timestamp_str = @message.dig('updated') || @message.dig('timestamp')
+      begin
+        parsed_time = Time.zone.parse(timestamp_str) if timestamp_str
+        if timestamp_str && parsed_time.nil?
+          @logger.warn("[Kafka::SystemRemover] Failed to parse timestamp '#{timestamp_str}' " \
+                       "for system #{@id}, falling back to current time")
+        end
+        parsed_time || Time.current
+      rescue StandardError => e
+        @logger.warn("[Kafka::SystemRemover] Error parsing timestamp '#{timestamp_str}' " \
+                     "for system #{@id}: #{e.message}")
+        Time.current
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -266,6 +266,89 @@ objects:
         livenessProbe:
           exec:
             command: ["pgrep" ,"-f", "rake"]
+    - name: cleanup-systems
+      schedule: ${CLEANUP_SYSTEMS_SCHEDULE}
+      concurrencyPolicy: Forbid
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command: ["/bin/sh"]
+          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+          inheritEnv: true
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
+          requests:
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-cleanup-systems
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
+        - name: SETTINGS__SLACK_WEBHOOK
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: slack_webhook
+              optional: true
+        - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
+          value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
+        - name: MAX_INIT_TIMEOUT_SECONDS
+          value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: SETTINGS__REDIS__SSL
+          value: "${REDIS_SSL}"
+        - name: PRIMARY_REDIS_AS_CACHE
+          value: "${PRIMARY_REDIS_AS_CACHE}"
+        - name: SETTINGS__REDIS__CACHE_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.endpoint
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.port
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.auth_token
+              optional: true
+        - name: IMAGE_TAG
+          value: "${IMAGE}:${IMAGE_TAG}"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOGSTREAM
+          value: "${LOGSTREAM_CLEANUP_SYSTEMS}"
+        - name: STALE_CLEANUP_ENABLED
+          value: "${STALE_CLEANUP_ENABLED}"
+        - name: STALE_RETENTION_DAYS
+          value: "${STALE_RETENTION_DAYS}"
+        - name: DELETED_RETENTION_DAYS
+          value: "${DELETED_RETENTION_DAYS}"
+        livenessProbe:
+          exec:
+            command: ["pgrep" ,"-f", "rake"]
     deployments:
     - name: service
       minReplicas: ${{REPLICAS_BACKEND}}
@@ -837,6 +920,18 @@ parameters:
 - name: BACKFILL_MAX_ROWS_PER_RUN
   description: Max rows to process per cron execution for systems backfill
   value: "50000"
+- name: CLEANUP_SYSTEMS_SCHEDULE
+  description: Cronjob schedule for systems cleanup
+  value: "*/15 * * * *" # every 15 minutes
+- name: STALE_CLEANUP_ENABLED
+  description: Enable stale systems cleanup
+  value: "true"
+- name: STALE_RETENTION_DAYS
+  description: Retention threshold in days for stale systems
+  value: "30"
+- name: DELETED_RETENTION_DAYS
+  description: Retention threshold in days for soft-deleted systems
+  value: "14"
 - name: MAX_INIT_TIMEOUT_SECONDS
   description: Number of seconds for timeout init container operation
   value: "120"
@@ -855,6 +950,8 @@ parameters:
   value: 'compliance-reindex-db'
 - name: LOGSTREAM_BACKFILL_SYSTEMS
   value: 'compliance-backfill-systems'
+- name: LOGSTREAM_CLEANUP_SYSTEMS
+  value: 'compliance-cleanup-systems'
 - name: RUBY_YJIT_ENABLE
   value: '0'
 - name: KESSEL_ENABLED

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,8 @@ elif [ "$APPLICATION_TYPE" = "compliance-reindex-db" ]; then
   exec bundle exec rake db:reindex --trace
 elif [ "$APPLICATION_TYPE" = "compliance-backfill-systems" ]; then
   exec bundle exec rake systems:backfill --trace
+elif [ "$APPLICATION_TYPE" = "compliance-cleanup-systems" ]; then
+  exec bundle exec rake systems:cleanup --trace
 elif [ "$APPLICATION_TYPE" = "sleep" ]; then
   while true; do sleep 60; done
 else

--- a/lib/tasks/cleanup_systems.rake
+++ b/lib/tasks/cleanup_systems.rake
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Service class for cleaning up stale, deleted, and ineligible systems
+class SystemsCleaner
+  def initialize(batch_size:, logger:)
+    @batch_size = batch_size
+    @logger = logger
+  end
+
+  def run(subtasks)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    if subtasks.include?('deleted')
+      @logger.info("Running subtask 'deleted'...")
+      deleted_ids = deleted_system_ids
+      delete_systems_in_batches(deleted_ids, 'deleted') if deleted_ids.any?
+    end
+
+    elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time).round(2)
+    @logger.info("systems:cleanup completed in #{elapsed}s.")
+  end
+
+  private
+
+  # Subtask: Deleted (Tombstones)
+  # Hard-deletes systems soft-deleted (deleted_at IS NOT NULL) older than retention days.
+  def deleted_system_ids
+    retention_days = ENV.fetch('DELETED_RETENTION_DAYS', 14).to_i
+    cutoff_time = retention_days.days.ago
+
+    sql = <<~SQL
+      SELECT id FROM systems
+      WHERE deleted_at IS NOT NULL
+        AND deleted_at < '#{cutoff_time.iso8601}'
+    SQL
+    ActiveRecord::Base.connection.select_values(sql)
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  # Batch deletion of identified systems and their related records
+  def delete_systems_in_batches(system_ids, subtask_name)
+    total = system_ids.size
+    @logger.info("Found #{total} systems to clean up for subtask '#{subtask_name}'.")
+
+    system_ids.each_slice(@batch_size) do |batch_ids|
+      ActiveRecord::Base.transaction do
+        # Purge related records
+        results_count = V2::HistoricalTestResult.where(system_id: batch_ids).delete_all
+        policy_systems_count = V2::PolicySystem.where(system_id: batch_ids).delete_all
+
+        # Purge the systems (bypassing default_scope deleted_at: nil)
+        systems_count = KafkaSystem.unscoped.where(id: batch_ids).delete_all
+
+        @logger.info("Deleted batch: #{systems_count} systems, #{results_count} test results, " \
+                     "#{policy_systems_count} policy-system associations.")
+      end
+    end
+    @logger.info("Completed subtask '#{subtask_name}'. Total systems cleaned up: #{total}")
+  end
+  # rubocop:enable Metrics/MethodLength
+end
+
+namespace :systems do
+  desc 'Cleanup stale, soft-deleted, and ineligible systems'
+  task cleanup: :environment do
+    subtasks = ENV.fetch('SUBTASKS', 'deleted').split(',')
+    batch_size = ENV.fetch('BATCH_SIZE', 1000).to_i
+
+    logger = Logger.new($stdout)
+    logger.info("systems:cleanup started. Subtasks: #{subtasks.join(', ')} | BATCH_SIZE: #{batch_size}")
+
+    SystemsCleaner.new(batch_size: batch_size, logger: logger).run(subtasks)
+  end
+end

--- a/lib/tasks/cleanup_systems.rake
+++ b/lib/tasks/cleanup_systems.rake
@@ -7,6 +7,7 @@ class SystemsCleaner
     @logger = logger
   end
 
+  # rubocop:disable Metrics/MethodLength
   def run(subtasks)
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
@@ -16,9 +17,16 @@ class SystemsCleaner
       delete_systems_in_batches(deleted_ids, 'deleted') if deleted_ids.any?
     end
 
+    if subtasks.include?('stale')
+      @logger.info("Running subtask 'stale'...")
+      stale_ids = stale_system_ids
+      delete_systems_in_batches(stale_ids, 'stale') if stale_ids.any?
+    end
+
     elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time).round(2)
     @logger.info("systems:cleanup completed in #{elapsed}s.")
   end
+  # rubocop:enable Metrics/MethodLength
 
   private
 
@@ -35,6 +43,26 @@ class SystemsCleaner
     SQL
     ActiveRecord::Base.connection.select_values(sql)
   end
+
+  # Subtask: Stale
+  # Clean up stale systems based on stale_timestamp threshold if enabled.
+  # rubocop:disable Metrics/MethodLength
+  def stale_system_ids
+    unless ENV['STALE_CLEANUP_ENABLED'] == 'true'
+      @logger.info("Subtask 'stale': STALE_CLEANUP_ENABLED is not set to 'true'. Skipping stale systems cleanup.")
+      return []
+    end
+
+    retention_days = ENV.fetch('STALE_RETENTION_DAYS', 30).to_i
+    cutoff_time = retention_days.days.ago
+
+    sql = <<~SQL
+      SELECT id FROM systems
+      WHERE stale_timestamp < '#{cutoff_time.iso8601}'
+    SQL
+    ActiveRecord::Base.connection.select_values(sql)
+  end
+  # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable Metrics/MethodLength
   # Batch deletion of identified systems and their related records
@@ -63,7 +91,7 @@ end
 namespace :systems do
   desc 'Cleanup stale, soft-deleted, and ineligible systems'
   task cleanup: :environment do
-    subtasks = ENV.fetch('SUBTASKS', 'deleted').split(',')
+    subtasks = ENV.fetch('SUBTASKS', 'deleted,stale').split(',')
     batch_size = ENV.fetch('BATCH_SIZE', 1000).to_i
 
     logger = Logger.new($stdout)

--- a/lib/tasks/cleanup_systems.rake
+++ b/lib/tasks/cleanup_systems.rake
@@ -1,98 +1,233 @@
 # frozen_string_literal: true
 
 # Service class for cleaning up stale, deleted, and ineligible systems
+# rubocop:disable Metrics/ClassLength
 class SystemsCleaner
+  DEFAULT_DELETED_RETENTION_DAYS = 14
+  DEFAULT_STALE_RETENTION_DAYS = 30
+
   def initialize(batch_size:, logger:)
     @batch_size = batch_size
     @logger = logger
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def run(subtasks)
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     if subtasks.include?('deleted')
       @logger.info("Running subtask 'deleted'...")
-      deleted_ids = deleted_system_ids
-      delete_systems_in_batches(deleted_ids, 'deleted') if deleted_ids.any?
+      cleanup_deleted_systems
     end
 
     if subtasks.include?('stale')
       @logger.info("Running subtask 'stale'...")
-      stale_ids = stale_system_ids
-      delete_systems_in_batches(stale_ids, 'stale') if stale_ids.any?
+      cleanup_stale_systems
+    end
+
+    if subtasks.include?('filter')
+      @logger.info("Running subtask 'filter'...")
+      cleanup_filtered_systems
     end
 
     elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time).round(2)
     @logger.info("systems:cleanup completed in #{elapsed}s.")
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   private
 
   # Subtask: Deleted (Tombstones)
-  # Hard-deletes systems soft-deleted (deleted_at IS NOT NULL) older than retention days.
-  def deleted_system_ids
-    retention_days = ENV.fetch('DELETED_RETENTION_DAYS', 14).to_i
+  # Hard-deletes systems soft-deleted (deleted_at IS NOT NULL) older than retention days in batches.
+  # rubocop:disable Metrics/MethodLength
+  def cleanup_deleted_systems
+    retention_days = positive_integer_env('DELETED_RETENTION_DAYS', DEFAULT_DELETED_RETENTION_DAYS)
     cutoff_time = retention_days.days.ago
 
-    sql = <<~SQL
-      SELECT id FROM systems
-      WHERE deleted_at IS NOT NULL
-        AND deleted_at < '#{cutoff_time.iso8601}'
-    SQL
-    ActiveRecord::Base.connection.select_values(sql)
+    sql = ActiveRecord::Base.sanitize_sql_array(
+      [
+        'SELECT id FROM systems WHERE deleted_at IS NOT NULL AND deleted_at < ?',
+        cutoff_time
+      ]
+    )
+
+    total = 0
+    each_id_batch(sql) do |batch_ids|
+      total += delete_systems_in_batches(batch_ids, 'deleted', cutoff_time: cutoff_time)
+    end
+    @logger.info("Completed subtask 'deleted'. Total systems cleaned up: #{total}")
   end
+  # rubocop:enable Metrics/MethodLength
 
   # Subtask: Stale
-  # Clean up stale systems based on stale_timestamp threshold if enabled.
+  # Clean up stale systems based on stale_timestamp threshold if enabled in batches.
   # rubocop:disable Metrics/MethodLength
-  def stale_system_ids
+  def cleanup_stale_systems
     unless ENV['STALE_CLEANUP_ENABLED'] == 'true'
       @logger.info("Subtask 'stale': STALE_CLEANUP_ENABLED is not set to 'true'. Skipping stale systems cleanup.")
-      return []
+      return
     end
 
-    retention_days = ENV.fetch('STALE_RETENTION_DAYS', 30).to_i
+    retention_days = positive_integer_env('STALE_RETENTION_DAYS', DEFAULT_STALE_RETENTION_DAYS)
     cutoff_time = retention_days.days.ago
 
-    sql = <<~SQL
-      SELECT id FROM systems
-      WHERE stale_timestamp < '#{cutoff_time.iso8601}'
-    SQL
-    ActiveRecord::Base.connection.select_values(sql)
-  end
-  # rubocop:enable Metrics/MethodLength
+    sql = ActiveRecord::Base.sanitize_sql_array(
+      [
+        'SELECT id FROM systems WHERE deleted_at IS NULL AND stale_timestamp < ?',
+        cutoff_time
+      ]
+    )
 
-  # rubocop:disable Metrics/MethodLength
-  # Batch deletion of identified systems and their related records
-  def delete_systems_in_batches(system_ids, subtask_name)
-    total = system_ids.size
-    @logger.info("Found #{total} systems to clean up for subtask '#{subtask_name}'.")
-
-    system_ids.each_slice(@batch_size) do |batch_ids|
-      ActiveRecord::Base.transaction do
-        # Purge related records
-        results_count = V2::HistoricalTestResult.where(system_id: batch_ids).delete_all
-        policy_systems_count = V2::PolicySystem.where(system_id: batch_ids).delete_all
-
-        # Purge the systems (bypassing default_scope deleted_at: nil)
-        systems_count = KafkaSystem.unscoped.where(id: batch_ids).delete_all
-
-        @logger.info("Deleted batch: #{systems_count} systems, #{results_count} test results, " \
-                     "#{policy_systems_count} policy-system associations.")
-      end
+    total = 0
+    each_id_batch(sql) do |batch_ids|
+      total += delete_systems_in_batches(batch_ids, 'stale', cutoff_time: cutoff_time)
     end
-    @logger.info("Completed subtask '#{subtask_name}'. Total systems cleaned up: #{total}")
+    @logger.info("Completed subtask 'stale'. Total systems cleaned up: #{total}")
   end
   # rubocop:enable Metrics/MethodLength
+
+  # Subtask: Filter (Kafka Filter requirements)
+  # Deletes systems that should not have been imported in the first place in batches.
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def cleanup_filtered_systems
+    total = 0
+
+    # Select 1: Invalid or missing Insights ID
+    sql_insights_id = <<~SQL
+      SELECT id FROM systems
+      WHERE deleted_at IS NULL
+        AND (insights_id IS NULL OR insights_id = '00000000-0000-0000-0000-000000000000')
+    SQL
+    each_id_batch(sql_insights_id) do |batch_ids|
+      total += delete_systems_in_batches(batch_ids, 'filter:insights_id')
+    end
+
+    # Select 2: Operating System is CentOS
+    sql_centos = <<~SQL
+      SELECT id FROM systems
+      WHERE deleted_at IS NULL
+        AND system_profile -> 'operating_system' ->> 'name' ILIKE '%centos%'
+    SQL
+    each_id_batch(sql_centos) do |batch_ids|
+      total += delete_systems_in_batches(batch_ids, 'filter:centos')
+    end
+
+    # Select 3: Host type is 'edge' (retrieved from inventory.hosts)
+    sql_edge = <<~SQL
+      SELECT s.id FROM systems s
+      INNER JOIN inventory.hosts h ON s.id = h.id
+      WHERE s.deleted_at IS NULL
+        AND h.system_profile ->> 'host_type' = 'edge'
+    SQL
+    each_id_batch(sql_edge, id_column: 's.id') do |batch_ids|
+      total += delete_systems_in_batches(batch_ids, 'filter:edge')
+    end
+
+    # Select 4: BootC system with booted image digest present (retrieved from inventory.hosts)
+    sql_bootc = <<~SQL
+      SELECT s.id FROM systems s
+      INNER JOIN inventory.hosts h ON s.id = h.id
+      WHERE s.deleted_at IS NULL
+        AND h.system_profile -> 'bootc_status' -> 'booted' ->> 'image_digest' IS NOT NULL
+    SQL
+    each_id_batch(sql_bootc, id_column: 's.id') do |batch_ids|
+      total += delete_systems_in_batches(batch_ids, 'filter:bootc')
+    end
+
+    @logger.info("Completed subtask 'filter'. Total systems cleaned up: #{total}")
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  # Keyset-paginates SQL queries and yields batch IDs to prevent out-of-memory errors
+  # rubocop:disable Metrics/MethodLength
+  def each_id_batch(sql_query, id_column: 'id')
+    last_id = nil
+    loop do
+      paged_sql = if last_id
+                    if sql_query.match?(/where/i)
+                      sql_query.sub(/where/i, "WHERE #{id_column} > '#{last_id}' AND")
+                    else
+                      "#{sql_query} WHERE #{id_column} > '#{last_id}'"
+                    end
+                  else
+                    sql_query
+                  end
+
+      paged_sql += " ORDER BY #{id_column} LIMIT #{@batch_size}"
+
+      batch_ids = ActiveRecord::Base.connection.select_values(paged_sql)
+      break if batch_ids.empty?
+
+      yield batch_ids
+
+      last_id = batch_ids.last
+      break if batch_ids.size < @batch_size
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # Batch deletion of identified systems and their related records
+  # rubocop:disable Metrics/AbcSize, Metrics/BlockLength
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+  def delete_systems_in_batches(batch_ids, subtask_name, cutoff_time: nil)
+    ActiveRecord::Base.transaction do
+      # Re-select and lock candidates in transaction to avoid TOCTOU race conditions (e.g. resurrection)
+      query = KafkaSystem.unscoped.where(id: batch_ids).lock('FOR UPDATE OF systems')
+
+      query = case subtask_name
+              when 'deleted'
+                query.where.not(deleted_at: nil).where(deleted_at: ...cutoff_time)
+              when 'stale'
+                query.where(stale_timestamp: ...cutoff_time)
+              when 'filter:insights_id'
+                query.where("insights_id IS NULL OR insights_id = '00000000-0000-0000-0000-000000000000'")
+              when 'filter:centos'
+                query.where("system_profile -> 'operating_system' ->> 'name' ILIKE '%centos%'")
+              when 'filter:edge'
+                query.joins('INNER JOIN inventory.hosts h ON systems.id = h.id')
+                     .where("h.system_profile ->> 'host_type' = 'edge'")
+              when 'filter:bootc'
+                query.joins('INNER JOIN inventory.hosts h ON systems.id = h.id')
+                     .where("h.system_profile -> 'bootc_status' -> 'booted' ->> 'image_digest' IS NOT NULL")
+              else
+                query
+              end
+
+      eligible_ids = query.pluck(:id)
+      return 0 if eligible_ids.empty?
+
+      # Purge related records
+      results_count = V2::HistoricalTestResult.where(system_id: eligible_ids).delete_all
+      policy_systems_count = V2::PolicySystem.where(system_id: eligible_ids).delete_all
+
+      # Purge the systems (bypassing default_scope deleted_at: nil)
+      systems_count = KafkaSystem.unscoped.where(id: eligible_ids).delete_all
+
+      @logger.info("Deleted batch for #{subtask_name}: #{systems_count} systems, #{results_count} test results, " \
+                   "#{policy_systems_count} policy-system associations.")
+      systems_count
+    end
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/BlockLength
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
+
+  def positive_integer_env(name, default)
+    value = Integer(ENV.fetch(name, default.to_s), 10)
+    raise ArgumentError, "#{name} must be positive" unless value.positive?
+
+    value
+  rescue ArgumentError
+    raise ArgumentError, "#{name} must be a positive integer"
+  end
 end
+# rubocop:enable Metrics/ClassLength
 
 namespace :systems do
   desc 'Cleanup stale, soft-deleted, and ineligible systems'
   task cleanup: :environment do
-    subtasks = ENV.fetch('SUBTASKS', 'deleted,stale').split(',')
-    batch_size = ENV.fetch('BATCH_SIZE', 1000).to_i
+    subtasks = ENV.fetch('SUBTASKS', 'deleted,stale,filter').split(',')
+    batch_size = Integer(ENV.fetch('BATCH_SIZE', '1000'), 10)
+    raise ArgumentError, 'BATCH_SIZE must be positive' unless batch_size.positive?
 
     logger = Logger.new($stdout)
     logger.info("systems:cleanup started. Subtasks: #{subtasks.join(', ')} | BATCH_SIZE: #{batch_size}")

--- a/lib/tasks/systems_backfill.rake
+++ b/lib/tasks/systems_backfill.rake
@@ -101,8 +101,7 @@ class SystemsBackfiller
         groups = EXCLUDED.groups,
         insights_id = EXCLUDED.insights_id,
         deleted_at = EXCLUDED.deleted_at
-      WHERE (systems.deleted_at IS NULL AND systems.updated < EXCLUDED.updated)
-         OR (systems.deleted_at IS NOT NULL AND systems.deleted_at < EXCLUDED.updated);
+      WHERE COALESCE(systems.deleted_at, systems.updated) < EXCLUDED.updated;
     SQL
   end
   # rubocop:enable Metrics/MethodLength

--- a/lib/tasks/systems_backfill.rake
+++ b/lib/tasks/systems_backfill.rake
@@ -101,7 +101,8 @@ class SystemsBackfiller
         groups = EXCLUDED.groups,
         insights_id = EXCLUDED.insights_id,
         deleted_at = EXCLUDED.deleted_at
-      WHERE systems.updated < EXCLUDED.updated;
+      WHERE (systems.deleted_at IS NULL AND systems.updated < EXCLUDED.updated)
+         OR (systems.deleted_at IS NOT NULL AND systems.deleted_at < EXCLUDED.updated);
     SQL
   end
   # rubocop:enable Metrics/MethodLength

--- a/spec/lib/tasks/systems_backfill_rake_spec.rb
+++ b/spec/lib/tasks/systems_backfill_rake_spec.rb
@@ -63,6 +63,39 @@ RSpec.describe 'systems:backfill', type: :task do
         expect(name).to eq(live_name) # Ignored the backfill
       end
     end
+
+    context 'when existing system is soft-deleted (has deleted_at set)' do
+      let(:live_name) { Faker::Lorem.word }
+      let!(:backfill_host) { FactoryBot.create(:system, id: host_id, account: account, updated: 2.days.ago) }
+
+      it 'resurrects the system if the backfill record is newer than the tombstone' do
+        ActiveRecord::Base.connection.execute(<<-SQL)
+          INSERT INTO systems (id, org_id, display_name, tags, updated, created, stale_timestamp, system_profile, deleted_at)
+          VALUES ('#{host_id}', '#{org_id}', '#{live_name}', '{}', '#{4.days.ago.iso8601}', '#{4.days.ago.iso8601}', '#{4.days.ago.iso8601}', '{}', '#{3.days.ago.iso8601}')
+        SQL
+
+        Rake::Task['systems:backfill'].execute
+
+        deleted_at = ActiveRecord::Base.connection.select_value(
+          "SELECT deleted_at FROM systems WHERE id = '#{host_id}'"
+        )
+        expect(deleted_at).to be_nil # Resurrected!
+      end
+
+      it 'ignores backfill and preserves tombstone if the tombstone is newer than the backfill record' do
+        ActiveRecord::Base.connection.execute(<<-SQL)
+          INSERT INTO systems (id, org_id, display_name, tags, updated, created, stale_timestamp, system_profile, deleted_at)
+          VALUES ('#{host_id}', '#{org_id}', '#{live_name}', '{}', '#{4.days.ago.iso8601}', '#{4.days.ago.iso8601}', '#{4.days.ago.iso8601}', '{}', '#{1.day.ago.iso8601}')
+        SQL
+
+        Rake::Task['systems:backfill'].execute
+
+        deleted_at = ActiveRecord::Base.connection.select_value(
+          "SELECT deleted_at FROM systems WHERE id = '#{host_id}'"
+        )
+        expect(deleted_at).not_to be_nil # Preserved tombstone!
+      end
+    end
   end
 
   describe 'batching and limits' do

--- a/spec/services/kafka/deleted_system_cleaner_spec.rb
+++ b/spec/services/kafka/deleted_system_cleaner_spec.rb
@@ -28,7 +28,6 @@ describe Kafka::DeletedSystemCleaner do
     expect { service.cleanup_system }.to(
       change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
       .and(change { policy.systems.count }.from(1).to(0))
-      .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
     )
   end
 
@@ -48,7 +47,6 @@ describe Kafka::DeletedSystemCleaner do
       expect { service.cleanup_system }.to(
         change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0)
         .and(change { policy.systems.count }.from(2).to(1))
-        .and(change { KafkaSystem.where(id: system.id).count }.from(1).to(0))
       )
 
       expect(V2::HistoricalTestResult.where(system_id: extra_system.id).count).to eql(1)

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -103,6 +103,52 @@ RSpec.describe Kafka::SystemImporter do
       end
     end
 
+    context 'when existing system is soft-deleted (has deleted_at set)' do
+      let(:system_id) { message['host']['id'] }
+
+      context 'and incoming message has a newer updated timestamp' do
+        before do
+          FactoryBot.create(
+            :kafka_system,
+            id: system_id,
+            display_name: 'old-name',
+            updated: (Time.zone.parse(updated_time) - 2.hours).iso8601,
+            deleted_at: (Time.zone.parse(updated_time) - 1.hour).iso8601
+          )
+        end
+
+        it 'resurrects the system by setting deleted_at to nil' do
+          expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
+          expect { service.import }.to change { KafkaSystem.count }.by(1)
+
+          system = KafkaSystem.find(system_id)
+          expect(system.deleted_at).to be_nil
+          expect(system.display_name).to eq(message.dig('host', 'display_name'))
+        end
+      end
+
+      context 'and incoming message has an older updated timestamp than deleted_at' do
+        before do
+          FactoryBot.create(
+            :kafka_system,
+            id: system_id,
+            display_name: 'old-name',
+            updated: (Time.zone.parse(updated_time) - 2.hours).iso8601,
+            deleted_at: (Time.zone.parse(updated_time) + 1.hour).iso8601
+          )
+        end
+
+        it 'ignores the message as stale' do
+          expect(Karafka.logger).to receive(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
+          expect { service.import }.not_to(change { KafkaSystem.count })
+
+          system = KafkaSystem.unscoped.find(system_id)
+          expect(system.deleted_at).not_to be_nil
+          expect(system.display_name).to eq('old-name')
+        end
+      end
+    end
+
     context 'when system_profile contains extra fields' do
       before do
         message['host']['system_profile'] = {

--- a/spec/services/kafka/system_remover_spec.rb
+++ b/spec/services/kafka/system_remover_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Kafka::SystemRemover do
+  let(:service) { described_class.new(message, Karafka.logger) }
+  let(:system_id) { Faker::Internet.uuid }
+  let(:org_id) { Faker::Number.number(digits: 6).to_s }
+  let!(:kafka_system) { FactoryBot.create(:kafka_system, id: system_id, org_id: org_id, updated: 2.days.ago) }
+
+  context 'with simple delete event' do
+    let(:message) do
+      {
+        'id' => system_id,
+        'org_id' => org_id
+      }
+    end
+
+    it 'soft-deletes the KafkaSystem by setting deleted_at to current time' do
+      expect(Karafka.logger).to receive(:audit_success).with(/Soft-deleted system/)
+      expect { service.remove_system }.to change { KafkaSystem.count }.from(1).to(0)
+
+      system = KafkaSystem.unscoped.find(system_id)
+      expect(system.deleted_at).not_to be_nil
+    end
+  end
+
+  context 'with updated timestamp in delete message' do
+    let(:event_time) { 1.day.ago.utc.iso8601 }
+    let(:message) do
+      {
+        'id' => system_id,
+        'org_id' => org_id,
+        'updated' => event_time
+      }
+    end
+
+    it 'uses the event timestamp for deleted_at' do
+      service.remove_system
+      system = KafkaSystem.unscoped.find(system_id)
+      expect(system.deleted_at).to eq(Time.zone.parse(event_time))
+    end
+  end
+
+  context 'with invalid timestamp in delete message' do
+    let(:message) do
+      {
+        'id' => system_id,
+        'org_id' => org_id,
+        'updated' => 'invalid-timestamp-string'
+      }
+    end
+
+    it 'logs a warning and falls back to current time' do
+      expect(Karafka.logger).to receive(:warn).with(/Failed to parse timestamp 'invalid-timestamp-string'/)
+      service.remove_system
+      system = KafkaSystem.unscoped.find(system_id)
+      expect(system.deleted_at).not_to be_nil
+    end
+  end
+
+  context 'when existing system has a newer updated timestamp' do
+    let(:event_time) { 1.day.ago.utc.iso8601 }
+    let(:message) do
+      {
+        'id' => system_id,
+        'org_id' => org_id,
+        'updated' => event_time
+      }
+    end
+
+    before do
+      kafka_system.update!(updated: Time.current)
+    end
+
+    it 'ignores the delete message and does not soft-delete the system' do
+      expect(Karafka.logger).to receive(:info).with(/Ignored stale delete event/)
+      expect { service.remove_system }.not_to(change { KafkaSystem.count })
+      expect(kafka_system.reload.deleted_at).to be_nil
+    end
+  end
+
+  context 'when an exception occurs' do
+    let(:message) do
+      {
+        'id' => system_id,
+        'org_id' => org_id
+      }
+    end
+
+    before do
+      allow(KafkaSystem).to receive(:where).and_raise(ActiveRecord::ActiveRecordError, 'db error')
+    end
+
+    it 'logs audit_fail and re-raises the exception' do
+      expect(Karafka.logger).to receive(:audit_fail).with(/Failed to soft-delete system.*db error/)
+      expect { service.remove_system }.to raise_error(ActiveRecord::ActiveRecordError, 'db error')
+    end
+  end
+end

--- a/spec/tasks/cleanup_systems_spec.rb
+++ b/spec/tasks/cleanup_systems_spec.rb
@@ -67,4 +67,59 @@ RSpec.describe 'systems:cleanup task' do
       expect(KafkaSystem.unscoped.find_by(id: stale_tombstone.id)).to be_nil
     end
   end
+
+  describe 'subtask: stale' do
+    let(:user) { FactoryBot.create(:v2_user) }
+    let(:policy) { FactoryBot.create(:v2_policy, account: user.account, supports_minors: [0]) }
+    let(:system1) { FactoryBot.create(:system, account: user.account, policy_id: policy.id, os_minor_version: 0) }
+    let(:system2) { FactoryBot.create(:system, account: user.account, policy_id: policy.id, os_minor_version: 0) }
+
+    let!(:stale_system) do
+      FactoryBot.create(
+        :kafka_system,
+        id: system1.id,
+        account: '12345',
+        org_id: user.org_id,
+        stale_timestamp: 35.days.ago
+      )
+    end
+
+    let!(:fresh_system) do
+      FactoryBot.create(
+        :kafka_system,
+        id: system2.id,
+        account: '12345',
+        org_id: user.org_id,
+        stale_timestamp: 10.days.ago
+      )
+    end
+
+    context 'when stale cleanup is disabled (default)' do
+      it 'does not purge any systems' do
+        expect do
+          suppress_stdout do
+            ENV['SUBTASKS'] = 'stale'
+            ENV['STALE_CLEANUP_ENABLED'] = 'false'
+            Rake::Task['systems:cleanup'].invoke
+          end
+        end.not_to(change { KafkaSystem.count })
+      end
+    end
+
+    context 'when stale cleanup is enabled' do
+      it 'purges stale systems older than retention threshold' do
+        expect do
+          suppress_stdout do
+            ENV['SUBTASKS'] = 'stale'
+            ENV['STALE_CLEANUP_ENABLED'] = 'true'
+            ENV['STALE_RETENTION_DAYS'] = '30'
+            Rake::Task['systems:cleanup'].invoke
+          end
+        end.to change { KafkaSystem.count }.by(-1)
+
+        expect(KafkaSystem.find_by(id: fresh_system.id)).not_to be_nil
+        expect(KafkaSystem.find_by(id: stale_system.id)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/tasks/cleanup_systems_spec.rb
+++ b/spec/tasks/cleanup_systems_spec.rb
@@ -17,6 +17,31 @@ RSpec.describe 'systems:cleanup task' do
     $stdout = original
   end
 
+  let(:account) { Faker::Number.number(digits: 5).to_s }
+
+  ENV_KEYS = %w[
+    SUBTASKS
+    DELETED_RETENTION_DAYS
+    STALE_CLEANUP_ENABLED
+    STALE_RETENTION_DAYS
+    BATCH_SIZE
+  ].freeze
+
+  around do |example|
+    original_envs = ENV_KEYS.to_h { |k| [k, ENV.fetch(k, nil)] }
+    begin
+      example.run
+    ensure
+      ENV_KEYS.each do |key|
+        if original_envs[key].nil?
+          ENV.delete(key)
+        else
+          ENV[key] = original_envs[key]
+        end
+      end
+    end
+  end
+
   before do
     # Re-enable the task before each test to allow multiple executions
     Rake::Task['systems:cleanup'].reenable
@@ -31,7 +56,7 @@ RSpec.describe 'systems:cleanup task' do
       FactoryBot.create(
         :kafka_system,
         id: system.id,
-        account: '12345',
+        account: account,
         org_id: user.org_id,
         deleted_at: 15.days.ago
       )
@@ -40,8 +65,8 @@ RSpec.describe 'systems:cleanup task' do
     let!(:fresh_tombstone) do
       FactoryBot.create(
         :kafka_system,
-        id: SecureRandom.uuid,
-        account: '12345',
+        id: Faker::Internet.uuid,
+        account: account,
         org_id: user.org_id,
         deleted_at: 5.days.ago
       )
@@ -78,7 +103,7 @@ RSpec.describe 'systems:cleanup task' do
       FactoryBot.create(
         :kafka_system,
         id: system1.id,
-        account: '12345',
+        account: account,
         org_id: user.org_id,
         stale_timestamp: 35.days.ago
       )
@@ -88,7 +113,7 @@ RSpec.describe 'systems:cleanup task' do
       FactoryBot.create(
         :kafka_system,
         id: system2.id,
-        account: '12345',
+        account: account,
         org_id: user.org_id,
         stale_timestamp: 10.days.ago
       )
@@ -120,6 +145,100 @@ RSpec.describe 'systems:cleanup task' do
         expect(KafkaSystem.find_by(id: fresh_system.id)).not_to be_nil
         expect(KafkaSystem.find_by(id: stale_system.id)).to be_nil
       end
+    end
+  end
+
+  describe 'subtask: filter' do
+    let(:user) { FactoryBot.create(:v2_user) }
+
+    # 1. Valid/eligible system
+    let(:eligible_sys) { FactoryBot.create(:system, account: user.account, os_minor_version: 0) }
+    let!(:eligible_kafka_sys) do
+      FactoryBot.create(
+        :kafka_system,
+        id: eligible_sys.id,
+        account: account,
+        org_id: user.org_id,
+        insights_id: Faker::Internet.uuid
+      )
+    end
+
+    # 2. Ineligible: Missing insights_id
+    let(:missing_insights_sys) { FactoryBot.create(:system, account: user.account, os_minor_version: 0) }
+    let!(:missing_insights_kafka_sys) do
+      FactoryBot.create(
+        :kafka_system,
+        id: missing_insights_sys.id,
+        account: account,
+        org_id: user.org_id,
+        insights_id: nil
+      )
+    end
+
+    # 3. Ineligible: CentOS OS
+    let(:centos_sys) { FactoryBot.create(:system, account: user.account, os_minor_version: 0) }
+    let!(:centos_kafka_sys) do
+      FactoryBot.create(
+        :kafka_system,
+        id: centos_sys.id,
+        account: account,
+        org_id: user.org_id,
+        insights_id: Faker::Internet.uuid,
+        system_profile: { 'operating_system' => { 'name' => 'CentOS Linux', 'major' => 8, 'minor' => 4 } }
+      )
+    end
+
+    # 4. Ineligible: host_type == 'edge'
+    let(:edge_sys) do
+      sys = FactoryBot.build(:system, account: user.account, os_minor_version: 0)
+      sys.system_profile = sys.system_profile.merge('host_type' => 'edge')
+      sys.save!
+      sys
+    end
+    let!(:edge_kafka_sys) do
+      FactoryBot.create(
+        :kafka_system,
+        id: edge_sys.id,
+        account: account,
+        org_id: user.org_id,
+        insights_id: Faker::Internet.uuid
+      )
+    end
+
+    # 5. Ineligible: bootc booted image digest present
+    let(:bootc_sys) do
+      sys = FactoryBot.build(:system, account: user.account, os_minor_version: 0)
+      sys.system_profile = sys.system_profile.merge(
+        'bootc_status' => { 'booted' => { 'image_digest' => 'sha256:123' } }
+      )
+      sys.save!
+      sys
+    end
+    let!(:bootc_kafka_sys) do
+      FactoryBot.create(
+        :kafka_system,
+        id: bootc_sys.id,
+        account: account,
+        org_id: user.org_id,
+        insights_id: Faker::Internet.uuid
+      )
+    end
+
+    it 'purges ineligible systems based on Kafka filter criteria' do
+      expect(KafkaSystem.count).to eq(5)
+
+      expect do
+        suppress_stdout do
+          ENV['SUBTASKS'] = 'filter'
+          Rake::Task['systems:cleanup'].invoke
+        end
+      end.to change { KafkaSystem.count }.by(-4)
+
+      expect(KafkaSystem.find_by(id: eligible_kafka_sys.id)).not_to be_nil
+      expect(KafkaSystem.find_by(id: missing_insights_kafka_sys.id)).to be_nil
+      expect(KafkaSystem.find_by(id: centos_kafka_sys.id)).to be_nil
+      expect(KafkaSystem.find_by(id: edge_kafka_sys.id)).to be_nil
+      expect(KafkaSystem.find_by(id: bootc_kafka_sys.id)).to be_nil
     end
   end
 end

--- a/spec/tasks/cleanup_systems_spec.rb
+++ b/spec/tasks/cleanup_systems_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'systems:cleanup task' do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  # Suppress task stdout outputs
+  def suppress_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+
+  before do
+    # Re-enable the task before each test to allow multiple executions
+    Rake::Task['systems:cleanup'].reenable
+  end
+
+  describe 'subtask: deleted' do
+    let(:user) { FactoryBot.create(:v2_user) }
+    let(:policy) { FactoryBot.create(:v2_policy, account: user.account, supports_minors: [0]) }
+    let(:system) { FactoryBot.create(:system, account: user.account, policy_id: policy.id, os_minor_version: 0) }
+
+    let!(:stale_tombstone) do
+      FactoryBot.create(
+        :kafka_system,
+        id: system.id,
+        account: '12345',
+        org_id: user.org_id,
+        deleted_at: 15.days.ago
+      )
+    end
+
+    let!(:fresh_tombstone) do
+      FactoryBot.create(
+        :kafka_system,
+        id: SecureRandom.uuid,
+        account: '12345',
+        org_id: user.org_id,
+        deleted_at: 5.days.ago
+      )
+    end
+
+    let!(:test_result) { FactoryBot.create(:v2_test_result, system: system, report_id: policy.id) }
+
+    it 'purges old soft-deleted tombstones and related records but preserves fresh ones' do
+      expect(KafkaSystem.unscoped.count).to eq(2)
+      expect(KafkaSystem.count).to eq(0)
+
+      expect do
+        suppress_stdout do
+          ENV['SUBTASKS'] = 'deleted'
+          ENV['DELETED_RETENTION_DAYS'] = '14'
+          Rake::Task['systems:cleanup'].invoke
+        end
+      end.to change { KafkaSystem.unscoped.count }.by(-1)
+         .and(change { V2::HistoricalTestResult.where(system_id: system.id).count }.from(1).to(0))
+                                                  .and(change { policy.systems.count }.from(1).to(0))
+
+      expect(KafkaSystem.unscoped.find_by(id: fresh_tombstone.id)).not_to be_nil
+      expect(KafkaSystem.unscoped.find_by(id: stale_tombstone.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Jira Issues
- [RHINENG-23282](https://issues.redhat.com/browse/RHINENG-23282) - Implement soft delete logic for inventory events
- [RHINENG-23280](https://issues.redhat.com/browse/RHINENG-23280) - Add Inventory update and delete events consumer

## Description
Implements soft-delete/tombstoning logic for the local `systems` table when processing Kafka inventory events, preventing late/out-of-order delete/update messages from incorrectly recreating deleted systems. 

Also introduces a dedicated `systems:cleanup` Rake task with three configurable subtasks:
1. **`deleted`**: Purges old soft-deleted tombstones (older than configured retention, e.g., 14 days) and their associated compliance records (test results, policy associations).
2. **`stale`**: Stubs stale system identification (disabled by default, runs only when `STALE_CLEANUP_ENABLED` is `'true'`).
3. **`filter`**: Uses four highly readable distinct SQL SELECT statements to find and purge existing systems in the local database that do not match our current Kafka consumer filter eligibility criteria (missing/invalid `insights_id`, CentOS OS, Edge host type, or BootC systems).

## Key Changes
- **Model:** Added `default_scope { where(deleted_at: nil) }` to `KafkaSystem`.
- **Consumer:** Updated `InventoryEventsConsumer` to run `Kafka::SystemRemover` immediately before `Kafka::DeletedSystemCleaner` for delete events.
- **Service (Tombstone):** Created `Kafka::SystemRemover` to write the soft-deletion timestamp to `deleted_at`.
- **Service (Upsert):** Enhanced `Kafka::SystemImporter#upsert_system` to set `deleted_at: nil` and updated the SQL UPSERT conditional check to support resurrection or ignore older, out-of-order messages.
- **Rake Task:** Added the multi-stage, batched `systems:cleanup` task.
- **Testing:** Comprehensive test suite in `spec/tasks/cleanup_systems_spec.rb`, `spec/services/kafka/system_remover_spec.rb`, and updated specs in `system_importer_spec.rb` and `deleted_system_cleaner_spec.rb`.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added soft-delete/tombstoning for Kafka inventory `systems` to prevent out-of-order delete/update events from recreating deleted rows.
- Updated `KafkaSystem` to exclude soft-deleted records by default (`default_scope { where(deleted_at: nil) }`).
- Updated delete processing in `InventoryEventsConsumer` to run `Kafka::SystemRemover` (sets `deleted_at`) before `Kafka::DeletedSystemCleaner`.
- Enhanced `Kafka::SystemImporter#upsert_system` to clear `deleted_at` on valid upserts and adjust UPSERT conflict rules to support resurrection while ignoring older messages.
- Added `systems:cleanup` Rake task with `deleted`, `stale` (optional), and `filter` subtasks to purge old tombstones, optionally remove stale systems, and hard-delete locally ineligible systems based on current eligibility rules.
- Added/extended specs covering importer resurrection vs stale ignoring, `Kafka::SystemRemover` behavior (including invalid timestamp handling and error logging), and `systems:cleanup` for each subtask.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[RHINENG-23282]: https://redhat.atlassian.net/browse/RHINENG-23282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-23280]: https://redhat.atlassian.net/browse/RHINENG-23280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ