### PR TITLE
fix(consumers): prevent DB connection pool exhaustion in inventory-consumer

### DIFF
--- a/app/consumers/application_consumer.rb
+++ b/app/consumers/application_consumer.rb
@@ -5,18 +5,9 @@ class ApplicationConsumer < Karafka::BaseConsumer
   attr_reader :message
 
   def consume
-    log_metadata
-
-    messages.each do |message|
-      @message = message
-
-      if attempt > 3
-        logger.error 'Discarded message'
-      else
-        consume_one
-      end
-
-      mark_as_consumed(message)
+    Rails.application.executor.wrap do
+      log_metadata
+      messages.each { |message| process(message) }
     end
   end
 
@@ -27,6 +18,18 @@ class ApplicationConsumer < Karafka::BaseConsumer
   end
 
   private
+
+  def process(message)
+    @message = message
+
+    if attempt > 3
+      logger.error 'Discarded message'
+    else
+      consume_one
+    end
+
+    mark_as_consumed(message)
+  end
 
   def log_metadata
     logger.info "Processing from #{messages.metadata.topic}/#{messages.metadata.partition} " \

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -561,6 +561,10 @@ objects:
               fieldPath: metadata.namespace
         - name: LOGSTREAM
           value: "${LOGSTREAM_CONSUMER}"
+        - name: POSTGRESQL_MAX_CONNECTIONS
+          value: "${POSTGRESQL_MAX_CONNECTIONS}"
+        - name: KARAFKA_CONCURRENCY
+          value: "${KARAFKA_CONCURRENCY}"
         livenessProbe:
           httpGet:
             path: /
@@ -999,6 +1003,9 @@ parameters:
 - name: POSTGRESQL_MAX_CONNECTIONS
   description: 'ActiveRecord connection pool size per process'
   value: "5"
+- name: KARAFKA_CONCURRENCY
+  description: 'Number of Karafka worker threads in the inventory-consumer process; must be less than POSTGRESQL_MAX_CONNECTIONS'
+  value: "4"
 - name: OLD_PATH_PREFIX
   value: /r/insights/platform
 - name: SETTINGS__FORCE_IMPORT_SSGS

--- a/karafka.rb
+++ b/karafka.rb
@@ -31,6 +31,7 @@ class KarafkaApp < Karafka::App
     config.client_id = self::CLIENT_ID
     config.consumer_persistence = !Rails.env.development?
     config.pause_with_exponential_backoff = false
+    config.concurrency = ENV.fetch('KARAFKA_CONCURRENCY', 4).to_i
   end
 
   Karafka.monitor.subscribe(

--- a/spec/consumers/application_consumer_spec.rb
+++ b/spec/consumers/application_consumer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ApplicationConsumer do
+  subject(:consumer) { karafka.consumer_for(Settings.kafka.topics.inventory_events) }
+
+  let(:message) do
+    {
+      'type' => 'delete',
+      'host' => {
+        'id' => Faker::Internet.uuid,
+        'insights_id' => Faker::Internet.uuid
+      }
+    }
+  end
+
+  before { karafka.produce(message.to_json) }
+
+  describe '#consume' do
+    before { allow_any_instance_of(Kafka::DeletedSystemCleaner).to receive(:cleanup_system) }
+
+    it 'wraps processing in the Rails executor for connection and state management' do
+      expect(Rails.application.executor).to receive(:wrap).and_call_original
+      consumer.consume
+    end
+
+    context 'when an error is raised during message processing' do
+      before { allow(consumer).to receive(:consume_one).and_raise(StandardError) }
+
+      it 'propagates the error outside the executor wrap' do
+        expect(Rails.application.executor).to receive(:wrap).and_call_original
+        expect { consumer.consume }.to raise_error(StandardError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
RHINENG-28796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Execute `ApplicationConsumer#consume` inside `Rails.application.executor.wrap` to ensure Rails/ActiveRecord thread-local state cleanup and consistent error-path handling; refactor per-message logic into `process(message)` and add consumer metadata logging.
- Make Karafka worker concurrency configurable via `KARAFKA_CONCURRENCY` (default `4`) and set it in the `inventory-consumer` deployment, constrained to be less than `POSTGRESQL_MAX_CONNECTIONS`.
- Add specs for `ApplicationConsumer` verifying `consume` runs within the Rails executor wrapper and that exceptions raised during message processing propagate as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->