### PR TITLE
fix(db): align systems.org_id with host-inventory varchar(36)

### DIFF
--- a/db/migrate/20260714140729_align_systems_org_id_limit.rb
+++ b/db/migrate/20260714140729_align_systems_org_id_limit.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AlignSystemsOrgIdLimit < ActiveRecord::Migration[7.1]
+  def up
+    change_column :systems, :org_id, :string, limit: 36, null: false
+  end
+
+  def down
+    change_column :systems, :org_id, :string, limit: 36, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_24_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_140729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -205,7 +205,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_120000) do
     t.string "display_name", limit: 200, null: false
     t.jsonb "groups", default: []
     t.uuid "insights_id"
-    t.string "org_id", limit: 10, null: false
+    t.string "org_id", limit: 36, null: false
     t.datetime "stale_timestamp", null: false
     t.jsonb "system_profile", default: {}, null: false
     t.jsonb "tags", default: {}, null: false


### PR DESCRIPTION
host-inventory defines org_id as varchar(36):
https://github.com/RedHatInsights/insights-host-inventory/blob/82e0b3e0/app/models/host.py#L224

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Expands `systems.org_id` from 10 to 36 characters (kept `NOT NULL`) to match host-inventory’s `varchar(36)` definition.
- Adds a Rails migration to align the column limit and regenerates `db/schema.rb`.
- Updates PR template to include the Secure Coding Practices checklist link (only “General Coding Practices” marked complete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->