### PR TITLE
feat(metrics): add Prometheus counters for system write failures

### DIFF
--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -26,6 +26,7 @@ module Kafka
     def payload_valid_for_import?(payload)
       unless valid_payload?(payload)
         @logger.error('[Kafka::SystemImporter] Ignored invalid message: missing host id or malformed tags')
+        Yabeda.compliance_system_import_invalid_total.increment({})
         return false
       end
       true
@@ -51,10 +52,14 @@ module Kafka
 
     def upsert_system(id, payload, updated)
       attrs = extract_system_attrs(id, payload, updated)
+      result = upsert_kafka_system(attrs)
+      log_upsert_result(result, id)
+    end
 
+    def upsert_kafka_system(attrs)
       # rubocop:disable Rails/SkipsModelValidations
       # rubocop:disable Layout/LineLength
-      result = KafkaSystem.upsert(
+      KafkaSystem.upsert(
         attrs,
         unique_by: :id,
         returning: %w[id],
@@ -62,13 +67,15 @@ module Kafka
       )
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations
-
-      log_upsert_result(result, id)
+    rescue ActiveRecord::ActiveRecordError
+      Yabeda.compliance_system_import_failures_total.increment({})
+      raise
     end
 
     def log_upsert_result(result, id)
       if result.rows.empty?
         @logger.info("[Kafka::SystemImporter] Ignored stale message for system #{id}")
+        Yabeda.compliance_system_import_stale_total.increment({})
       else
         @logger.audit_success("[Kafka::SystemImporter] Imported system #{id}")
       end

--- a/app/services/kafka/system_remover.rb
+++ b/app/services/kafka/system_remover.rb
@@ -21,6 +21,7 @@ module Kafka
 
       if result.zero?
         @logger.info("[Kafka::SystemRemover] Ignored stale delete event or no active system found for ID #{@id}")
+        Yabeda.compliance_system_delete_noop_total.increment({})
       else
         @logger.audit_success("[Kafka::SystemRemover] Soft-deleted system #{@id}")
       end

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -82,6 +82,18 @@ Yabeda.configure do
         comment: 'Number of unfinished jobs in the GoodJob queue',
         tags: %i[queue]
 
+  counter :compliance_system_import_invalid_total,
+          comment: 'Count of system import messages rejected due to invalid payload or type mismatch'
+
+  counter :compliance_system_import_stale_total,
+          comment: 'Count of system import messages ignored because the DB record is newer'
+
+  counter :compliance_system_import_failures_total,
+          comment: 'Count of system import DB write failures'
+
+  counter :compliance_system_delete_noop_total,
+          comment: 'Count of system delete events where no matching records were found'
+
   collect do
     Compliance::TableSizeCollector.collect
     Compliance::GoodJobQueueDepthCollector.collect

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ if Rails.env.production?
 end
 require 'spec_helper'
 require 'rspec/rails'
+require 'yabeda/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Kafka::SystemImporter do
         expect(Karafka.logger).to receive(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
         expect { service.import }.not_to(change { KafkaSystem.count })
       end
+
+      it 'increments the invalid counter' do
+        expect { service.import }.to increment_yabeda_counter(Yabeda.compliance_system_import_invalid_total).by(1)
+      end
     end
 
     context 'when payload is invalid (malformed tags)' do
@@ -40,6 +44,10 @@ RSpec.describe Kafka::SystemImporter do
       it 'ignores the message and logs an error' do
         expect(Karafka.logger).to receive(:error).with(/\[Kafka::SystemImporter\] Ignored invalid message/)
         expect { service.import }.not_to(change { KafkaSystem.count })
+      end
+
+      it 'increments the invalid counter' do
+        expect { service.import }.to increment_yabeda_counter(Yabeda.compliance_system_import_invalid_total).by(1)
       end
     end
 
@@ -86,6 +94,10 @@ RSpec.describe Kafka::SystemImporter do
         system = KafkaSystem.find(message['host']['id'])
         expect(system.display_name).to eq('old-name')
       end
+
+      it 'increments the stale counter' do
+        expect { service.import }.to increment_yabeda_counter(Yabeda.compliance_system_import_stale_total).by(1)
+      end
     end
 
     context 'when message is strictly stale (older than DB)' do
@@ -100,6 +112,10 @@ RSpec.describe Kafka::SystemImporter do
       it 'ignores the stale message' do
         expect(Karafka.logger).to receive(:info).with(/\[Kafka::SystemImporter\] Ignored stale message/)
         expect { service.import }.not_to(change { KafkaSystem.count })
+      end
+
+      it 'increments the stale counter' do
+        expect { service.import }.to increment_yabeda_counter(Yabeda.compliance_system_import_stale_total).by(1)
       end
     end
 
@@ -179,7 +195,7 @@ RSpec.describe Kafka::SystemImporter do
       end
     end
 
-    context 'when exception occurs' do
+    context 'when a database exception occurs' do
       before do
         allow(KafkaSystem).to receive(:upsert).and_raise(ActiveRecord::ActiveRecordError, 'db down')
       end
@@ -189,6 +205,35 @@ RSpec.describe Kafka::SystemImporter do
           .to receive(:audit_fail)
           .with(/\[Kafka::SystemImporter\] Failed to import system.*db down/)
         expect { service.import }.to raise_error(ActiveRecord::ActiveRecordError, 'db down')
+      end
+
+      it 'increments the failures counter' do
+        expect do
+          service.import
+        rescue ActiveRecord::ActiveRecordError
+          nil
+        end.to increment_yabeda_counter(Yabeda.compliance_system_import_failures_total).by(1)
+      end
+    end
+
+    context 'when a non-database exception occurs' do
+      before do
+        allow(service).to receive(:extract_system_attrs).and_raise(StandardError, 'unexpected')
+      end
+
+      it 'logs error and re-raises it' do
+        expect(Karafka.logger)
+          .to receive(:audit_fail)
+          .with(/\[Kafka::SystemImporter\] Failed to import system.*unexpected/)
+        expect { service.import }.to raise_error(StandardError, 'unexpected')
+      end
+
+      it 'does not increment the failures counter' do
+        expect do
+          service.import
+        rescue StandardError
+          nil
+        end.not_to increment_yabeda_counter(Yabeda.compliance_system_import_failures_total)
       end
     end
 

--- a/spec/services/kafka/system_remover_spec.rb
+++ b/spec/services/kafka/system_remover_spec.rb
@@ -78,6 +78,10 @@ describe Kafka::SystemRemover do
       expect { service.remove_system }.not_to(change { KafkaSystem.count })
       expect(kafka_system.reload.deleted_at).to be_nil
     end
+
+    it 'increments the noop delete counter' do
+      expect { service.remove_system }.to increment_yabeda_counter(Yabeda.compliance_system_delete_noop_total).by(1)
+    end
   end
 
   context 'when an exception occurs' do


### PR DESCRIPTION
RHINENG-23126

~~This PR might need to be edited due to changes that are currently being merged to the services that we want to track.~~

PR adopted to latest changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added Prometheus counters for invalid, stale, and failed system imports, plus no-op system deletes.
- Added tests verifying counter increments across importer and remover scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->