### PR TITLE
fix(migration): comment out model references in old migrations

### DIFF
--- a/db/migrate/20191203091219_remove_time_fields_from_rule_results.rb
+++ b/db/migrate/20191203091219_remove_time_fields_from_rule_results.rb
@@ -7,11 +7,11 @@ class RemoveTimeFieldsFromRuleResults < ActiveRecord::Migration[5.2]
   def down
     add_column :rule_results, :start_time, :datetime
     add_column :rule_results, :end_time, :datetime
-    TestResult.find_each do |test_result|
-      rule_result_ids = test_result.rule_results.pluck(:id)
-      RuleResult.where(id: rule_result_ids).update_all(
-        start_time: test_result.start_time, end_time: test_result.end_time
-      )
-    end
+    # TestResult.find_each do |test_result|
+    #   rule_result_ids = test_result.rule_results.pluck(:id)
+    #   RuleResult.where(id: rule_result_ids).update_all(
+    #     start_time: test_result.start_time, end_time: test_result.end_time
+    #   )
+    # end
   end
 end

--- a/db/migrate/20200414144209_remove_default_benchmarks_from_rules.rb
+++ b/db/migrate/20200414144209_remove_default_benchmarks_from_rules.rb
@@ -4,13 +4,13 @@ class RemoveDefaultBenchmarksFromRules < ActiveRecord::Migration[5.2]
   end
 
   def down
-    phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
-      ref_id: 'phony_ref_id',
-      version: '0.0.0',
-      title: 'phony title',
-      description: 'phony description'
-    )
+    # phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
+    #   ref_id: 'phony_ref_id',
+    #   version: '0.0.0',
+    #   title: 'phony title',
+    #   description: 'phony description'
+    # )
 
-    change_column_default :rules, :benchmark_id, phony_benchmark.id
+    # change_column_default :rules, :benchmark_id, phony_benchmark.id
   end
 end

--- a/db/migrate/20200414144221_remove_default_benchmarks_from_profiles.rb
+++ b/db/migrate/20200414144221_remove_default_benchmarks_from_profiles.rb
@@ -4,13 +4,13 @@ class RemoveDefaultBenchmarksFromProfiles < ActiveRecord::Migration[5.2]
   end
 
   def down
-    phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
-      ref_id: 'phony_ref_id',
-      version: '0.0.0',
-      title: 'phony title',
-      description: 'phony description'
-    )
+    # phony_benchmark = Xccdf::Benchmark.find_or_create_by!(
+    #   ref_id: 'phony_ref_id',
+    #   version: '0.0.0',
+    #   title: 'phony title',
+    #   description: 'phony description'
+    # )
 
-    change_column_default :profiles, :benchmark_id, phony_benchmark.id
+    # change_column_default :profiles, :benchmark_id, phony_benchmark.id
   end
 end

--- a/db/migrate/20211005131012_delete_nil_account.rb
+++ b/db/migrate/20211005131012_delete_nil_account.rb
@@ -3,7 +3,7 @@
 # Removes accounts with NIL account_number
 class DeleteNilAccount < ActiveRecord::Migration[5.2]
   def up
-    Account.where(account_number: [nil, '']).delete_all
+    # Account.where(account_number: [nil, '']).delete_all
     change_column :accounts, :account_number, :string, null: false
   end
 

--- a/db/migrate/20211013152353_reset_revisions.rb
+++ b/db/migrate/20211013152353_reset_revisions.rb
@@ -1,6 +1,6 @@
 class ResetRevisions < ActiveRecord::Migration[5.2]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20211104065354_reset_datastream_revisions.rb
+++ b/db/migrate/20211104065354_reset_datastream_revisions.rb
@@ -1,6 +1,6 @@
 class ResetDatastreamRevisions < ActiveRecord::Migration[5.2]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20211112131735_clear_datastream_revisions.rb
