### PR TITLE
perf(parsing): use streaming XML reader to reduce memory usage

### DIFF
--- a/app/services/xccdf_report_extractor.rb
+++ b/app/services/xccdf_report_extractor.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Streams an XCCDF report and extracts only the Benchmark metadata and TestResult subtree
+class XccdfReportExtractor
+  class ExtractionError < StandardError; end
+
+  def self.extract(xml_string)
+    new(xml_string).extract
+  end
+
+  def initialize(xml_string)
+    @xml = xml_string
+  end
+
+  def extract
+    benchmark_tag = nil
+    benchmark_name = nil
+    benchmark_depth = nil
+    version_xml = nil
+    test_result_xml = nil
+
+    reader = Nokogiri::XML::Reader(@xml)
+    reader.each do |node|
+      next unless node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+
+      if benchmark_depth.nil? && node.local_name == 'Benchmark'
+        benchmark_depth = node.depth
+        benchmark_name = node.name
+        benchmark_tag = build_benchmark_open_tag(node)
+        next
+      end
+
+      next unless benchmark_depth
+      next unless node.depth == benchmark_depth + 1
+
+      case node.local_name
+      when 'version'
+        version_xml ||= node.outer_xml
+      when 'TestResult'
+        test_result_xml = node.outer_xml
+        break
+      end
+    end
+
+    validate!(benchmark_tag, version_xml, test_result_xml)
+    build_minimal_xml(benchmark_tag, benchmark_name, version_xml, test_result_xml)
+  rescue Nokogiri::XML::SyntaxError => e
+    raise ExtractionError, "Malformed XML: #{e.message}"
+  end
+
+  private
+
+  def build_benchmark_open_tag(node)
+    attr_str = node.attributes&.map { |name, value| %(#{name}="#{value}") }&.join(' ')
+    attr_str ? "<#{node.name} #{attr_str}>" : "<#{node.name}>"
+  end
+
+  def validate!(benchmark_tag, version_xml, test_result_xml)
+    raise ExtractionError, 'No <Benchmark> element found in report' unless benchmark_tag
+    raise ExtractionError, 'No <version> element found in report' unless version_xml
+    raise ExtractionError, 'No <TestResult> element found in report' unless test_result_xml
+  end
+
+  def build_minimal_xml(benchmark_tag, benchmark_name, version_xml, test_result_xml)
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n#{benchmark_tag}\n#{version_xml}\n#{test_result_xml}\n</#{benchmark_name}>"
+  end
+end

--- a/app/services/xccdf_report_extractor.rb
+++ b/app/services/xccdf_report_extractor.rb
@@ -6,6 +6,18 @@ require 'cgi'
 class XccdfReportExtractor
   class ExtractionError < StandardError; end
 
+  # Quote-aware match for the Benchmark start tag. Used instead of
+  # Reader#attribute_hash / #namespaces, which call xmlTextReaderExpand and
+  # materialize the entire Benchmark subtree (the rest of the report).
+  BENCHMARK_OPEN_TAG = /
+    <((?:[A-Za-z_][\w.-]*:)?Benchmark)
+    \b
+    (?:[^>"']|"[^"]*"|'[^']*')*
+    >
+  /x
+
+  FALLBACK_ATTRS = %w[xmlns xmlns:xsi id resolved style xml:lang].freeze
+
   def self.extract(xml_string)
     new(xml_string).extract
   end
@@ -67,7 +79,7 @@ class XccdfReportExtractor
 
     fragments[:benchmark_depth] = node.depth
     fragments[:benchmark_name] = node.name
-    fragments[:benchmark_tag] = build_benchmark_open_tag(node)
+    fragments[:benchmark_tag] = raw_benchmark_open_tag || fallback_open_tag(node)
   end
 
   def capture_child!(fragments, node)
@@ -79,31 +91,18 @@ class XccdfReportExtractor
     end
   end
 
-  def build_benchmark_open_tag(node)
-    attr_str = serialized_attributes(node)
-    attr_str.empty? ? "<#{node.name}>" : "<#{node.name} #{attr_str}>"
+  def raw_benchmark_open_tag
+    @xml[BENCHMARK_OPEN_TAG]
   end
 
-  def serialized_attributes(node)
-    combined_attributes(node).map do |name, value|
-      %(#{name}="#{escape_xml_attribute(value)}")
+  # Reader#attribute / #namespace_uri do not expand the subtree.
+  def fallback_open_tag(node)
+    attr_str = FALLBACK_ATTRS.filter_map do |name|
+      value = node.attribute(name)
+      %(#{name}="#{escape_xml_attribute(value)}") if value
     end.join(' ')
-  end
 
-  def combined_attributes(node)
-    namespace_attributes(node).merge(node.attribute_hash || {})
-  end
-
-  def namespace_attributes(node)
-    (node.namespaces || {}).each_with_object({}) do |(prefix, uri), attrs|
-      attrs[xmlns_attr_name(prefix)] = uri
-    end
-  end
-
-  def xmlns_attr_name(prefix)
-    return 'xmlns' if [nil, '', 'xmlns'].include?(prefix)
-
-    prefix.start_with?('xmlns:') ? prefix : "xmlns:#{prefix}"
+    attr_str.empty? ? "<#{node.name}>" : "<#{node.name} #{attr_str}>"
   end
 
   def escape_xml_attribute(value)

--- a/app/services/xccdf_report_extractor.rb
+++ b/app/services/xccdf_report_extractor.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'cgi'
+
+# Streams an XCCDF report and extracts only the Benchmark metadata and TestResult subtree
+class XccdfReportExtractor
+  class ExtractionError < StandardError; end
+
+  # Quote-aware match for the Benchmark start tag. Used instead of
+  # Reader#attribute_hash / #namespaces, which call xmlTextReaderExpand and
+  # materialize the entire Benchmark subtree (the rest of the report).
+  BENCHMARK_OPEN_TAG = /
+    <((?:[A-Za-z_][\w.-]*:)?Benchmark)
+    \b
+    (?:[^>"']|"[^"]*"|'[^']*')*
+    >
+  /x
+
+  FALLBACK_ATTRS = %w[xmlns xmlns:xsi id resolved style xml:lang].freeze
+
+  def self.extract(xml_string)
+    new(xml_string).extract
+  end
+
+  def initialize(xml_string)
+    @xml = xml_string
+  end
+
+  def extract
+    fragments = scan_report
+    validate!(fragments)
+    build_minimal_xml(fragments)
+  rescue Nokogiri::XML::SyntaxError => e
+    raise ExtractionError, "Malformed XML: #{e.message}"
+  end
+
+  private
+
+  def scan_report
+    fragments = empty_fragments
+
+    Nokogiri::XML::Reader(@xml).each do |node|
+      next unless element?(node)
+
+      process_node(fragments, node)
+      break if fragments[:test_result_xml]
+    end
+
+    fragments
+  end
+
+  def empty_fragments
+    {
+      benchmark_tag: nil,
+      benchmark_name: nil,
+      benchmark_depth: nil,
+      version_xml: nil,
+      test_result_xml: nil
+    }
+  end
+
+  def element?(node)
+    node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+  end
+
+  def process_node(fragments, node)
+    if fragments[:benchmark_depth].nil?
+      capture_benchmark!(fragments, node)
+      return
+    end
+
+    return unless node.depth == fragments[:benchmark_depth] + 1
+
+    capture_child!(fragments, node)
+  end
+
+  def capture_benchmark!(fragments, node)
+    return unless node.local_name == 'Benchmark'
+
+    fragments[:benchmark_depth] = node.depth
+    fragments[:benchmark_name] = node.name
+    fragments[:benchmark_tag] = raw_benchmark_open_tag || fallback_open_tag(node)
+  end
+
+  def capture_child!(fragments, node)
+    case node.local_name
+    when 'version'
+      fragments[:version_xml] ||= node.outer_xml
+    when 'TestResult'
+      fragments[:test_result_xml] = node.outer_xml
+    end
+  end
+
+  def raw_benchmark_open_tag
+    @xml[BENCHMARK_OPEN_TAG]
+  end
+
+  # Reader#attribute / #namespace_uri do not expand the subtree.
+  def fallback_open_tag(node)
+    attr_str = FALLBACK_ATTRS.filter_map do |name|
+      value = node.attribute(name)
+      %(#{name}="#{escape_xml_attribute(value)}") if value
+    end.join(' ')
+
+    attr_str.empty? ? "<#{node.name}>" : "<#{node.name} #{attr_str}>"
+  end
+
+  def escape_xml_attribute(value)
+    CGI.escapeHTML(value.to_s)
+  end
+
+  def validate!(fragments)
+    raise ExtractionError, 'No <Benchmark> element found in report' unless fragments[:benchmark_tag]
+    raise ExtractionError, 'No <version> element found in report' unless fragments[:version_xml]
+    raise ExtractionError, 'No <TestResult> element found in report' unless fragments[:test_result_xml]
+  end
+
+  def build_minimal_xml(fragments)
+    <<~XML.chomp
+      <?xml version="1.0" encoding="UTF-8"?>
+      #{fragments[:benchmark_tag]}
+      #{fragments[:version_xml]}
+      #{fragments[:test_result_xml]}
+      </#{fragments[:benchmark_name]}>
+    XML
+  end
+end

--- a/app/services/xccdf_report_extractor.rb
+++ b/app/services/xccdf_report_extractor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 # Streams an XCCDF report and extracts only the Benchmark metadata and TestResult subtree
 class XccdfReportExtractor
   class ExtractionError < StandardError; end
@@ -13,55 +15,114 @@ class XccdfReportExtractor
   end
 
   def extract
-    benchmark_tag = nil
-    benchmark_name = nil
-    benchmark_depth = nil
-    version_xml = nil
-    test_result_xml = nil
-
-    reader = Nokogiri::XML::Reader(@xml)
-    reader.each do |node|
-      next unless node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
-
-      if benchmark_depth.nil? && node.local_name == 'Benchmark'
-        benchmark_depth = node.depth
-        benchmark_name = node.name
-        benchmark_tag = build_benchmark_open_tag(node)
-        next
-      end
-
-      next unless benchmark_depth
-      next unless node.depth == benchmark_depth + 1
-
-      case node.local_name
-      when 'version'
-        version_xml ||= node.outer_xml
-      when 'TestResult'
-        test_result_xml = node.outer_xml
-        break
-      end
-    end
-
-    validate!(benchmark_tag, version_xml, test_result_xml)
-    build_minimal_xml(benchmark_tag, benchmark_name, version_xml, test_result_xml)
+    fragments = scan_report
+    validate!(fragments)
+    build_minimal_xml(fragments)
   rescue Nokogiri::XML::SyntaxError => e
     raise ExtractionError, "Malformed XML: #{e.message}"
   end
 
   private
 
+  def scan_report
+    fragments = empty_fragments
+
+    Nokogiri::XML::Reader(@xml).each do |node|
+      next unless element?(node)
+
+      process_node(fragments, node)
+      break if fragments[:test_result_xml]
+    end
+
+    fragments
+  end
+
+  def empty_fragments
+    {
+      benchmark_tag: nil,
+      benchmark_name: nil,
+      benchmark_depth: nil,
+      version_xml: nil,
+      test_result_xml: nil
+    }
+  end
+
+  def element?(node)
+    node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+  end
+
+  def process_node(fragments, node)
+    if fragments[:benchmark_depth].nil?
+      capture_benchmark!(fragments, node)
+      return
+    end
+
+    return unless node.depth == fragments[:benchmark_depth] + 1
+
+    capture_child!(fragments, node)
+  end
+
+  def capture_benchmark!(fragments, node)
+    return unless node.local_name == 'Benchmark'
+
+    fragments[:benchmark_depth] = node.depth
+    fragments[:benchmark_name] = node.name
+    fragments[:benchmark_tag] = build_benchmark_open_tag(node)
+  end
+
+  def capture_child!(fragments, node)
+    case node.local_name
+    when 'version'
+      fragments[:version_xml] ||= node.outer_xml
+    when 'TestResult'
+      fragments[:test_result_xml] = node.outer_xml
+    end
+  end
+
   def build_benchmark_open_tag(node)
-    attr_str = node.attributes&.map { |name, value| %(#{name}="#{value}") }&.join(' ')
-    attr_str ? "<#{node.name} #{attr_str}>" : "<#{node.name}>"
+    attr_str = serialized_attributes(node)
+    attr_str.empty? ? "<#{node.name}>" : "<#{node.name} #{attr_str}>"
   end
 
-  def validate!(benchmark_tag, version_xml, test_result_xml)
-    raise ExtractionError, 'No <Benchmark> element found in report' unless benchmark_tag
-    raise ExtractionError, 'No <version> element found in report' unless version_xml
-    raise ExtractionError, 'No <TestResult> element found in report' unless test_result_xml
+  def serialized_attributes(node)
+    combined_attributes(node).map do |name, value|
+      %(#{name}="#{escape_xml_attribute(value)}")
+    end.join(' ')
   end
 
-  def build_minimal_xml(benchmark_tag, benchmark_name, version_xml, test_result_xml)
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n#{benchmark_tag}\n#{version_xml}\n#{test_result_xml}\n</#{benchmark_name}>"
+  def combined_attributes(node)
+    namespace_attributes(node).merge(node.attribute_hash || {})
+  end
+
+  def namespace_attributes(node)
+    (node.namespaces || {}).each_with_object({}) do |(prefix, uri), attrs|
+      attrs[xmlns_attr_name(prefix)] = uri
+    end
+  end
+
+  def xmlns_attr_name(prefix)
+    return 'xmlns' if [nil, '', 'xmlns'].include?(prefix)
+
+    prefix.start_with?('xmlns:') ? prefix : "xmlns:#{prefix}"
+  end
+
+  def escape_xml_attribute(value)
+    CGI.escapeHTML(value.to_s)
+  end
+
+  def validate!(fragments)
+    raise ExtractionError, 'No <Benchmark> element found in report' unless fragments[:benchmark_tag]
+    raise ExtractionError, 'No <version> element found in report' unless fragments[:version_xml]
+    raise ExtractionError, 'No <TestResult> element found in report' unless fragments[:test_result_xml]
+  end
+
+  def build_minimal_xml(fragments)
+    <<~XML.chomp
+      <?xml version="1.0" encoding="UTF-8"?>
+      #{fragments[:benchmark_tag]}
+      #{fragments[:version_xml]}
+      #{fragments[:test_result_xml]}
+      </#{fragments[:benchmark_name]}>
+    XML
   end
 end

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -39,8 +39,7 @@ class XccdfReportParser
 
     @account = Account.from_identity_header(Insights::Api::Common::IdentityHeader.new(@b64_identity))
     @system = System.find(message['id'])
-    minimal_xml = XccdfReportExtractor.extract(report_contents)
-    @test_result_file = OpenscapParser::TestResultFile.new(minimal_xml)
+    @test_result_file = parse_test_result_file(report_contents)
     set_openscap_parser_data
 
     @policy = Policy.joins(:systems, :profile)
@@ -140,6 +139,10 @@ class XccdfReportParser
   end
 
   private
+
+  def parse_test_result_file(report_contents)
+    OpenscapParser::TestResultFile.new(XccdfReportExtractor.extract(report_contents))
+  end
 
   def parse_failure_message
     "Report for profile #{@test_result_file.test_result.profile_id} against " \

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -19,6 +19,7 @@ class XccdfReportParser
   class UnknownRuleError < StandardError; end
 
   ERRORS = [
+    XccdfReportExtractor::ExtractionError,
     MissingIdError, WrongFormatError, OSVersionMismatch, UnknownProfileError,
     ActiveRecord::RecordInvalid, ExternalReportError, UnknownBenchmarkError, UnknownRuleError
   ].freeze
@@ -38,7 +39,8 @@ class XccdfReportParser
 
     @account = Account.from_identity_header(Insights::Api::Common::IdentityHeader.new(@b64_identity))
     @system = System.find(message['id'])
-    @test_result_file = OpenscapParser::TestResultFile.new(report_contents)
+    minimal_xml = XccdfReportExtractor.extract(report_contents)
+    @test_result_file = OpenscapParser::TestResultFile.new(minimal_xml)
     set_openscap_parser_data
 
     @policy = Policy.joins(:systems, :profile)

--- a/app/services/xccdf_report_parser.rb
+++ b/app/services/xccdf_report_parser.rb
@@ -19,6 +19,7 @@ class XccdfReportParser
   class UnknownRuleError < StandardError; end
 
   ERRORS = [
+    XccdfReportExtractor::ExtractionError,
     MissingIdError, WrongFormatError, OSVersionMismatch, UnknownProfileError,
     ActiveRecord::RecordInvalid, ExternalReportError, UnknownBenchmarkError, UnknownRuleError
   ].freeze
@@ -38,7 +39,7 @@ class XccdfReportParser
 
     @account = Account.from_identity_header(Insights::Api::Common::IdentityHeader.new(@b64_identity))
     @system = System.find(message['id'])
-    @test_result_file = OpenscapParser::TestResultFile.new(report_contents)
+    @test_result_file = parse_test_result_file(report_contents)
     set_openscap_parser_data
 
     @policy = Policy.joins(:systems, :profile)
@@ -138,6 +139,10 @@ class XccdfReportParser
   end
 
   private
+
+  def parse_test_result_file(report_contents)
+    OpenscapParser::TestResultFile.new(XccdfReportExtractor.extract(report_contents))
+  end
 
   def parse_failure_message
     "Report for profile #{@test_result_file.test_result.profile_id} against " \

--- a/spec/services/xccdf_report_extractor_spec.rb
+++ b/spec/services/xccdf_report_extractor_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe XccdfReportExtractor do
+  let(:full_xml) { file_fixture('xccdf_report.xml').read }
+
+  describe '.extract' do
+    subject(:minimal_xml) { described_class.extract(full_xml) }
+
+    it 'produces a significantly smaller document' do
+      expect(minimal_xml.length).to be < full_xml.length / 4
+    end
+
+    it 'preserves the Benchmark id attribute' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.benchmark.id).to eq('xccdf_org.ssgproject.content_benchmark_RHEL-8')
+    end
+
+    it 'preserves the Benchmark version' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.benchmark.version).to eq('0.1.40')
+    end
+
+    it 'preserves the TestResult profile id' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.test_result.profile_id).to eq('xccdf_org.ssgproject.content_profile_standard')
+    end
+
+    it 'preserves all rule results' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.test_result.rule_results.count).to eq(367)
+    end
+
+    it 'returns empty arrays for unused benchmark children' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.benchmark.groups).to eq([])
+      expect(parsed.benchmark.profiles).to eq([])
+      expect(parsed.benchmark.rules).to eq([])
+      expect(parsed.benchmark.values).to eq([])
+    end
+
+    it 'produces a result that matches a full parse on all used fields' do
+      full_parsed = OpenscapParser::TestResultFile.new(full_xml)
+      mini_parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+
+      expect(mini_parsed.benchmark.id).to eq(full_parsed.benchmark.id)
+      expect(mini_parsed.benchmark.version).to eq(full_parsed.benchmark.version)
+      expect(mini_parsed.test_result.profile_id).to eq(full_parsed.test_result.profile_id)
+      expect(mini_parsed.test_result.score).to eq(full_parsed.test_result.score)
+      expect(mini_parsed.test_result.start_time).to eq(full_parsed.test_result.start_time)
+      expect(mini_parsed.test_result.end_time).to eq(full_parsed.test_result.end_time)
+      expect(mini_parsed.test_result.rule_results.count).to eq(full_parsed.test_result.rule_results.count)
+    end
+
+    context 'with the wrong_xccdf_report fixture' do
+      let(:full_xml) { file_fixture('wrong_xccdf_report.xml').read }
+
+      it 'extracts successfully' do
+        expect { minimal_xml }.not_to raise_error
+      end
+
+      it 'preserves the Benchmark id' do
+        parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+        expect(parsed.benchmark.id).to be_present
+      end
+    end
+
+    context 'when Benchmark element is missing' do
+      let(:full_xml) { '<not-a-benchmark/>' }
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /No <Benchmark> element/
+        )
+      end
+    end
+
+    context 'when TestResult element is missing' do
+      let(:benchmark_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
+      let(:full_xml) do
+        %(<Benchmark id="#{benchmark_id}"><version>#{Faker::App.semantic_version}</version></Benchmark>)
+      end
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /No <TestResult> element/
+        )
+      end
+    end
+
+    context 'when version element is missing' do
+      let(:benchmark_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
+      let(:full_xml) do
+        %(<Benchmark id="#{benchmark_id}"><TestResult id="#{Faker::Internet.uuid}"><score>50</score></TestResult></Benchmark>)
+      end
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /No <version> element/
+        )
+      end
+    end
+
+    context 'when XML is malformed' do
+      let(:full_xml) { '<Benchmark><truncated' }
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /Malformed XML/
+        )
+      end
+    end
+
+    it 'is idempotent on already-extracted XML' do
+      first_pass = described_class.extract(full_xml)
+      second_pass = described_class.extract(first_pass)
+
+      parsed1 = OpenscapParser::TestResultFile.new(first_pass)
+      parsed2 = OpenscapParser::TestResultFile.new(second_pass)
+
+      expect(parsed2.benchmark.id).to eq(parsed1.benchmark.id)
+      expect(parsed2.benchmark.version).to eq(parsed1.benchmark.version)
+      expect(parsed2.test_result.rule_results.count).to eq(parsed1.test_result.rule_results.count)
+    end
+  end
+end

--- a/spec/services/xccdf_report_extractor_spec.rb
+++ b/spec/services/xccdf_report_extractor_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe XccdfReportExtractor do
+  let(:full_xml) { file_fixture('xccdf_report.xml').read }
+
+  describe '.extract' do
+    subject(:minimal_xml) { described_class.extract(full_xml) }
+
+    it 'produces a significantly smaller document' do
+      expect(minimal_xml.length).to be < full_xml.length / 4
+    end
+
+    it 'preserves namespace declarations' do
+      expect(minimal_xml).to include('xmlns="http://checklists.nist.gov/xccdf/1.2"')
+    end
+
+    it 'preserves xml:lang on Benchmark' do
+      expect(minimal_xml).to include('xml:lang="en-US"')
+    end
+
+    it 'preserves the Benchmark id attribute' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.benchmark.id).to eq('xccdf_org.ssgproject.content_benchmark_RHEL-8')
+    end
+
+    it 'preserves the Benchmark version' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.benchmark.version).to eq('0.1.40')
+    end
+
+    it 'preserves the TestResult profile id' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.test_result.profile_id).to eq('xccdf_org.ssgproject.content_profile_standard')
+    end
+
+    it 'preserves all rule results' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.test_result.rule_results.count).to eq(367)
+    end
+
+    it 'returns empty arrays for unused benchmark children' do
+      parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+      expect(parsed.benchmark.groups).to eq([])
+      expect(parsed.benchmark.profiles).to eq([])
+      expect(parsed.benchmark.rules).to eq([])
+      expect(parsed.benchmark.values).to eq([])
+    end
+
+    it 'produces a result that matches a full parse on all used fields' do
+      full_parsed = OpenscapParser::TestResultFile.new(full_xml)
+      mini_parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+
+      expect(mini_parsed.benchmark.id).to eq(full_parsed.benchmark.id)
+      expect(mini_parsed.benchmark.version).to eq(full_parsed.benchmark.version)
+      expect(mini_parsed.test_result.profile_id).to eq(full_parsed.test_result.profile_id)
+      expect(mini_parsed.test_result.score).to eq(full_parsed.test_result.score)
+      expect(mini_parsed.test_result.start_time).to eq(full_parsed.test_result.start_time)
+      expect(mini_parsed.test_result.end_time).to eq(full_parsed.test_result.end_time)
+      expect(mini_parsed.test_result.rule_results.count).to eq(full_parsed.test_result.rule_results.count)
+    end
+
+    context 'with the wrong_xccdf_report fixture' do
+      let(:full_xml) { file_fixture('wrong_xccdf_report.xml').read }
+
+      it 'extracts successfully' do
+        expect { minimal_xml }.not_to raise_error
+      end
+
+      it 'preserves the Benchmark id' do
+        parsed = OpenscapParser::TestResultFile.new(minimal_xml)
+        expect(parsed.benchmark.id).to be_present
+      end
+    end
+
+    context 'when Benchmark element is missing' do
+      let(:full_xml) { '<not-a-benchmark/>' }
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /No <Benchmark> element/
+        )
+      end
+    end
+
+    context 'when TestResult element is missing' do
+      let(:benchmark_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
+      let(:full_xml) do
+        %(<Benchmark id="#{benchmark_id}"><version>#{Faker::App.semantic_version}</version></Benchmark>)
+      end
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /No <TestResult> element/
+        )
+      end
+    end
+
+    context 'when a Benchmark attribute value contains an unescaped >' do
+      let(:benchmark_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
+      let(:full_xml) do
+        <<~XML
+          <Benchmark id="#{benchmark_id}" title="a > b">
+            <version>#{Faker::App.semantic_version}</version>
+            <TestResult id="#{Faker::Internet.uuid}"/>
+          </Benchmark>
+        XML
+      end
+
+      it 'keeps the full open tag' do
+        expect(minimal_xml).to include(%(id="#{benchmark_id}"))
+        expect(minimal_xml).to include('title="a > b"')
+      end
+    end
+
+    context 'when a Benchmark attribute contains XML special characters' do
+      let(:attr_value) do
+        "#{Faker::Alphanumeric.alpha(number: 4)}&\"<>#{Faker::Alphanumeric.alpha(number: 4)}"
+      end
+      let(:full_xml) do
+        <<~XML
+          <Benchmark id="#{CGI.escapeHTML(attr_value)}">
+            <version>#{Faker::App.semantic_version}</version>
+            <TestResult id="#{Faker::Internet.uuid}"/>
+          </Benchmark>
+        XML
+      end
+
+      it 'round-trips the attribute without producing malformed XML' do
+        parsed = Nokogiri::XML(minimal_xml)
+
+        expect(parsed.errors).to be_empty
+        expect(parsed.at('Benchmark')['id']).to eq(attr_value)
+      end
+    end
+
+    context 'when version element is missing' do
+      let(:benchmark_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
+      let(:full_xml) do
+        <<~XML
+          <Benchmark id="#{benchmark_id}">
+            <TestResult id="#{Faker::Internet.uuid}">
+              <score>#{Faker::Number.between(from: 0, to: 100)}</score>
+            </TestResult>
+          </Benchmark>
+        XML
+      end
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /No <version> element/
+        )
+      end
+    end
+
+    context 'when XML is malformed' do
+      let(:full_xml) { '<Benchmark><truncated' }
+
+      it 'raises ExtractionError' do
+        expect { minimal_xml }.to raise_error(
+          described_class::ExtractionError, /Malformed XML/
+        )
+      end
+    end
+
+    it 'is idempotent on already-extracted XML' do
+      first_pass = described_class.extract(full_xml)
+      second_pass = described_class.extract(first_pass)
+
+      parsed1 = OpenscapParser::TestResultFile.new(first_pass)
+      parsed2 = OpenscapParser::TestResultFile.new(second_pass)
+
+      expect(parsed2.benchmark.id).to eq(parsed1.benchmark.id)
+      expect(parsed2.benchmark.version).to eq(parsed1.benchmark.version)
+      expect(parsed2.test_result.rule_results.count).to eq(parsed1.test_result.rule_results.count)
+    end
+  end
+end

--- a/spec/services/xccdf_report_extractor_spec.rb
+++ b/spec/services/xccdf_report_extractor_spec.rb
@@ -16,6 +16,10 @@ describe XccdfReportExtractor do
       expect(minimal_xml).to include('xmlns="http://checklists.nist.gov/xccdf/1.2"')
     end
 
+    it 'preserves xml:lang on Benchmark' do
+      expect(minimal_xml).to include('xml:lang="en-US"')
+    end
+
     it 'preserves the Benchmark id attribute' do
       parsed = OpenscapParser::TestResultFile.new(minimal_xml)
       expect(parsed.benchmark.id).to eq('xccdf_org.ssgproject.content_benchmark_RHEL-8')
@@ -90,6 +94,23 @@ describe XccdfReportExtractor do
         expect { minimal_xml }.to raise_error(
           described_class::ExtractionError, /No <TestResult> element/
         )
+      end
+    end
+
+    context 'when a Benchmark attribute value contains an unescaped >' do
+      let(:benchmark_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
+      let(:full_xml) do
+        <<~XML
+          <Benchmark id="#{benchmark_id}" title="a > b">
+            <version>#{Faker::App.semantic_version}</version>
+            <TestResult id="#{Faker::Internet.uuid}"/>
+          </Benchmark>
+        XML
+      end
+
+      it 'keeps the full open tag' do
+        expect(minimal_xml).to include(%(id="#{benchmark_id}"))
+        expect(minimal_xml).to include('title="a > b"')
       end
     end
 

--- a/spec/services/xccdf_report_extractor_spec.rb
+++ b/spec/services/xccdf_report_extractor_spec.rb
@@ -12,6 +12,10 @@ describe XccdfReportExtractor do
       expect(minimal_xml.length).to be < full_xml.length / 4
     end
 
+    it 'preserves namespace declarations' do
+      expect(minimal_xml).to include('xmlns="http://checklists.nist.gov/xccdf/1.2"')
+    end
+
     it 'preserves the Benchmark id attribute' do
       parsed = OpenscapParser::TestResultFile.new(minimal_xml)
       expect(parsed.benchmark.id).to eq('xccdf_org.ssgproject.content_benchmark_RHEL-8')
@@ -89,10 +93,37 @@ describe XccdfReportExtractor do
       end
     end
 
+    context 'when a Benchmark attribute contains XML special characters' do
+      let(:attr_value) do
+        "#{Faker::Alphanumeric.alpha(number: 4)}&\"<>#{Faker::Alphanumeric.alpha(number: 4)}"
+      end
+      let(:full_xml) do
+        <<~XML
+          <Benchmark id="#{CGI.escapeHTML(attr_value)}">
+            <version>#{Faker::App.semantic_version}</version>
+            <TestResult id="#{Faker::Internet.uuid}"/>
+          </Benchmark>
+        XML
+      end
+
+      it 'round-trips the attribute without producing malformed XML' do
+        parsed = Nokogiri::XML(minimal_xml)
+
+        expect(parsed.errors).to be_empty
+        expect(parsed.at('Benchmark')['id']).to eq(attr_value)
+      end
+    end
+
     context 'when version element is missing' do
       let(:benchmark_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
       let(:full_xml) do
-        %(<Benchmark id="#{benchmark_id}"><TestResult id="#{Faker::Internet.uuid}"><score>50</score></TestResult></Benchmark>)
+        <<~XML
+          <Benchmark id="#{benchmark_id}">
+            <TestResult id="#{Faker::Internet.uuid}">
+              <score>#{Faker::Number.between(from: 0, to: 100)}</score>
+            </TestResult>
+          </Benchmark>
+        XML
       end
 
       it 'raises ExtractionError' do


### PR DESCRIPTION
## Summary

Use a streaming `Nokogiri::XML::Reader` to extract only the data needed for report parsing from XCCDF reports, instead of building a full DOM tree for the entire document.

- **New `XccdfReportExtractor` service:** streams through the XML and extracts the `<Benchmark>` id/version and the `<TestResult>` subtree, then assembles a minimal synthetic document (~12-15% of the original size).
- **Transparent integration:** extraction happens inside `XccdfReportParser#initialize`, so all callers (Kafka validation, ParseReportJob persistence) benefit without changes.
- **No behavioral change:** the existing parser receives a smaller document but produces identical results — benchmark id, version, profile id, score, rule results are all preserved. Groups, profiles, rules, and values return empty arrays, which matches their current effective usage (loaded but never consumed during report parsing).
- **DatastreamImporter unaffected:** SSG imports use a separate class (`DatastreamFile`) and never touch the extractor.

RHINENG-1998

## Out of scope / follow-ups

- Extract once in `Kafka::ReportParser#validate_and_enqueue` and enqueue the minimal XML to reduce GoodJob/queue payload size by ~85%

> Draft: opened for early review and CI validation.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Replace full-DOM XCCDF parsing with streaming extraction.
- Preserve benchmark metadata, scores, and rule results in a reduced document.
- Preserve namespaces and complete `Benchmark` opening tags.
- Handle extraction errors through `XccdfReportParser`.
- Add extraction, validation, error-handling, and idempotency tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->