### PR TITLE
cleanup(DB): remove the v2 suffix from table names

### DIFF
--- a/app/models/concerns/merge_with_alias.rb
+++ b/app/models/concerns/merge_with_alias.rb
@@ -98,6 +98,7 @@ module MergeWithAlias
     alias visit_Arel_Nodes_TableAlias nop
     alias visit_Arel_Nodes_SqlLiteral nop
     alias visit_Arel_Table nop
+    alias visit_Arel_Nodes_In nop
     # rubocop:enable Naming/MethodName
   end
 end

--- a/app/models/fix.rb
+++ b/app/models/fix.rb
@@ -3,9 +3,6 @@
 # Stores information about rules. This comes from SCAP.
 # Model for Rules
 class Fix < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :fixes
-
   ANACONDA = 'urn:redhat:anaconda:pre'
   BLUEPRINT = 'urn:redhat:osbuild:blueprint'
   ANSIBLE = 'urn:xccdf:fix:script:ansible'

--- a/app/models/historical_test_result.rb
+++ b/app/models/historical_test_result.rb
@@ -2,10 +2,6 @@
 
 # Database model representing historical results of compliance scans
 class HistoricalTestResult < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :historical_test_results_v2
-  self.primary_key = :id
-
   belongs_to :system, class_name: 'System', optional: true
   belongs_to :tailoring, class_name: 'Tailoring'
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -4,10 +4,6 @@
 class Policy < ApplicationRecord
   include RuleTree
 
-  # FIXME: clean up after the remodel
-  self.table_name = :policies_v2
-  self.primary_key = :id
-
   belongs_to :account, class_name: 'Account'
   belongs_to :profile, class_name: 'Profile'
   belongs_to :report, class_name: 'Report', foreign_key: :id, optional: true # rubocop:disable Rails/InverseOf
@@ -66,7 +62,7 @@ class Policy < ApplicationRecord
                 .where(Arel::Nodes.build_quoted(val).eq(match_os_minors))
                 .select(arel_table[:id])
 
-    { conditions: "policies_v2.id IN (#{ids.to_sql})" }
+    { conditions: "policies.id IN (#{ids.to_sql})" }
   end
 
   before_validation :ensure_default_values

--- a/app/models/policy_system.rb
+++ b/app/models/policy_system.rb
@@ -2,10 +2,6 @@
 
 # Model link between Policy and System
 class PolicySystem < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :policy_systems_v2
-  self.primary_key = :id
-
   attr_accessor :request_id
 
   belongs_to :policy, class_name: 'Policy'

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,10 +4,6 @@
 class Profile < ApplicationRecord
   include RuleTree
 
-  # FIXME: clean up after the remodel
-  self.table_name = :canonical_profiles_v2
-  self.primary_key = :id
-
   indexable_by :ref_id, &->(scope, value) { scope.find_by!(ref_id: value.try(:gsub, '-', '.')) }
 
   sortable_by :title

--- a/app/models/profile_os_minor_version.rb
+++ b/app/models/profile_os_minor_version.rb
@@ -2,8 +2,5 @@
 
 # Model for the profile support matrix
 class ProfileOsMinorVersion < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :profile_os_minor_versions
-
   belongs_to :profile, class_name: 'Profile'
 end

--- a/app/models/profile_rule.rb
+++ b/app/models/profile_rule.rb
@@ -2,8 +2,6 @@
 
 # Model for ProfileRules
 class ProfileRule < ApplicationRecord
-  self.table_name = :profile_rules_v2
-
   belongs_to :profile, class_name: 'Profile'
   belongs_to :rule, class_name: 'Rule'
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,8 +2,8 @@
 
 # Model for reports
 class Report < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :policies_v2
+  # Necessary explicits, since Report is backed by the policies table
+  self.table_name = :policies
   self.primary_key = :id
 
   SYSTEM_COUNT = lambda do
@@ -116,7 +116,7 @@ class Report < ApplicationRecord
                 .merge_with_alias(Pundit.policy_scope(User.current, System))
                 .select(:id)
 
