### PR TITLE
test(SSG): add integration spec with real datastream file

### DIFF
--- a/spec/services/concerns/xccdf/security_guides_spec.rb
+++ b/spec/services/concerns/xccdf/security_guides_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Xccdf::SecurityGuides do
                                    version: op_security_guide.version,
                                    os_major_version: '7',
                                    package_name: 'ssg-rhel7')
-      previous_timestamp = existing.updated_at
+      previous_timestamp = existing.reload.updated_at
 
       service.save_security_guide
 

--- a/spec/services/datastream_importer_spec.rb
+++ b/spec/services/datastream_importer_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe DatastreamImporter, type: :service do
 
   let(:importer) { described_class.new(datastream_filename) }
 
-  before do
-    allow_any_instance_of(DatastreamImporter).to receive(:op_datastream_file)
-      .with(datastream_filename).and_return(op_datastream)
-  end
-
   describe '#initialize' do
+    before do
+      allow_any_instance_of(DatastreamImporter).to receive(:op_datastream_file)
+        .with(datastream_filename).and_return(op_datastream)
+    end
+
     it 'loads the datastream from the fixture path' do
       expect(importer.instance_variable_get(:@op_security_guide)).to eq(op_security_guide)
       expect(importer.instance_variable_get(:@op_profiles)).to eq(op_profiles)
@@ -44,6 +44,8 @@ RSpec.describe DatastreamImporter, type: :service do
 
   describe '#import!' do
     before do
+      allow_any_instance_of(DatastreamImporter).to receive(:op_datastream_file)
+        .with(datastream_filename).and_return(op_datastream)
       allow(importer).to receive(:save_all_security_guide_info)
     end
 
@@ -51,6 +53,44 @@ RSpec.describe DatastreamImporter, type: :service do
       expect(SecurityGuide).to receive(:transaction).and_yield
       expect(importer).to receive(:save_all_security_guide_info)
       importer.import!
+    end
+  end
+
+  context 'with a real RHEL-8 datastream', :slow do
+    let(:importer) { described_class.new(file_fixture('ssg-rhel8-ds.xml').to_s) }
+
+    before do
+      allow(SupportedSsg).to receive(:by_os_major).and_return(
+        '8' => [OpenStruct.new(version: '0.1.81', package: 'scap-security-guide-0.1.81-1.el8_10')]
+      )
+      allow(SupportedSsg).to receive(:by_ssg_version).and_return(
+        '0.1.81' => [OpenStruct.new(os_major_version: '8', version: '0.1.81', os_minor_version: '10')]
+      )
+    end
+
+    describe '#import!' do
+      before { importer.import! }
+
+      let(:security_guide) { SecurityGuide.find_by!(ref_id: 'xccdf_org.ssgproject.content_benchmark_RHEL-8') }
+
+      it 'creates a security guide' do
+        expect(security_guide).not_to be_nil
+        expect(security_guide.version).to eq('0.1.81')
+        expect(security_guide.os_major_version).to eq(8)
+        expect(security_guide.package_name).to eq('scap-security-guide-0.1.81-1.el8_10')
+      end
+
+      it 'creates rule groups with ancestry' do
+        rule_groups = RuleGroup.where(security_guide: security_guide)
+        expect(rule_groups.count).to be > 0
+        expect(rule_groups.pluck(:ref_id)).to all(start_with('xccdf_org.ssgproject.content_group_'))
+        expect(rule_groups.where.not(ancestry: [nil, '']).count).to be > 0
+      end
+
+      it 'links rules to rule groups' do
+        orphan_rules = Rule.where(security_guide: security_guide, rule_group_id: nil)
+        expect(orphan_rules.count).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
[RHINENG-23712](https://redhat.atlassian.net/browse/RHINENG-23712)

Adds an integration spec that exercises `DatastreamImporter#import!` against a real RHEL-8 datastream file (`ssg-rhel8-ds.xml`, SSG version 0.1.81). This complements the existing mock-based unit tests with real-data coverage.

**Changes:**
- Add `spec/fixtures/files/ssg-rhel8-ds.xml` — real RHEL-8 datastream fixture
- Add `spec/services/concerns/xccdf/real_datastream_spec.rb` — integration spec that runs the full import pipeline and verifies:
  - Security guide is created with correct version, OS major version, and package name
  - Rule groups are created with ancestry (parent-child hierarchy)
  - All rules are linked to rule groups (no orphans)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

[RHINENG-23712]: https://redhat.atlassian.net/browse/RHINENG-23712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added a slow integration spec for `DatastreamImporter#import!` using the RHEL 8 SSG 0.1.81 `ssg-rhel8-ds.xml` fixture.
- Stubbed `SupportedSsg` (RHEL 8 / SSG 0.1.81) and asserted the imported `V2::SecurityGuide` metadata (`ref_id`, `version`, `os_major_version`, `package_name`).
- Verified `V2::RuleGroup` creation (expected `ref_id` prefix) including parent-child ancestry, and confirmed every imported `V2::Rule` is linked to a rule group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->