+++ b/db/migrate/20211112131735_clear_datastream_revisions.rb
@@ -1,6 +1,6 @@
 class ClearDatastreamRevisions < ActiveRecord::Migration[5.2]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20211211074855_clear_revisions.rb
+++ b/db/migrate/20211211074855_clear_revisions.rb
@@ -1,6 +1,6 @@
 class ClearRevisions < ActiveRecord::Migration[5.2]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20220103131739_reset_revisions_ssg.rb
+++ b/db/migrate/20220103131739_reset_revisions_ssg.rb
@@ -1,6 +1,6 @@
 class ResetRevisionsSsg < ActiveRecord::Migration[6.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20220208085557_nullify_revisions.rb
+++ b/db/migrate/20220208085557_nullify_revisions.rb
@@ -1,6 +1,6 @@
 class NullifyRevisions < ActiveRecord::Migration[6.1]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20220210115944_reset_datastream_revisions_again.rb
+++ b/db/migrate/20220210115944_reset_datastream_revisions_again.rb
@@ -1,6 +1,6 @@
 class ResetDatastreamRevisionsAgain < ActiveRecord::Migration[6.1]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20220222190410_reset_revisions_again_again.rb
+++ b/db/migrate/20220222190410_reset_revisions_again_again.rb
@@ -1,6 +1,6 @@
 class ResetRevisionsAgainAgain < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20220310135223_reset_revisions_march_tenth.rb
+++ b/db/migrate/20220310135223_reset_revisions_march_tenth.rb
@@ -1,6 +1,6 @@
 class ResetRevisionsMarchTenth < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20220311152114_reset_remediations_revision.rb
+++ b/db/migrate/20220311152114_reset_remediations_revision.rb
@@ -1,6 +1,6 @@
 class ResetRemediationsRevision < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'remediations')&.delete
+    # Revision.find_by(name: 'remediations')&.delete
   end
 
   def down

--- a/db/migrate/20220312143550_reset_remediations_syslog.rb
+++ b/db/migrate/20220312143550_reset_remediations_syslog.rb
@@ -1,6 +1,6 @@
 class ResetRemediationsSyslog < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'remediations')&.delete
+    # Revision.find_by(name: 'remediations')&.delete
   end
 
   def down

--- a/db/migrate/20220323130920_clear_revisions_march_twenty_third.rb
+++ b/db/migrate/20220323130920_clear_revisions_march_twenty_third.rb
@@ -1,6 +1,6 @@
 class ClearRevisionsMarchTwentyThird < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20221014125732_clear_revisions_oct_fourteenth.rb
+++ b/db/migrate/20221014125732_clear_revisions_oct_fourteenth.rb
@@ -1,6 +1,6 @@
 class ClearRevisionsOctFourteenth < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20221122204659_rule_group_cleanup_reimport.rb
+++ b/db/migrate/20221122204659_rule_group_cleanup_reimport.rb
@@ -1,6 +1,6 @@
 class RuleGroupCleanupReimport < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20221130153701_reset_revisions_for_ancestry.rb
+++ b/db/migrate/20221130153701_reset_revisions_for_ancestry.rb
@@ -1,5 +1,5 @@
 class ResetRevisionsForAncestry < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20221202104757_reset_revision_rule_group_precedence.rb
+++ b/db/migrate/20221202104757_reset_revision_rule_group_precedence.rb
@@ -1,5 +1,5 @@
 class ResetRevisionRuleGroupPrecedence < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20221205103453_reset_datastream_identifier_references.rb
+++ b/db/migrate/20221205103453_reset_datastream_identifier_references.rb
@@ -1,5 +1,5 @@
 class ResetDatastreamIdentifierReferences < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20221208104648_reset_datastreams_for_rrc.rb
+++ b/db/migrate/20221208104648_reset_datastreams_for_rrc.rb
@@ -1,5 +1,5 @@
 class ResetDatastreamsForRrc < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20221216135909_reset_revision_dec_sixteenth.rb