-    { conditions: "policies_v2.id IN (#{ids.to_sql})" }
+    { conditions: "policies.id IN (#{ids.to_sql})" }
   end
   searchable_by :percent_compliant, %i[eq gt lt gte lte], except_parents: %i[systems] do |_key, op, val|
     {
@@ -155,7 +155,7 @@ class Report < ApplicationRecord
 
     RuleResult.joins(:system, :rule) # Because joins(test_results: :system, rule: []) is not that pretty
               .merge_with_alias(Pundit.policy_scope(User.current, System))
-              .where(result: RuleResult::FAILED, v2_test_results: { report_id: id }) # FIXME: aliasing
+              .where(result: RuleResult::FAILED, test_results: { report_id: id })
               .group(rule_fields).select(rule_fields, RuleResult.arel_table[:result].count.as('count'))
               .order(Rule.sorted_severities => :desc, count: :desc).limit(10)
   end

--- a/app/models/report_system.rb
+++ b/app/models/report_system.rb
@@ -2,7 +2,7 @@
 
 # Model link between Report and System
 class ReportSystem < ApplicationRecord
-  self.table_name = :report_systems
+  # Necessary explicit primary key, since ReportSystem is backed by a view
   self.primary_key = :id
 
   belongs_to :report, class_name: 'Report'

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -3,10 +3,6 @@
 # Stores information about rules. This comes from SCAP.
 # Model for Rules
 class Rule < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :rules_v2
-  self.primary_key = :id
-
   indexable_by :ref_id, &->(scope, value) { scope.find_by!(ref_id: value.try(:gsub, '-', '.')) }
 
   attr_accessor :op_source
@@ -43,12 +39,11 @@ class Rule < ApplicationRecord
   has_many :fixes, class_name: 'Fix', dependent: :destroy
 
   scope :with_remediation_context, lambda {
-    # FIXME: cleanup `Arel::Table.new` after renaming the V2 tables
     joins(:security_guide, :profiles).select(
       arel_table[Arel.star],
       SecurityGuide.arel_table[:ref_id].as('security_guide__ref_id'),
       SecurityGuide.arel_table[:version].as('security_guide__version'),
-      Arel::Table.new('profiles')[:ref_id].as('profiles__ref_id')
+      Profile.arel_table[:ref_id].as('profiles__ref_id')
     )
   }
 
@@ -67,7 +62,7 @@ class Rule < ApplicationRecord
     val = "%#{val}%" if ['ILIKE', 'NOT ILIKE'].include?(op)
 
     {
-      conditions: "rules_v2.identifier->>'label' #{op} ?",
+      conditions: "rules.identifier->>'label' #{op} ?",
       parameter: [val]
     }
   end

--- a/app/models/rule_group.rb
+++ b/app/models/rule_group.rb
@@ -2,10 +2,6 @@
 
 # Stores information about Rule Groups. This (eventually) comes from SCAP import.
 class RuleGroup < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :rule_groups_v2
-  self.primary_key = :id
-
   belongs_to :security_guide
 
   has_ancestry primary_key_format: %r{\A[\w\-]+(\/[\w\-]+)*\z}

--- a/app/models/rule_group_relationship.rb
+++ b/app/models/rule_group_relationship.rb
@@ -2,7 +2,7 @@
 
 # Required and conflicting relationships between rules and rule groups
 class RuleGroupRelationship < ApplicationRecord
-  # FIXME: clean up after the remodel
+  # FIXME: no-op model, needs to be removed
   self.table_name = :rule_group_relationships_v2
   self.primary_key = :id
 

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -3,9 +3,6 @@
 # Class representing individual rule results unter a test result
 # rubocop:disable Metrics/ClassLength
 class RuleResult < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :rule_results_v2
-
   belongs_to :test_result, class_name: 'TestResult'
   belongs_to :historical_test_result, class_name: 'HistoricalTestResult', foreign_key: :test_result_id,
                                       inverse_of: :rule_results, optional: true

--- a/app/models/security_guide.rb
+++ b/app/models/security_guide.rb
@@ -4,10 +4,6 @@
 class SecurityGuide < ApplicationRecord
   include RuleTree
 
-  # FIXME: clean up after the remodel
-  self.primary_key = :id
-  self.table_name = :security_guides_v2
-
   has_many :profiles, class_name: 'Profile', dependent: :destroy
   has_many :value_definitions, class_name: 'ValueDefinition', dependent: :destroy
   has_many :rules, class_name: 'Rule', dependent: :destroy
@@ -21,7 +17,7 @@ class SecurityGuide < ApplicationRecord
   searchable_by :profile_ref_id, %i[eq] do |_key, _op, val|
     ids = ::Profile.unscoped.where(ref_id: val).select(:security_guide_id)
 
-    { conditions: "security_guides_v2.id IN (#{ids.to_sql})" }
+    { conditions: "security_guides.id IN (#{ids.to_sql})" }
   end
 
   searchable_by :supported_profile, %i[eq] do |_key, _op, val|
@@ -31,7 +27,7 @@ class SecurityGuide < ApplicationRecord
       ref_id: ref_id, os_minor_versions: { os_minor_version: os_minor.to_i }
     ).select(:security_guide_id)
 
-    { conditions: "security_guides_v2.id IN (#{ids.to_sql})" }
+    { conditions: "security_guides.id IN (#{ids.to_sql})" }
   end
 
   sortable_by :title

--- a/app/models/supported_profile.rb
+++ b/app/models/supported_profile.rb
@@ -2,8 +2,7 @@
 
 # Model for the SupportedProfiles view
 class SupportedProfile < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :supported_profiles
+  # Necessary explicit primary key, since SupportedProfile is backed by a view
   self.primary_key = :id
 
   searchable_by :os_major_version, %i[eq ne]

--- a/app/models/tailoring.rb
+++ b/app/models/tailoring.rb
@@ -22,10 +22,6 @@ class Tailoring < ApplicationRecord
     ]
   )
 
-  # FIXME: clean up after the remodel
-  self.table_name = :tailorings_v2
-  self.primary_key = :id
-
   indexable_by :os_minor_version, &->(scope, value) { scope.find_by!(os_minor_version: value) }
 
   sortable_by :os_minor_version

--- a/app/models/tailoring_rule.rb
+++ b/app/models/tailoring_rule.rb
@@ -2,10 +2,6 @@
 
 # Model link between (Profile) Tailoring and Rule
 class TailoringRule < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :tailoring_rules_v2
-  self.primary_key = :id
-
   belongs_to :tailoring, class_name: 'Tailoring', inverse_of: :tailoring_rules
   belongs_to :rule, class_name: 'Rule'
 

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -3,8 +3,7 @@
 # Database model representing latest results of compliance scans
 # rubocop:disable Metrics/ClassLength
 class TestResult < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.table_name = :v2_test_results
+  # Necessary explicit primary key, since TestResult is backed by a view
   self.primary_key = :id
 
   if Rails.env.test? # For testing taggable
@@ -80,10 +79,10 @@ class TestResult < ApplicationRecord
 
   searchable_by :failed_rule_severity, %i[eq in] do |_key, _op, val|
     ids = ::RuleResult.unscoped.joins(:rule)
-                      .where(rules_v2: { severity: val.split(',') }, rule_results_v2: { result: 'fail' })
+                      .where(rules: { severity: val.split(',') }, rule_results: { result: 'fail' })
                       .select(:test_result_id)
 
