### PR TITLE
perf(collection): skip serialization-only aggregations from collection count

### DIFF
--- a/app/controllers/concerns/collection.rb
+++ b/app/controllers/concerns/collection.rb
@@ -9,10 +9,9 @@ module Collection
   included do
     private
 
-    # Scope for metadata endpoints (e.g. os_versions) that need search and tag filtering
-    # but not the aggregation subqueries added by expand_resource for serialization.
-    def filtered_base_scope
-      scope = filter_by_tags(search(base_scope))
+    # Apply search, tag filtering, count, and parent validation to the given scope.
+    def resolve_collection(scope)
+      scope = filter_by_tags(search(scope))
       count = count_collection(scope)
       # If the count of records equals zero, make sure that the parents are not accessible
       validate_parents! if count.zero? && permitted_params[:parents]&.any?
@@ -21,12 +20,7 @@ module Collection
 
     # This is the method where you probably want to put a breakpoint to debug SQL
     def fetch_collection
-      scope = filter_by_tags(search(expand_resource))
-      count = count_collection(scope)
-      # If the count of records equals zero, make sure that the parents are not accessible
-      validate_parents! if count.zero? && permitted_params[:parents]&.any?
-
-      sort(scope).limit(pagination_limit).offset(pagination_offset)
+      sort(resolve_collection(expand_resource)).limit(pagination_limit).offset(pagination_offset)
     end
 
     def count_collection(scope)

--- a/app/controllers/concerns/collection.rb
+++ b/app/controllers/concerns/collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Generic methods to be used when calling fetch_collection on our models
+# Generic methods to be used when calling resolve_collection on our models
 module Collection
   extend ActiveSupport::Concern
 
@@ -14,15 +14,15 @@ module Collection
     end
 
     # Apply search, tag filtering, count, and parent validation to the given scope.
-    def resolve_collection(scope)
+    def fetch_collection(scope)
       scope = apply_filters(scope)
       validate_parents! if permitted_params[:parents]&.any? && collection_count.zero?
       scope
     end
 
     # This is the method where you probably want to put a breakpoint to debug SQL
-    def fetch_collection
-      sort(resolve_collection(expand_resource)).limit(pagination_limit).offset(pagination_offset)
+    def resolve_collection
+      sort(fetch_collection(expand_resource)).limit(pagination_limit).offset(pagination_offset)
     end
 
     def collection_count

--- a/app/controllers/concerns/collection.rb
+++ b/app/controllers/concerns/collection.rb
@@ -9,12 +9,14 @@ module Collection
   included do
     private
 
+    def apply_filters(scope)
+      filter_by_tags(search(scope))
+    end
+
     # Apply search, tag filtering, count, and parent validation to the given scope.
     def resolve_collection(scope)
-      scope = filter_by_tags(search(scope))
-      count = count_collection(scope)
-      # If the count of records equals zero, make sure that the parents are not accessible
-      validate_parents! if count.zero? && permitted_params[:parents]&.any?
+      scope = apply_filters(scope)
+      validate_parents! if permitted_params[:parents]&.any? && collection_count.zero?
       scope
     end
 
@@ -23,12 +25,11 @@ module Collection
       sort(resolve_collection(expand_resource)).limit(pagination_limit).offset(pagination_offset)
     end
 
-    def count_collection(scope)
+    def collection_count
       # Count the whole collection using a single column and not the whole table. This column
       # by default is the primary key of the table, however, in certain cases using a different
       # indexed column might produce faster results without even accessing the table.
-      # Pagination is disabled when counting collection so that all returned entities are counted.
-      @count_collection ||= scope.except(:limit, :offset).reselect(resource.base_class.count_by).count
+      @collection_count ||= apply_filters(count_scope).reselect(resource.base_class.count_by).count
     end
 
     def validate_parents!

