### PR TITLE
fix(rules): use plaintext banner value definitions on banner rules

### DIFF
--- a/app/services/concerns/xccdf/banner_value_mappings.rb
+++ b/app/services/concerns/xccdf/banner_value_mappings.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Xccdf
+  # Maps OVAL regex banner value refs to plaintext banner value refs introduced in
+  # scap-security-guide 0.1.81 (RHEL-118499). Remediations use *_banner_contents;
+  # check-export still references *_banner_text.
+  module BannerValueMappings
+    BANNER_TEXT_TO_CONTENTS = {
+      'xccdf_org.ssgproject.content_value_login_banner_text' =>
+        'xccdf_org.ssgproject.content_value_login_banner_contents',
+      'xccdf_org.ssgproject.content_value_remote_login_banner_text' =>
+        'xccdf_org.ssgproject.content_value_remote_login_banner_contents',
+      'xccdf_org.ssgproject.content_value_motd_banner_text' =>
+        'xccdf_org.ssgproject.content_value_motd_banner_contents',
+      'xccdf_org.ssgproject.content_value_dconf_login_banner_text' =>
+        'xccdf_org.ssgproject.content_value_dconf_login_banner_contents'
+    }.freeze
+  end
+end

--- a/app/services/concerns/xccdf/rules.rb
+++ b/app/services/concerns/xccdf/rules.rb
@@ -4,12 +4,13 @@ module Xccdf
   # Methods related to parsing rules
   module Rules
     extend ActiveSupport::Concern
+    include BannerValueMappings
 
     included do
       def rules
         @rules ||= @op_rules.each_with_index.map do |op_rule, idx|
           rule_group = rule_group_for(ref_id: op_rule.parent_id)
-          value_checks = op_rule.values.map { |value_ref_id| value_definition_for(ref_id: value_ref_id).id }
+          value_checks = value_checks_for(op_rule)
 
           ::Rule.from_parser(
             op_rule,
@@ -34,6 +35,19 @@ module Xccdf
       end
 
       private
+
+      def value_checks_for(op_rule)
+        op_rule.values.map do |value_ref_id|
+          value_definition_for(ref_id: remediable_banner_value_ref_id(value_ref_id)).id
+        end.uniq
+      end
+
+      def remediable_banner_value_ref_id(value_ref_id)
+        contents_ref_id = BANNER_TEXT_TO_CONTENTS[value_ref_id]
+        return value_ref_id unless contents_ref_id
+
+        value_definition_for(ref_id: contents_ref_id) ? contents_ref_id : value_ref_id
+      end
 
       def new_rules
         @new_rules ||= rules.select(&:new_record?)

--- a/spec/services/concerns/xccdf/rules_spec.rb
+++ b/spec/services/concerns/xccdf/rules_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Xccdf::Rules do
 
       # NOTE: taken from `app/services/concerns/xccdf/value_definitions.rb`
       def value_definition_for(ref_id:)
-        @value_lookup.fetch(ref_id)
+        @value_lookup[ref_id]
       end
     end.new(
       security_guide: security_guide,
@@ -140,6 +140,51 @@ RSpec.describe Xccdf::Rules do
 
       expect(results.length).to eq(2)
       expect(results.map(&:ref_id)).to contain_exactly(*op_rules.map(&:id))
+    end
+
+    context 'when a rule references a regex banner value' do
+      let!(:banner_text_definition) do
+        FactoryBot.create(
+          :value_definition,
+          security_guide: security_guide,
+          ref_id: 'xccdf_org.ssgproject.content_value_login_banner_text'
+        )
+      end
+
+      let(:banner_values) { [banner_text_definition.ref_id] }
+      let(:op_rule_to_update) { super().tap { |rule| rule.values = banner_values } }
+      let(:value_lookup) { super().merge(banner_text_definition.ref_id => banner_text_definition) }
+      let(:banner_rule) { service.rules.find { |rule| rule.ref_id == op_rule_to_update.id } }
+
+      context 'when plaintext banner contents exist in the security guide' do
+        let!(:banner_contents_definition) do
+          FactoryBot.create(
+            :value_definition,
+            security_guide: security_guide,
+            ref_id: 'xccdf_org.ssgproject.content_value_login_banner_contents'
+          )
+        end
+
+        let(:value_lookup) { super().merge(banner_contents_definition.ref_id => banner_contents_definition) }
+
+        it 'maps regex banner values to plaintext banner contents for remediation' do
+          expect(banner_rule.value_checks).to eq([banner_contents_definition.id])
+        end
+
+        context 'and the rule also references the plaintext banner value' do
+          let(:banner_values) { [banner_text_definition.ref_id, banner_contents_definition.ref_id] }
+
+          it 'deduplicates mapped and legacy banner values to a single contents id' do
+            expect(banner_rule.value_checks).to eq([banner_contents_definition.id])
+          end
+        end
+      end
+
+      context 'when plaintext banner contents are unavailable in the security guide' do
+        it 'keeps the regex banner value as a fallback' do
+          expect(banner_rule.value_checks).to eq([banner_text_definition.id])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/RHINENG-22924 - users could not edit `Login Banner` value.

Starting with scap-security-guide 0.1.81 [JIRA](https://redhat.atlassian.net/browse/RHEL-118499) & [PR #14371](https://github.com/ComplianceAsCode/content/pull/14371)), SSG introduced plaintext *_banner_contents value definitions for remediation, while OVAL checks still export regex *_banner_text refs. During SSG import, openscap_parser only reads OVAL check-export refs, so banner rules were persisted with value_checks pointing at the regex value definition — which the console cannot meaningfully edit.

This change maps banner rules to the plaintext *_banner_contents value definitions when they exist in the security guide, so the UI will allow patching values for banners.



## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Map regex banner references to editable plaintext banner contents when available.
- Preserve fallback behavior when plaintext banner definitions are unavailable.
- Add coverage for login, remote login, MOTD, and dconf banner mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->