-    { conditions: "v2_test_results.id IN (#{ids.to_sql})" }
+    { conditions: "test_results.id IN (#{ids.to_sql})" }
   end
 
   scope :with_groups, lambda { |groups, table = System.arel_table, key = :id|

--- a/app/models/value_definition.rb
+++ b/app/models/value_definition.rb
@@ -3,10 +3,6 @@
 # Stores information about value definitions. This comes from SCAP.
 # Model for Value Definitions
 class ValueDefinition < ApplicationRecord
-  # FIXME: clean up after the remodel
-  self.primary_key = :id
-  self.table_name = :value_definitions_v2
-
   belongs_to :security_guide
 
   sortable_by :title

--- a/app/policies/tailoring_policy.rb
+++ b/app/policies/tailoring_policy.rb
@@ -25,11 +25,9 @@ class TailoringPolicy < ApplicationPolicy
   # Only show tailoring in our user account
   class Scope < ApplicationPolicy::Scope
     def resolve
-      resolve scope.none if user&.account_id.blank?
+      return scope.none if user&.account_id.blank?
 
-      scope.where
-           .associated(:policy)
-           .where(policy: { account_id: user.account_id })
+      scope.where(policy_id: Policy.where(account_id: user.account_id).select(:id))
     end
   end
 end

--- a/app/services/concerns/xccdf/test_result.rb
+++ b/app/services/concerns/xccdf/test_result.rb
@@ -22,7 +22,7 @@ module Xccdf
 
     def delete_old_test_results
       old_test_results = ::TestResult.left_outer_joins(tailoring: :policy)
-                                     .where(tailorings_v2: { policy_id: @tailoring.policy_id },
+                                     .where(tailorings: { policy_id: @tailoring.policy_id },
                                             system: @system)
                                      .where.not(id: @test_result.id)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,8 +31,10 @@ module ComplianceBackend
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
-    # Partial inserts are necessary for writing into views with read-only fields
-    config.active_record.partial_inserts = true # FIXME: clean up after the remodel
+    # Partial inserts are necessary for writing through views with INSTEAD OF triggers
+    # (e.g. test_results). Without this, Rails 7+ would include all columns in INSERT
+    # statements, which can conflict with the trigger's column mapping.
+    config.active_record.partial_inserts = true
 
     # Autoload lib/ (excluding Rake tasks) so Exceptions and other lib/
     # constants are available without manual require calls.

--- a/db/functions/test_results_delete_v01.sql
+++ b/db/functions/test_results_delete_v01.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION test_results_delete() RETURNS trigger LANGUAGE plpgsql AS
+$func$
+BEGIN
+    DELETE FROM "historical_test_results" WHERE "id" = OLD."id";
+    RETURN OLD;
+END
+$func$;

--- a/db/functions/test_results_insert_v01.sql
+++ b/db/functions/test_results_insert_v01.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION test_results_insert() RETURNS trigger LANGUAGE plpgsql AS
+$func$
+DECLARE result_id uuid;
+BEGIN
+    INSERT INTO "historical_test_results" (
+      "tailoring_id",
+      "report_id",
+      "system_id",
+      "start_time",
+      "end_time",
+      "score",
+      "supported",
+      "failed_rule_count",
+      "created_at",
+      "updated_at"
+    ) VALUES (
+      NEW."tailoring_id",
+      NEW."report_id",
+      NEW."system_id",
+      NEW."start_time",
+      NEW."end_time",
+      NEW."score",
+      NEW."supported",
+      COALESCE(NEW."failed_rule_count", 0),
+      COALESCE(NEW."created_at", NOW()),
+      COALESCE(NEW."updated_at", NOW())
+    ) RETURNING "id" INTO "result_id";
+
+    NEW."id" := "result_id";
+    RETURN NEW;
+END
+$func$;

--- a/db/migrate/20260721112129_rename_v2_tables.rb
+++ b/db/migrate/20260721112129_rename_v2_tables.rb
@@ -1,0 +1,52 @@
+class RenameV2Tables < ActiveRecord::Migration[8.1]
+  def change
+    # Triggers and functions on v2_test_results must be dropped before the view itself
+    drop_trigger :v2_test_results_insert, on: :v2_test_results, revert_to_version: 1
+    drop_trigger :v2_test_results_delete, on: :v2_test_results, revert_to_version: 1
+    drop_function :v2_test_results_insert, revert_to_version: 2
+    drop_function :v2_test_results_delete, revert_to_version: 2
+
+    # Views reference V2-named tables and must be dropped before the renames
+    drop_view :v2_test_results,   revert_to_version: 5
+    drop_view :report_systems,    revert_to_version: 2
+    drop_view :supported_profiles, revert_to_version: 4
+
+    # Rename V2 tables to their canonical names (removing _v2 suffix / v2_ prefix)
+    rename_table :security_guides_v2,          :security_guides
+    rename_table :value_definitions_v2,        :value_definitions
+    rename_table :canonical_profiles_v2,       :profiles
+    rename_table :rules_v2,                    :rules
+    rename_table :rule_groups_v2,              :rule_groups
+    rename_table :profile_rules_v2,            :profile_rules
+    rename_table :policies_v2,                 :policies
+    rename_table :policy_systems_v2,           :policy_systems
+    rename_table :tailorings_v2,               :tailorings
+    rename_table :tailoring_rules_v2,          :tailoring_rules
+    rename_table :historical_test_results_v2,  :historical_test_results
+    rename_table :rule_results_v2,             :rule_results
+
+    # Rename indexes that still carry the old _v2 table name in their identifier
+    rename_index :historical_test_results,
+                 :index_historical_test_results_v2_on_system_tailoring_end_time,
+                 :index_historical_test_results_on_system_tailoring_end_time
+    rename_index :historical_test_results,
+                 :index_historical_test_results_v2_for_latest_lookup,
+                 :index_historical_test_results_for_latest_lookup
+    rename_index :rules,
+                 :index_rules_v2_on_identifier_labels,
+                 :index_rules_on_identifier_labels
+
+    # Recreate functions with updated references to the renamed tables
+    create_function :test_results_insert
+    create_function :test_results_delete
+
+    # Recreate views with SQL that references the renamed tables
+    create_view :test_results
+    create_view :report_systems,     version: 3
+    create_view :supported_profiles, version: 5
+
+    # Recreate triggers on the renamed view
+    create_trigger :test_results_insert, on: :test_results
+    create_trigger :test_results_delete, on: :test_results
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_112129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -21,20 +21,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.string "org_id", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["org_id"], name: "index_accounts_on_org_id", unique: true
-  end
-
-  create_table "canonical_profiles_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.string "description"
-    t.string "ref_id"
-    t.uuid "security_guide_id", null: false
-    t.string "title"
-    t.datetime "updated_at", precision: nil, null: false
-    t.boolean "upstream"
-    t.jsonb "value_overrides", default: {}
-    t.index ["ref_id", "security_guide_id"], name: "index_canonical_profiles_v2_on_ref_id_and_security_guide_id", unique: true
-    t.index ["title"], name: "index_canonical_profiles_v2_on_title"
-    t.index ["upstream"], name: "index_canonical_profiles_v2_on_upstream"
   end
 
   create_table "fixes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -151,7 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
-  create_table "historical_test_results_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "historical_test_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "end_time", precision: nil
     t.integer "failed_rule_count", default: 0, null: false
@@ -162,14 +148,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.uuid "system_id", null: false
     t.uuid "tailoring_id", null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["supported"], name: "index_historical_test_results_v2_on_supported"
-    t.index ["system_id", "tailoring_id", "end_time"], name: "index_historical_test_results_v2_on_system_tailoring_end_time", unique: true
-    t.index ["system_id"], name: "index_historical_test_results_v2_on_system_id"
-    t.index ["tailoring_id", "system_id", "end_time"], name: "index_historical_test_results_v2_for_latest_lookup", order: { end_time: :desc }, include: ["id"]
-    t.index ["tailoring_id"], name: "index_historical_test_results_v2_on_tailoring_id"
+    t.index ["supported"], name: "index_historical_test_results_on_supported"
+    t.index ["system_id", "tailoring_id", "end_time"], name: "index_historical_test_results_on_system_tailoring_end_time", unique: true
+    t.index ["system_id"], name: "index_historical_test_results_on_system_id"
+    t.index ["tailoring_id", "system_id", "end_time"], name: "index_historical_test_results_for_latest_lookup", order: { end_time: :desc }, include: ["id"]
+    t.index ["tailoring_id"], name: "index_historical_test_results_on_tailoring_id"
   end
 
-  create_table "policies_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "policies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
     t.string "business_objective"
     t.float "compliance_threshold", default: 100.0, null: false
@@ -178,18 +164,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.uuid "profile_id", null: false
     t.string "title", null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["account_id"], name: "index_policies_v2_on_account_id"
-    t.index ["profile_id"], name: "index_policies_v2_on_profile_id"
+    t.index ["account_id"], name: "index_policies_on_account_id"
+    t.index ["profile_id"], name: "index_policies_on_profile_id"
   end
 
-  create_table "policy_systems_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "policy_systems", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.uuid "policy_id", null: false
     t.uuid "system_id", null: false
     t.datetime "updated_at", precision: nil
-    t.index ["policy_id", "system_id"], name: "index_policy_systems_v2_on_policy_id_and_system_id", unique: true
-    t.index ["policy_id"], name: "index_policy_systems_v2_on_policy_id"
-    t.index ["system_id"], name: "index_policy_systems_v2_on_system_id"
+    t.index ["policy_id", "system_id"], name: "index_policy_systems_on_policy_id_and_system_id", unique: true
+    t.index ["policy_id"], name: "index_policy_systems_on_policy_id"
+    t.index ["system_id"], name: "index_policy_systems_on_system_id"
   end
 
   create_table "profile_os_minor_versions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -200,14 +186,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.index ["profile_id"], name: "index_profile_os_minor_versions_on_profile_id"
   end
 
-  create_table "profile_rules_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "profile_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.uuid "profile_id", null: false
     t.uuid "rule_id", null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["profile_id", "rule_id"], name: "index_profile_rules_v2_on_profile_id_and_rule_id", unique: true
-    t.index ["profile_id"], name: "index_profile_rules_v2_on_profile_id"
-    t.index ["rule_id"], name: "index_profile_rules_v2_on_rule_id"
+    t.index ["profile_id", "rule_id"], name: "index_profile_rules_on_profile_id_and_rule_id", unique: true
+    t.index ["profile_id"], name: "index_profile_rules_on_profile_id"
+    t.index ["rule_id"], name: "index_profile_rules_on_rule_id"
+  end
+
+  create_table "profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
+    t.string "description"
+    t.string "ref_id"
+    t.uuid "security_guide_id", null: false
+    t.string "title"
+    t.datetime "updated_at", precision: nil, null: false
+    t.boolean "upstream"
+    t.jsonb "value_overrides", default: {}
+    t.index ["ref_id", "security_guide_id"], name: "index_profiles_on_ref_id_and_security_guide_id", unique: true
+    t.index ["title"], name: "index_profiles_on_title"
+    t.index ["upstream"], name: "index_profiles_on_upstream"
   end
 
   create_table "revisions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -231,7 +231,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.index ["right_type", "right_id"], name: "index_rule_group_relationships_v2_on_right"
   end
 
-  create_table "rule_groups_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "rule_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "ancestry"
     t.datetime "created_at", precision: nil, null: false
     t.text "description"
@@ -242,26 +242,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.uuid "security_guide_id", null: false
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["ancestry"], name: "index_rule_groups_v2_on_ancestry"
-    t.index ["precedence"], name: "index_rule_groups_v2_on_precedence"
-    t.index ["ref_id", "security_guide_id"], name: "index_rule_groups_v2_on_ref_id_and_security_guide_id", unique: true
-    t.index ["rule_id"], name: "index_rule_groups_v2_on_rule_id", unique: true
-    t.index ["security_guide_id"], name: "index_rule_groups_v2_on_security_guide_id"
+    t.index ["ancestry"], name: "index_rule_groups_on_ancestry"
+    t.index ["precedence"], name: "index_rule_groups_on_precedence"
+    t.index ["ref_id", "security_guide_id"], name: "index_rule_groups_on_ref_id_and_security_guide_id", unique: true
+    t.index ["rule_id"], name: "index_rule_groups_on_rule_id", unique: true
+    t.index ["security_guide_id"], name: "index_rule_groups_on_security_guide_id"
   end
 
-  create_table "rule_results_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "rule_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "result"
     t.uuid "rule_id", null: false
     t.uuid "test_result_id", null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["rule_id"], name: "index_rule_results_v2_on_rule_id"
-    t.index ["test_result_id", "result"], name: "index_rule_results_v2_on_test_result_id_and_result"
-    t.index ["test_result_id", "rule_id"], name: "index_rule_results_v2_on_test_result_id_and_rule_id", unique: true
-    t.index ["test_result_id"], name: "index_rule_results_v2_on_test_result_id"
+    t.index ["rule_id"], name: "index_rule_results_on_rule_id"
+    t.index ["test_result_id", "result"], name: "index_rule_results_on_test_result_id_and_result"
+    t.index ["test_result_id", "rule_id"], name: "index_rule_results_on_test_result_id_and_rule_id", unique: true
+    t.index ["test_result_id"], name: "index_rule_results_on_test_result_id"
   end
 
-  create_table "rules_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.text "description"
     t.jsonb "identifier"
@@ -277,16 +277,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "upstream", default: false, null: false
     t.uuid "value_checks", default: [], array: true
-    t.index "((identifier -> 'label'::text))", name: "index_rules_v2_on_identifier_labels", using: :gin
-    t.index ["precedence"], name: "index_rules_v2_on_precedence"
-    t.index ["ref_id", "security_guide_id"], name: "index_rules_v2_on_ref_id_and_security_guide_id", unique: true
-    t.index ["ref_id"], name: "index_rules_v2_on_ref_id"
-    t.index ["references"], name: "index_rules_v2_on_references", opclass: :jsonb_path_ops, using: :gin
-    t.index ["severity"], name: "index_rules_v2_on_severity"
-    t.index ["upstream"], name: "index_rules_v2_on_upstream"
+    t.index "((identifier -> 'label'::text))", name: "index_rules_on_identifier_labels", using: :gin
+    t.index ["precedence"], name: "index_rules_on_precedence"
+    t.index ["ref_id", "security_guide_id"], name: "index_rules_on_ref_id_and_security_guide_id", unique: true
+    t.index ["ref_id"], name: "index_rules_on_ref_id"
+    t.index ["references"], name: "index_rules_on_references", opclass: :jsonb_path_ops, using: :gin
+    t.index ["severity"], name: "index_rules_on_severity"
+    t.index ["upstream"], name: "index_rules_on_upstream"
   end
 
-  create_table "security_guides_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "security_guides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.text "description", null: false
     t.integer "os_major_version", null: false
@@ -295,7 +295,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.string "title", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "version", null: false
-    t.index ["ref_id", "version"], name: "index_security_guides_v2_on_ref_id_and_version", unique: true
+    t.index ["ref_id", "version"], name: "index_security_guides_on_ref_id_and_version", unique: true
   end
 
   create_table "systems", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -313,25 +313,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.index ["insights_id"], name: "index_systems_on_insights_id"
   end
 
-  create_table "tailoring_rules_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "tailoring_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.uuid "rule_id", null: false
     t.uuid "tailoring_id", null: false
     t.datetime "updated_at", precision: nil
-    t.index ["rule_id"], name: "index_tailoring_rules_v2_on_rule_id"
-    t.index ["tailoring_id", "rule_id"], name: "index_tailoring_rules_v2_on_tailoring_id_and_rule_id", unique: true
-    t.index ["tailoring_id"], name: "index_tailoring_rules_v2_on_tailoring_id"
+    t.index ["rule_id"], name: "index_tailoring_rules_on_rule_id"
+    t.index ["tailoring_id", "rule_id"], name: "index_tailoring_rules_on_tailoring_id_and_rule_id", unique: true
+    t.index ["tailoring_id"], name: "index_tailoring_rules_on_tailoring_id"
   end
 
-  create_table "tailorings_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "tailorings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "os_minor_version"
     t.uuid "policy_id", null: false
     t.uuid "profile_id", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.jsonb "value_overrides", default: {}
-    t.index ["policy_id"], name: "index_tailorings_v2_on_policy_id"
-    t.index ["profile_id"], name: "index_tailorings_v2_on_profile_id"
+    t.index ["policy_id"], name: "index_tailorings_on_policy_id"
+    t.index ["profile_id"], name: "index_tailorings_on_profile_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -352,7 +352,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.index ["account_id"], name: "index_users_on_account_id"
   end
 
-  create_table "value_definitions_v2", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "value_definitions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "default_value"
     t.text "description"
@@ -363,68 +363,68 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
     t.datetime "updated_at", precision: nil, null: false
     t.decimal "upper_bound"
     t.string "value_type"
-    t.index ["ref_id", "security_guide_id"], name: "index_value_definitions_v2_on_ref_id_and_security_guide_id", unique: true
-    t.index ["security_guide_id"], name: "index_value_definitions_v2_on_security_guide_id"
+    t.index ["ref_id", "security_guide_id"], name: "index_value_definitions_on_ref_id_and_security_guide_id", unique: true
+    t.index ["security_guide_id"], name: "index_value_definitions_on_security_guide_id"
   end
 
-  add_foreign_key "policies_v2", "accounts"
-  add_foreign_key "policies_v2", "canonical_profiles_v2", column: "profile_id"
-  add_foreign_key "policy_systems_v2", "policies_v2", column: "policy_id"
-  add_foreign_key "rule_groups_v2", "rules_v2", column: "rule_id"
-  add_foreign_key "rule_groups_v2", "security_guides_v2", column: "security_guide_id"
-  add_foreign_key "rules_v2", "rule_groups_v2", column: "rule_group_id"
-  add_foreign_key "tailorings_v2", "canonical_profiles_v2", column: "profile_id"
-  add_foreign_key "tailorings_v2", "policies_v2", column: "policy_id"
-  add_foreign_key "value_definitions_v2", "security_guides_v2", column: "security_guide_id"
+  add_foreign_key "policies", "accounts"
+  add_foreign_key "policies", "profiles"
+  add_foreign_key "policy_systems", "policies"
+  add_foreign_key "rule_groups", "rules"
+  add_foreign_key "rule_groups", "security_guides"
+  add_foreign_key "rules", "rule_groups"
+  add_foreign_key "tailorings", "policies"
+  add_foreign_key "tailorings", "profiles"
+  add_foreign_key "value_definitions", "security_guides"
 
   create_view "report_systems", sql_definition: <<-SQL
       SELECT id,
       policy_id AS report_id,
       system_id
-     FROM policy_systems_v2;
+     FROM policy_systems;
   SQL
   create_view "supported_profiles", sql_definition: <<-SQL
-      SELECT (array_agg(canonical_profiles_v2.id ORDER BY (string_to_array((security_guides_v2.version)::text, '.'::text))::integer[] DESC))[1] AS id,
-      (array_agg(canonical_profiles_v2.title ORDER BY (string_to_array((security_guides_v2.version)::text, '.'::text))::integer[] DESC))[1] AS title,
-      (array_agg(canonical_profiles_v2.description ORDER BY (string_to_array((security_guides_v2.version)::text, '.'::text))::integer[] DESC))[1] AS description,
-      canonical_profiles_v2.ref_id,
-      (array_agg(security_guides_v2.id ORDER BY (string_to_array((security_guides_v2.version)::text, '.'::text))::integer[] DESC))[1] AS security_guide_id,
-      (array_agg(security_guides_v2.version ORDER BY (string_to_array((security_guides_v2.version)::text, '.'::text))::integer[] DESC))[1] AS security_guide_version,
-      security_guides_v2.os_major_version,
+      SELECT (array_agg(profiles.id ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS id,
+      (array_agg(profiles.title ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS title,
+      (array_agg(profiles.description ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS description,
+      profiles.ref_id,
+      (array_agg(security_guides.id ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS security_guide_id,
+      (array_agg(security_guides.version ORDER BY (string_to_array((security_guides.version)::text, '.'::text))::integer[] DESC))[1] AS security_guide_version,
+      security_guides.os_major_version,
       array_agg(DISTINCT profile_os_minor_versions.os_minor_version ORDER BY profile_os_minor_versions.os_minor_version DESC) AS os_minor_versions
-     FROM ((canonical_profiles_v2
-       JOIN security_guides_v2 ON ((security_guides_v2.id = canonical_profiles_v2.security_guide_id)))
-       JOIN profile_os_minor_versions ON ((profile_os_minor_versions.profile_id = canonical_profiles_v2.id)))
-    GROUP BY canonical_profiles_v2.ref_id, security_guides_v2.os_major_version;
+     FROM ((profiles
+       JOIN security_guides ON ((security_guides.id = profiles.security_guide_id)))
+       JOIN profile_os_minor_versions ON ((profile_os_minor_versions.profile_id = profiles.id)))
+    GROUP BY profiles.ref_id, security_guides.os_major_version;
   SQL
-  create_view "v2_test_results", sql_definition: <<-SQL
-      SELECT historical_test_results_v2.id,
-      historical_test_results_v2.tailoring_id,
-      historical_test_results_v2.report_id,
-      historical_test_results_v2.system_id,
-      historical_test_results_v2.start_time,
-      historical_test_results_v2.end_time,
-      historical_test_results_v2.score,
-      historical_test_results_v2.supported,
-      historical_test_results_v2.failed_rule_count,
-      historical_test_results_v2.created_at,
-      historical_test_results_v2.updated_at
-     FROM (historical_test_results_v2
-       JOIN ( SELECT historical_test_results_v2_1.tailoring_id,
-              historical_test_results_v2_1.system_id,
-              max(historical_test_results_v2_1.end_time) AS end_time
-             FROM historical_test_results_v2 historical_test_results_v2_1
-            GROUP BY historical_test_results_v2_1.tailoring_id, historical_test_results_v2_1.system_id) tr ON (((historical_test_results_v2.tailoring_id = tr.tailoring_id) AND (historical_test_results_v2.system_id = tr.system_id) AND (historical_test_results_v2.end_time = tr.end_time))));
+  create_view "test_results", sql_definition: <<-SQL
+      SELECT historical_test_results.id,
+      historical_test_results.tailoring_id,
+      historical_test_results.report_id,
+      historical_test_results.system_id,
+      historical_test_results.start_time,
+      historical_test_results.end_time,
+      historical_test_results.score,
+      historical_test_results.supported,
+      historical_test_results.failed_rule_count,
+      historical_test_results.created_at,
+      historical_test_results.updated_at
+     FROM (historical_test_results
+       JOIN ( SELECT historical_test_results_1.tailoring_id,
+              historical_test_results_1.system_id,
+              max(historical_test_results_1.end_time) AS end_time
+             FROM historical_test_results historical_test_results_1
+            GROUP BY historical_test_results_1.tailoring_id, historical_test_results_1.system_id) tr ON (((historical_test_results.tailoring_id = tr.tailoring_id) AND (historical_test_results.system_id = tr.system_id) AND (historical_test_results.end_time = tr.end_time))));
   SQL
 
-  create_function :v2_test_results_insert, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.v2_test_results_insert()
+  create_function :test_results_insert, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.test_results_insert()
        RETURNS trigger
        LANGUAGE plpgsql
       AS $function$
       DECLARE result_id uuid;
       BEGIN
-          INSERT INTO "historical_test_results_v2" (
+          INSERT INTO "historical_test_results" (
             "tailoring_id",
             "report_id",
             "system_id",
@@ -454,23 +454,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
       $function$
   SQL
 
-  create_function :v2_test_results_delete, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.v2_test_results_delete()
+  create_function :test_results_delete, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.test_results_delete()
        RETURNS trigger
        LANGUAGE plpgsql
       AS $function$
       BEGIN
-          DELETE FROM "historical_test_results_v2" WHERE "id" = OLD."id";
+          DELETE FROM "historical_test_results" WHERE "id" = OLD."id";
           RETURN OLD;
       END
       $function$
   SQL
 
-  create_trigger :v2_test_results_insert, sql_definition: <<-SQL
-      CREATE TRIGGER v2_test_results_insert INSTEAD OF INSERT ON public.v2_test_results FOR EACH ROW EXECUTE FUNCTION v2_test_results_insert()
+  create_trigger :test_results_delete, sql_definition: <<-SQL
+      CREATE TRIGGER test_results_delete INSTEAD OF DELETE ON public.test_results FOR EACH ROW EXECUTE FUNCTION test_results_delete()
   SQL
 
-  create_trigger :v2_test_results_delete, sql_definition: <<-SQL
-      CREATE TRIGGER v2_test_results_delete INSTEAD OF DELETE ON public.v2_test_results FOR EACH ROW EXECUTE FUNCTION v2_test_results_delete()
+  create_trigger :test_results_insert, sql_definition: <<-SQL
+      CREATE TRIGGER test_results_insert INSTEAD OF INSERT ON public.test_results FOR EACH ROW EXECUTE FUNCTION test_results_insert()
   SQL
 end

--- a/db/triggers/test_results_delete_v01.sql
+++ b/db/triggers/test_results_delete_v01.sql
@@ -1,0 +1,2 @@
+CREATE TRIGGER "test_results_delete" INSTEAD OF DELETE ON "test_results"
+FOR EACH ROW EXECUTE FUNCTION test_results_delete();

--- a/db/triggers/test_results_insert_v01.sql
+++ b/db/triggers/test_results_insert_v01.sql
@@ -1,0 +1,2 @@
+CREATE TRIGGER "test_results_insert" INSTEAD OF INSERT ON "test_results"
+FOR EACH ROW EXECUTE FUNCTION test_results_insert();

--- a/db/views/report_systems_v03.sql
+++ b/db/views/report_systems_v03.sql
@@ -1,0 +1,5 @@
+SELECT
+  "policy_systems"."id",
+  "policy_systems"."policy_id" AS "report_id",
+  "policy_systems"."system_id"
+FROM "policy_systems";

--- a/db/views/supported_profiles_v05.sql
+++ b/db/views/supported_profiles_v05.sql
@@ -1,0 +1,13 @@
+SELECT
+  (ARRAY_AGG("profiles"."id" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "id",
+  (ARRAY_AGG("profiles"."title" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "title",
+  (ARRAY_AGG("profiles"."description" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "description",
+  "profiles"."ref_id" AS "ref_id",
+  (ARRAY_AGG("security_guides"."id" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "security_guide_id",
+  (ARRAY_AGG("security_guides"."version" ORDER BY STRING_TO_ARRAY("security_guides"."version", '.')::int[] DESC))[1] AS "security_guide_version",
+  "security_guides"."os_major_version" AS "os_major_version",
+  ARRAY_AGG(DISTINCT "profile_os_minor_versions"."os_minor_version" ORDER BY "profile_os_minor_versions"."os_minor_version" DESC) AS "os_minor_versions"
+FROM "profiles"
+INNER JOIN "security_guides" ON "security_guides"."id" = "profiles"."security_guide_id"
+INNER JOIN "profile_os_minor_versions" ON "profile_os_minor_versions"."profile_id" = "profiles"."id"
+GROUP BY "profiles"."ref_id", "security_guides"."os_major_version";

--- a/db/views/test_results_v01.sql
+++ b/db/views/test_results_v01.sql
@@ -1,0 +1,19 @@
+SELECT
+  "historical_test_results"."id",
+  "historical_test_results"."tailoring_id",
+  "historical_test_results"."report_id",
+  "historical_test_results"."system_id",
+  "historical_test_results"."start_time",
+  "historical_test_results"."end_time",
+  "historical_test_results"."score",
+  "historical_test_results"."supported",
+  "historical_test_results"."failed_rule_count",
+  "historical_test_results"."created_at",
+  "historical_test_results"."updated_at"
+FROM "historical_test_results"
+INNER JOIN (
+  SELECT "historical_test_results"."tailoring_id", "historical_test_results"."system_id", MAX("historical_test_results"."end_time") AS "end_time"
+  FROM "historical_test_results" GROUP BY "historical_test_results"."tailoring_id", "historical_test_results"."system_id"
+) AS "tr" ON "historical_test_results"."tailoring_id" = "tr"."tailoring_id" AND
+             "historical_test_results"."system_id" = "tr"."system_id" AND
+             "historical_test_results"."end_time" = "tr"."end_time";

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -792,32 +792,32 @@ objects:
     - prefix: insights/compliance/policies
       query: >-
         SELECT DISTINCT
-          "policies_v2"."id",
-          "canonical_profiles_v2"."ref_id",
-          "canonical_profiles_v2"."title" AS "name",
+          "policies"."id",
+          "profiles"."ref_id",
+          "profiles"."title" AS "name",
           "accounts"."org_id",
-          CAST("security_guides_v2"."os_major_version" AS TEXT) AS "os_major_version"
-          FROM "policies_v2"
-          INNER JOIN "canonical_profiles_v2" ON "canonical_profiles_v2"."id" = "policies_v2"."profile_id"
-          INNER JOIN "accounts" ON "accounts"."id" = "policies_v2"."account_id"
-          INNER JOIN "security_guides_v2" ON "security_guides_v2"."id" = "canonical_profiles_v2"."security_guide_id";
+          CAST("security_guides"."os_major_version" AS TEXT) AS "os_major_version"
+          FROM "policies"
+          INNER JOIN "profiles" ON "profiles"."id" = "policies"."profile_id"
+          INNER JOIN "accounts" ON "accounts"."id" = "policies"."account_id"
+          INNER JOIN "security_guides" ON "security_guides"."id" = "profiles"."security_guide_id";
     - prefix: insights/compliance/policy_hosts
       query: >-
-        SELECT "policy_systems_v2"."system_id" AS "host_id", "policy_systems_v2"."policy_id" FROM "policy_systems_v2";
+        SELECT "policy_systems"."system_id" AS "host_id", "policy_systems"."policy_id" FROM "policy_systems";
     - prefix: insights/compliance/failed_rules
       query: >-
-        SELECT "rules_v2"."ref_id", "accounts"."org_id", COUNT("rule_results_v2"."id") as "failed_count" FROM "rule_results_v2"
-        INNER JOIN "rules_v2" ON "rules_v2"."id" = "rule_results_v2"."rule_id"
-        INNER JOIN "historical_test_results_v2" ON "historical_test_results_v2"."id" = "rule_results_v2"."test_result_id"
-        INNER JOIN "tailorings_v2" ON "tailorings_v2"."id" = "historical_test_results_v2"."tailoring_id"
-        INNER JOIN "policies_v2" ON "policies_v2"."id" = "tailorings_v2"."policy_id"
-        INNER JOIN "accounts" ON "accounts"."id" = "policies_v2"."account_id"
+        SELECT "rules"."ref_id", "accounts"."org_id", COUNT("rule_results"."id") as "failed_count" FROM "rule_results"
+        INNER JOIN "rules" ON "rules"."id" = "rule_results"."rule_id"
+        INNER JOIN "historical_test_results" ON "historical_test_results"."id" = "rule_results"."test_result_id"
+        INNER JOIN "tailorings" ON "tailorings"."id" = "historical_test_results"."tailoring_id"
+        INNER JOIN "policies" ON "policies"."id" = "tailorings"."policy_id"
+        INNER JOIN "accounts" ON "accounts"."id" = "policies"."account_id"
         INNER JOIN (
-          SELECT "historical_test_results_v2"."tailoring_id", "historical_test_results_v2"."system_id", MAX("historical_test_results_v2"."end_time") AS "end_time" FROM "historical_test_results_v2"
-          GROUP BY "historical_test_results_v2"."tailoring_id", "historical_test_results_v2"."system_id"
-        ) AS "tr" ON ("historical_test_results_v2"."tailoring_id" = "tr"."tailoring_id" AND "historical_test_results_v2"."system_id" = "tr"."system_id" AND "historical_test_results_v2"."end_time" = "tr"."end_time")
-        WHERE rule_results_v2.result IN ('fail', 'error', 'unknown', 'fixed')
-        GROUP BY "rules_v2"."ref_id", "accounts"."org_id";
+          SELECT "historical_test_results"."tailoring_id", "historical_test_results"."system_id", MAX("historical_test_results"."end_time") AS "end_time" FROM "historical_test_results"
+          GROUP BY "historical_test_results"."tailoring_id", "historical_test_results"."system_id"
+        ) AS "tr" ON ("historical_test_results"."tailoring_id" = "tr"."tailoring_id" AND "historical_test_results"."system_id" = "tr"."system_id" AND "historical_test_results"."end_time" = "tr"."end_time")
+        WHERE rule_results.result IN ('fail', 'error', 'unknown', 'fixed')
+        GROUP BY "rules"."ref_id", "accounts"."org_id";
 
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan
@@ -835,16 +835,16 @@ objects:
       chunksize: 200000
       query: >-
         SELECT
-          "historical_test_results_v2"."start_time" AS "start_time",
-          "historical_test_results_v2"."end_time" AS "end_time",
-          "historical_test_results_v2"."system_id"::TEXT AS "system_id",
-          "canonical_profiles_v2"."ref_id" AS "canonical_profile_ref_id",
+          "historical_test_results"."start_time" AS "start_time",
+          "historical_test_results"."end_time" AS "end_time",
+          "historical_test_results"."system_id"::TEXT AS "system_id",
+          "profiles"."ref_id" AS "canonical_profile_ref_id",
           "accounts"."org_id" AS "org_id"
-          FROM "historical_test_results_v2"
-          INNER JOIN "tailorings_v2" ON "tailorings_v2"."id" = "historical_test_results_v2"."tailoring_id"
-          INNER JOIN "policies_v2" ON "policies_v2"."id" = "tailorings_v2"."policy_id"
-          INNER JOIN "canonical_profiles_v2" ON "canonical_profiles_v2"."id" = "tailorings_v2"."profile_id"
-          INNER JOIN "accounts" ON "accounts"."id" = "policies_v2"."account_id";
+          FROM "historical_test_results"
+          INNER JOIN "tailorings" ON "tailorings"."id" = "historical_test_results"."tailoring_id"
+          INNER JOIN "policies" ON "policies"."id" = "tailorings"."policy_id"
+          INNER JOIN "profiles" ON "profiles"."id" = "tailorings"."profile_id"
+          INNER JOIN "accounts" ON "accounts"."id" = "policies"."account_id";
 
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan
@@ -863,10 +863,10 @@ objects:
       query: >-
         SELECT DISTINCT
           "accounts"."org_id"
-        FROM "policies_v2"
-        INNER JOIN "accounts" ON "accounts"."id" = "policies_v2"."account_id"
-        WHERE "policies_v2"."id" IN (
-          SELECT "policy_systems_v2"."policy_id" FROM "policy_systems_v2" GROUP BY "policy_systems_v2"."policy_id" HAVING COUNT("policy_systems_v2"."system_id") > 0);
+        FROM "policies"
+        INNER JOIN "accounts" ON "accounts"."id" = "policies"."account_id"
+        WHERE "policies"."id" IN (
+          SELECT "policy_systems"."policy_id" FROM "policy_systems" GROUP BY "policy_systems"."policy_id" HAVING COUNT("policy_systems"."system_id") > 0);
 
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan
@@ -884,13 +884,13 @@ objects:
       chunksize: 200000
       query: >-
         SELECT
-          "policies_v2"."account_id" AS "org_id",
-          "policy_systems_v2"."system_id"::TEXT AS "system_id",
-          MAX("historical_test_results_v2"."updated_at") AS "updated_at"
-        FROM "policies_v2"
-        INNER JOIN "policy_systems_v2" ON "policy_systems_v2"."policy_id" = "policies_v2"."id"
-        INNER JOIN "historical_test_results_v2" ON "historical_test_results_v2"."system_id" = "policy_systems_v2"."system_id"
-        GROUP BY "policies_v2"."account_id", "policy_systems_v2"."system_id";
+          "policies"."account_id" AS "org_id",
+          "policy_systems"."system_id"::TEXT AS "system_id",
+          MAX("historical_test_results"."updated_at") AS "updated_at"
+        FROM "policies"
+        INNER JOIN "policy_systems" ON "policy_systems"."policy_id" = "policies"."id"
+        INNER JOIN "historical_test_results" ON "historical_test_results"."system_id" = "policy_systems"."system_id"
+        GROUP BY "policies"."account_id", "policy_systems"."system_id";
 
 - apiVersion: v1
   kind: Secret

--- a/spec/controllers/rule_results_controller_spec.rb
+++ b/spec/controllers/rule_results_controller_spec.rb
@@ -96,7 +96,7 @@ describe RuleResultsController do
         # Verify the optimized query includes the required rule table with proper alias
         expect(query).to include('"rule"')
 
-        join_clauses = query.scan(/JOIN "v2_test_results"/i).count
+        join_clauses = query.scan(/JOIN "test_results"/i).count
         expect(join_clauses).to eq(1)
       end
     end

--- a/spec/factories/security_guide.rb
+++ b/spec/factories/security_guide.rb
@@ -20,8 +20,6 @@ FactoryBot.define do
       end
 
       create_list(:rule, ev.rule_count, security_guide: security_guide)
-
-      security_guide.reload # FIXME: remove this after the full remodel
     end
   end
 end


### PR DESCRIPTION
Depends on: https://github.com/RedHatInsights/compliance-backend/pull/2832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Renamed database tables and related indexes to remove legacy `v2` suffixes.
- Updated ActiveRecord models, queries, views, triggers, and migrations to use canonical table names.
- Added insert/delete trigger handling for the `test_results` view and restored the `reports` view.
- Updated compliance analytics queries and related specs for the new schema.
- Simplified model table mappings by relying on Rails defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->