### PR TITLE
fix(SupportedSsg): handle upstream SSG packages without .el suffix

### DIFF
--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -22,7 +22,7 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
 
   def version_with_revision
     Gem::Version.new(
-      package.sub(/^scap-security-guide-(.*)\.el.*$/, '\1')
+      package.sub(/^scap-security-guide-/, '').sub(/\.el.*$/, '')
     )
   end
 

--- a/spec/models/supported_ssg_spec.rb
+++ b/spec/models/supported_ssg_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SupportedSsg do
+  describe '#version_with_revision' do
+    it 'parses downstream package with .el suffix' do
+      ssg = described_class.new(
+        id: 'RHEL-8.0:scap-security-guide-0.1.79-1.el8',
+        package: 'scap-security-guide-0.1.79-1.el8',
+        version: '0.1.79',
+        os_major_version: '8',
+        os_minor_version: '0'
+      )
+
+      expect(ssg.version_with_revision).to eq(Gem::Version.new('0.1.79-1'))
+    end
+
+    it 'parses upstream package without .el suffix' do
+      ssg = described_class.new(
+        id: 'RHEL-9.0:scap-security-guide-0.1.81',
+        package: 'scap-security-guide-0.1.81',
+        version: '0.1.81',
+        os_major_version: '9',
+        os_minor_version: '0'
+      )
+
+      expect(ssg.version_with_revision).to eq(Gem::Version.new('0.1.81'))
+    end
+
+    it 'strips the .el suffix completely' do
+      ssg = described_class.new(
+        id: 'RHEL-9.4:scap-security-guide-0.1.73-2.el9_4',
+        package: 'scap-security-guide-0.1.73-2.el9_4',
+        version: '0.1.73',
+        os_major_version: '9',
+        os_minor_version: '4'
+      )
+
+      expect(ssg.version_with_revision).to eq(Gem::Version.new('0.1.73-2'))
+    end
+  end
+end


### PR DESCRIPTION
The single regex assumes all SSG packages have a `.el` suffix. Upstream packages (e.g. `scap-security-guide-0.1.81`) don't match, returning the full package string, which breaks Gem::Version parsing and SSG import sorting.

Split into two chained .sub() calls so each strips independently: the prefix is always removed, the .el suffix only when present.

Ref: RHINENG-28641

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated `SupportedSsg` `version_with_revision` parsing to support upstream SSG package IDs without an `.el` suffix by always stripping the `scap-security-guide-` prefix and only removing the `.el` suffix when present (prevents invalid `Gem::Version` parsing/import sorting issues).
- Added RSpec coverage for `.el` suffix present, `.el` suffix absent (upstream), and version normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->