### PR TITLE
fix(DB): remove duplicate trigger drop from migration

### DIFF
--- a/db/migrate/20260617110233_drop_unused_views_triggers_and_functions.rb
+++ b/db/migrate/20260617110233_drop_unused_views_triggers_and_functions.rb
@@ -4,7 +4,6 @@ class DropUnusedViewsTriggersAndFunctions < ActiveRecord::Migration[8.1]
     drop_trigger :v2_policies_insert,             on: :v2_policies,             revert_to_version: 1
     drop_trigger :v2_policies_update,             on: :v2_policies,             revert_to_version: 1
     drop_trigger :v2_policies_delete,             on: :v2_policies,             revert_to_version: 1
-    drop_trigger :historical_test_results_delete, on: :historical_test_results, revert_to_version: 1
 
     drop_trigger :v1_benchmarks_insert,                on: :v1_benchmarks,                revert_to_version: 1
     drop_trigger :v1_benchmarks_update,                on: :v1_benchmarks,                revert_to_version: 1


### PR DESCRIPTION
Ref: RHINENG-28444

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [x] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Removed the redundant `:historical_test_results_delete` trigger drop from the `DropUnusedViewsTriggersAndFunctions` migration to prevent duplicate trigger removal during Stage deployments.
- Left all other trigger/view/function cleanup statements in the migration unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->