### PR TITLE
fix(Kafka): process messages one-by-one

### DIFF
--- a/app/consumers/application_consumer.rb
+++ b/app/consumers/application_consumer.rb
@@ -10,7 +10,7 @@ class ApplicationConsumer < Karafka::BaseConsumer
     messages.each do |message|
       @message = message
 
-      if attempt > 2
+      if attempt > 3
         logger.error 'Discarded message'
       else
         consume_one

--- a/karafka.rb
+++ b/karafka.rb
@@ -48,6 +48,7 @@ class KarafkaApp < Karafka::App
     consumer_group :'complianceinventory-events-consumer' do
       topic Settings.kafka.topics.inventory_events do
         consumer InventoryEventsConsumer
+        max_messages 1
       end
     end
   end


### PR DESCRIPTION
### Problem

`ApplicationConsumer` processes Kafka messages in a batch loop and discards them after exceeding a retry threshold using Karafka's `attempt` counter. However, `attempt` is **batch-scoped** — it tracks how many times processing has been retried from the current committed offset, not per individual message.

With the default Karafka batch size, if message B fails repeatedly in a batch `[A, B, C, D]`, the retry batch on attempt 4 is `[B, C, D]`. The `attempt > 3` guard then discards B, C, and D — silently dropping C and D even though they never failed.

This has been the behaviour since the Karafka migration.

### Fix

- Set `max_messages 1` on the `inventory_events` topic. This ensures each `consume` call receives exactly one message, making `attempt` effectively per-message. A failing message is retried and eventually discarded in isolation without affecting subsequent messages.
- Bump the discard threshold from `attempt > 2` to `attempt > 3`, giving each message 3 genuine processing attempts before it is discarded. This aligns the implementation with the existing test description ("after three retries") which was already stubbing `attempt=4`.

### Why single-message batches are acceptable here

Processing inventory events one at a time does not meaningfully reduce throughput for this consumer. Each message triggers database operations (system upserts, policy assignments, report parsing dispatch) that individually take tens of milliseconds. The effective throughput is therefore bounded by `concurrency / avg_processing_time`, not by polling frequency. With `KARAFKA_CONCURRENCY=4` workers processing messages in parallel, `max_messages 1` changes the polling granularity but not the worker saturation point. The marginal cost of extra Kafka poll round-trips is negligible against the per-message DB work.

The alternative — DLQ with `independent: true` — would preserve real batching with correct per-message retry semantics, but requires provisioning a new Kafka topic and wiring it into `clowdapp.yaml`. That is left as a follow-up.

### References

- Karafka docs on [Unexpected Message Reprocessing](https://karafka.io/docs/Consumer-Groups-Unexpected-Message-Reprocessing) — confirms `attempt` is offset-scoped and documents `mark_as_consumed` per message as the mitigation for preceding-message reprocessing.
- Karafka docs on [Error Handling and Back-Off Policy](https://karafka.io/docs/Consumer-Groups-Error-Handling-and-Back-Off-Policy) — confirms `attempt` semantics and the `retrying?` helper.