### PR TITLE
fix(Actions): strip digest from base image before appending :latest tag

### DIFF
--- a/.github/workflows/ruby-update.yml
+++ b/.github/workflows/ruby-update.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Fetch latest Ruby version from base image
         timeout-minutes: 10
         run: |
-          base=$(grep -Po '(?<=FROM )([^\s]*)(?= AS build)' Dockerfile)
+          base=$(grep -Po '(?<=FROM )[^\s]+(?= AS build)' Dockerfile | cut -d@ -f1)
           docker run --rm -u 0 "${base}":latest sh -c "
             microdnf module enable -y ruby:3.3 > /dev/null;
             microdnf repoquery ruby --info | grep Version | awk '{ print \$3 }' | head -1 > .ruby-version;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Strip any digest from the base image before appending the `:latest` tag in the Ruby update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->