--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -15,8 +15,8 @@ module Metadata
     # This is part of a JSON schema, no need for strict metrics
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
-    def metadata(model)
-      total ||= count_collection(model)
+    def metadata
+      total ||= collection_count
 
       {
         meta: {

--- a/app/controllers/concerns/rendering.rb
+++ b/app/controllers/concerns/rendering.rb
@@ -36,7 +36,7 @@ module Rendering
         data: Panko::ArraySerializer.new(
           model, only: only, each_serializer: serializer, context: serialization_context
         ),
-        **metadata(model)
+        **metadata
       )
     end
 

--- a/app/controllers/concerns/resolver.rb
+++ b/app/controllers/concerns/resolver.rb
@@ -6,7 +6,7 @@ module Resolver
 
   private
 
-  # Parent joins and 1:1 association joins applied. Foundation for both `expand_resource` and `filtered_base_scope`.
+  # Parent joins and 1:1 association joins applied. Foundation for both `expand_resource` and `resolve_collection`.
   def base_scope
     # Join with the route parents
     scope = join_parents(pundit_scope, permitted_params[:parents])

--- a/app/controllers/concerns/resolver.rb
+++ b/app/controllers/concerns/resolver.rb
@@ -6,7 +6,7 @@ module Resolver
 
   private
 
-  # Parent joins and 1:1 association joins applied. Foundation for both `expand_resource` and `resolve_collection`.
+  # Parent joins and 1:1 association joins applied. Foundation for both `expand_resource` and `fetch_collection`.
   def base_scope
     # Join with the route parents
     scope = join_parents(pundit_scope, permitted_params[:parents])

--- a/app/controllers/concerns/resolver.rb
+++ b/app/controllers/concerns/resolver.rb
@@ -19,6 +19,18 @@ module Resolver
     join_aggregated(base_scope).select(*select_fields)
   end
 
+  # Minimal scope for counting: base_scope plus only the aggregation subqueries whose fields
+  # are referenced by the current filter. Skips all other aggregations to keep the count query fast.
+  def count_scope
+    needed = filter_required_aggregations
+    return base_scope if needed.empty?
+
+    needed.reduce(base_scope) do |scope, (association, fields)|
+      aliases = fields.map { |aggregation, column| aggregation.call.as(column) }
+      scope.joins(subquery_fragment(association, aliases)).select(fields.map(&:second))
+    end
+  end
+
   # Reduce through all the associations of the `relation` and join+scope them or return the
   # `relation˙ untouched if it does not have any associations.
   def join_parents(relation, associations)
@@ -109,6 +121,17 @@ module Resolver
   # Retrieve the list of aggregations on any one-to-many associations specified by the serializer
   def aggregations
     @aggregations ||= serializer.aggregations(permitted_params[:parents], resource.one_to_many)
+  end
+
+  # Returns the subset of aggregations whose field names appear in the current filter string,
+  # so that count_scope can join only what is necessary for the count query to succeed.
+  def filter_required_aggregations
+    return {} if permitted_params[:filter].blank?
+
+    filter_fields = permitted_params[:filter].scan(/[a-z_]+/).to_set
+    aggregations.select do |_assoc, fields|
+      fields.any? { |_fn, column| filter_fields.include?(column.delete_prefix('aggregate_')) }
+    end
   end
 
   # List all the joined (direct and indirect) associations of a given scope

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -62,7 +62,7 @@ class PoliciesController < ApplicationController
   private
 
   def compliance_policies
-    @compliance_policies ||= authorize(fetch_collection)
+    @compliance_policies ||= authorize(resolve_collection)
   end
 
   def compliance_policy

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -24,7 +24,7 @@ class ProfilesController < ApplicationController
   private
 
   def profiles
-    @profiles ||= authorize(fetch_collection)
+    @profiles ||= authorize(resolve_collection)
   end
 
   def profile

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -34,7 +34,7 @@ class ReportsController < ApplicationController
 
   # :nocov:
   def os_versions
-    render json: authorize(filtered_base_scope).os_versions, status: :ok
+    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
   end
   # :nocov:
   permission_for_action :os_versions, Rbac::SYSTEM_READ

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -34,7 +34,7 @@ class ReportsController < ApplicationController
 
   # :nocov:
   def os_versions
-    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
+    render json: authorize(fetch_collection(base_scope)).os_versions, status: :ok
   end
   # :nocov:
   permission_for_action :os_versions, Rbac::SYSTEM_READ
@@ -43,7 +43,7 @@ class ReportsController < ApplicationController
   private
 
   def reports
-    @reports ||= authorize(fetch_collection)
+    @reports ||= authorize(resolve_collection)
   end
 
   def report

--- a/app/controllers/rule_groups_controller.rb
+++ b/app/controllers/rule_groups_controller.rb
@@ -17,7 +17,7 @@ class RuleGroupsController < ApplicationController
   private
 
   def rule_groups
-    @rule_groups ||= authorize(fetch_collection)
+    @rule_groups ||= authorize(resolve_collection)
   end
 
   def rule_group

--- a/app/controllers/rule_results_controller.rb
+++ b/app/controllers/rule_results_controller.rb
@@ -11,7 +11,7 @@ class RuleResultsController < ApplicationController
   private
 
   def rule_results
-    @rule_results ||= authorize(fetch_collection)
+    @rule_results ||= authorize(resolve_collection)
   end
 
   def resource

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -53,7 +53,7 @@ class RulesController < ApplicationController
   private
 
   def rules
-    @rules ||= authorize(fetch_collection)
+    @rules ||= authorize(resolve_collection)
   end
 
   def rule

--- a/app/controllers/security_guides_controller.rb
+++ b/app/controllers/security_guides_controller.rb
@@ -22,7 +22,7 @@ class SecurityGuidesController < ApplicationController
   permitted_params_for_action :rule_tree, id: ID_TYPE.required
 
   def os_versions
-    render json: authorize(filtered_base_scope).os_versions, status: :ok
+    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
   end
   permission_for_action :os_versions, Rbac::COMPLIANCE_VIEWER
   kessel_permission_for_action :os_versions, KesselRbac::POLICY_VIEW

--- a/app/controllers/security_guides_controller.rb
+++ b/app/controllers/security_guides_controller.rb
@@ -22,7 +22,7 @@ class SecurityGuidesController < ApplicationController
   permitted_params_for_action :rule_tree, id: ID_TYPE.required
 
   def os_versions
-    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
+    render json: authorize(fetch_collection(base_scope)).os_versions, status: :ok
   end
   permission_for_action :os_versions, Rbac::COMPLIANCE_VIEWER
   kessel_permission_for_action :os_versions, KesselRbac::POLICY_VIEW
@@ -31,7 +31,7 @@ class SecurityGuidesController < ApplicationController
   private
 
   def security_guides
-    @security_guides ||= authorize(fetch_collection)
+    @security_guides ||= authorize(resolve_collection)
   end
 
   def security_guide

--- a/app/controllers/supported_profiles_controller.rb
+++ b/app/controllers/supported_profiles_controller.rb
@@ -11,7 +11,7 @@ class SupportedProfilesController < ApplicationController
   private
 
   def supported_profiles
-    @supported_profiles ||= authorize(fetch_collection)
+    @supported_profiles ||= authorize(resolve_collection)
   end
 
   def resource

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -49,7 +49,7 @@ class SystemsController < ApplicationController
   permitted_params_for_action :destroy, { id: ID_TYPE }
 
   def os_versions
-    render json: authorize(filtered_base_scope).os_versions, status: :ok
+    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
   end
   permission_for_action :os_versions, Rbac::SYSTEM_READ
   permitted_params_for_action :os_versions, { filter: ParamType.string }

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -49,7 +49,7 @@ class SystemsController < ApplicationController
   permitted_params_for_action :destroy, { id: ID_TYPE }
 
   def os_versions
-    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
+    render json: authorize(fetch_collection(base_scope)).os_versions, status: :ok
   end
   permission_for_action :os_versions, Rbac::SYSTEM_READ
   permitted_params_for_action :os_versions, { filter: ParamType.string }
@@ -57,7 +57,7 @@ class SystemsController < ApplicationController
   private
 
   def systems
-    @systems ||= authorize(fetch_collection)
+    @systems ||= authorize(resolve_collection)
   end
 
   def system

--- a/app/controllers/tailorings_controller.rb
+++ b/app/controllers/tailorings_controller.rb
@@ -66,7 +66,7 @@ class TailoringsController < ApplicationController
   private
 
   def tailorings
-    @tailorings ||= authorize(fetch_collection)
+    @tailorings ||= authorize(resolve_collection)
   end
 
   def tailoring

--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -15,7 +15,7 @@ class TestResultsController < ApplicationController
   kessel_permission_for_action :show, KesselRbac::REPORT_VIEW
 
   def os_versions
-    render json: authorize(filtered_base_scope).os_versions, status: :ok
+    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
   end
   permission_for_action :os_versions, Rbac::SYSTEM_READ
   permitted_params_for_action :os_versions, { filter: ParamType.string }

--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -15,7 +15,7 @@ class TestResultsController < ApplicationController
   kessel_permission_for_action :show, KesselRbac::REPORT_VIEW
 
   def os_versions
-    render json: authorize(resolve_collection(base_scope)).os_versions, status: :ok
+    render json: authorize(fetch_collection(base_scope)).os_versions, status: :ok
   end
   permission_for_action :os_versions, Rbac::SYSTEM_READ
   permitted_params_for_action :os_versions, { filter: ParamType.string }
@@ -30,7 +30,7 @@ class TestResultsController < ApplicationController
   private
 
   def test_results
-    @test_results ||= authorize(fetch_collection)
+    @test_results ||= authorize(resolve_collection)
   end
 
   def test_result

--- a/app/controllers/value_definitions_controller.rb
+++ b/app/controllers/value_definitions_controller.rb
@@ -17,7 +17,7 @@ class ValueDefinitionsController < ApplicationController
   private
 
   def value_definitions
-    @value_definitions ||= authorize(fetch_collection)
+    @value_definitions ||= authorize(resolve_collection)
   end
 
   def value_definition


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Optimized collection counting by adding `count_scope`/`collection_count` to join only the aggregations required by the current filter (skipping serialization-only aggregations), with parent validation deferred until after the count check.
- Refactored collection resolution in `Collection` to centralize search/tag filtering via `apply_filters`, move sorting/pagination into `resolve_collection`, and remove older `filtered_base_scope`/`count_collection` helpers.
- Updated JSON:API metadata/serialization plumbing so collection `total` is derived from `collection_count` (changed `metadata(model)` → `metadata` and adjusted serializer metadata inputs).
- Switched multiple controllers’ index/authorization paths to use `resolve_collection` (and updated `os_versions` actions to authorize `fetch_collection(base_scope)` instead of the previous filtering helper).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->