+++ b/db/migrate/20221216135909_reset_revision_dec_sixteenth.rb
@@ -1,5 +1,5 @@
 class ResetRevisionDecSixteenth < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20221220143030_reset_revision_dec_twentieth.rb
+++ b/db/migrate/20221220143030_reset_revision_dec_twentieth.rb
@@ -1,5 +1,5 @@
 class ResetRevisionDecTwentieth < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20230104132131_reset_revisions_for_profile_value_overrides.rb
+++ b/db/migrate/20230104132131_reset_revisions_for_profile_value_overrides.rb
@@ -1,5 +1,5 @@
 class ResetRevisionsForProfileValueOverrides < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20230403203929_reset_revisions_april_third.rb
+++ b/db/migrate/20230403203929_reset_revisions_april_third.rb
@@ -1,5 +1,5 @@
 class ResetRevisionsAprilThird < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20230503142809_reset_revisions_value_definition.rb
+++ b/db/migrate/20230503142809_reset_revisions_value_definition.rb
@@ -1,6 +1,6 @@
 class ResetRevisionsValueDefinition < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20230503162446_reset_revisions_value_definition_again.rb
+++ b/db/migrate/20230503162446_reset_revisions_value_definition_again.rb
@@ -1,6 +1,6 @@
 class ResetRevisionsValueDefinitionAgain < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 
   def down

--- a/db/migrate/20240105155203_reset_datastreams_new_year.rb
+++ b/db/migrate/20240105155203_reset_datastreams_new_year.rb
@@ -1,5 +1,5 @@
 class ResetDatastreamsNewYear < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20240219092555_reset_revisions_for_name_changes.rb
+++ b/db/migrate/20240219092555_reset_revisions_for_name_changes.rb
@@ -1,5 +1,5 @@
 class ResetRevisionsForNameChanges < ActiveRecord::Migration[7.0]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end

--- a/db/migrate/20240527092643_test_result_failed_rule_count.rb
+++ b/db/migrate/20240527092643_test_result_failed_rule_count.rb
@@ -2,13 +2,12 @@ class TestResultFailedRuleCount < ActiveRecord::Migration[7.1]
   def up
     add_column :test_results, :failed_rule_count, :integer, default: 0, null: false
 
-    sq = TestResult.joins(:rule_results).where(rule_results: { result: %w[fail error unknown fixed] })
-                                        .group('test_results.id').select('test_results.id', 'COUNT(rule_results.id) as cnt')
+    # sq = TestResult.joins(:rule_results).where(rule_results: { result: %w[fail error unknown fixed] })
+    #                                     .group('test_results.id').select('test_results.id', 'COUNT(rule_results.id) as cnt')
 
-
-    ActiveRecord::Base.connection.execute(
-      "UPDATE test_results SET failed_rule_count = sq.cnt FROM (#{sq.to_sql}) AS sq WHERE sq.id = test_results.id"
-    )
+    # ActiveRecord::Base.connection.execute(
+    #   "UPDATE test_results SET failed_rule_count = sq.cnt FROM (#{sq.to_sql}) AS sq WHERE sq.id = test_results.id"
+    # )
   end
 
   def down

--- a/db/migrate/20241024044139_reset_datastreams_fixes.rb
+++ b/db/migrate/20241024044139_reset_datastreams_fixes.rb
@@ -1,5 +1,5 @@
 class ResetDatastreamsFixes < ActiveRecord::Migration[7.1]
   def up
-    Revision.find_by(name: 'datastreams')&.delete
+    # Revision.find_by(name: 'datastreams')&.delete
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Commented out legacy model/data backfills and cleanup operations in old migrations.
- Prevented historical migrations from deleting `Revision` records.
- Disabled rollback logic that depended on application models or recreated benchmark records.
- Removed the `test_results.failed_rule_count` backfill while retaining the column migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->