### PR TITLE
chore(deploy): switch off systems backfill cronjob

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -138,57 +138,6 @@ objects:
         livenessProbe:
           exec:
             command: ["pgrep" ,"-f", "rake"]
-    - name: backfill-systems
-      schedule: ${BACKFILL_SYSTEMS_SCHEDULE}
-      concurrencyPolicy: Forbid
-      podSpec:
-        image: ${IMAGE}:${IMAGE_TAG}
-        initContainers:
-        - command: ["/bin/sh"]
-          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
-          inheritEnv: true
-        resources:
-          limits:
-            cpu: ${CPU_LIMIT_SERVICE}
-            memory: ${MEMORY_LIMIT_SERVICE}
-          requests:
-            cpu: ${CPU_REQUEST_SERVICE}
-            memory: ${MEMORY_REQUEST_SERVICE}
-        env:
-        - name: APPLICATION_TYPE
-          value: compliance-backfill-systems
-        - name: RAILS_ENV
-          value: "${RAILS_ENV}"
-        - name: RAILS_LOG_TO_STDOUT
-          value: "${RAILS_LOG_TO_STDOUT}"
-        - name: PATH_PREFIX
-          value: "${PATH_PREFIX}"
-        - name: RUBY_YJIT_ENABLE
-          value: "${RUBY_YJIT_ENABLE}"
-        - name: APP_NAME
-          value: "${APP_NAME}"
-        - name: BATCH_SIZE
-          value: "${BACKFILL_BATCH_SIZE}"
-        - name: MAX_ROWS_PER_RUN
-          value: "${BACKFILL_MAX_ROWS_PER_RUN}"
-        - name: SECRET_KEY_BASE
-          valueFrom:
-            secretKeyRef:
-              name: compliance-backend
-              key: secret_key_base
-        - name: MAX_INIT_TIMEOUT_SECONDS
-          value: "${MAX_INIT_TIMEOUT_SECONDS}"
-        - name: IMAGE_TAG
-          value: "${IMAGE}:${IMAGE_TAG}"
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: LOGSTREAM
-          value: "${LOGSTREAM_BACKFILL_SYSTEMS}"
-        livenessProbe:
-          exec:
-            command: ["pgrep" ,"-f", "rake"]
     - name: reindex-db
       schedule: ${REINDEX_DB_SCHEDULE}
       concurrencyPolicy: Forbid
@@ -1035,15 +984,6 @@ parameters:
 - name: REINDEX_DB_SCHEDULE
   description: Cronjob schedule for DB reindex
   value: "0 5 * * *" # every day at 5 AM
-- name: BACKFILL_SYSTEMS_SCHEDULE
-  description: Cronjob schedule for systems backfill
-  value: "*/5 * * * *" # every 5 minutes
-- name: BACKFILL_BATCH_SIZE
-  description: Number of rows per batch for systems backfill
-  value: "1000"
-- name: BACKFILL_MAX_ROWS_PER_RUN
-  description: Max rows to process per cron execution for systems backfill
-  value: "50000"
 - name: CLEANUP_SYSTEMS_SCHEDULE
   description: Cronjob schedule for systems cleanup
   value: "*/15 * * * *" # every 15 minutes
@@ -1073,8 +1013,6 @@ parameters:
   value: 'compliance-import-ssg'
 - name: LOGSTREAM_REINDEX_DB
   value: 'compliance-reindex-db'
-- name: LOGSTREAM_BACKFILL_SYSTEMS
-  value: 'compliance-backfill-systems'
 - name: LOGSTREAM_CLEANUP_SYSTEMS
   value: 'compliance-cleanup-systems'
 - name: RUBY_YJIT_ENABLE


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHINENG-28969

This PR switches off the systems backfill cronjob by removing the job definition and its associated parameters from clowdapp.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Disabled the systems backfill cronjob by removing its `backfill-systems` job from `deploy/clowdapp.yaml` and deleting its related scheduling/sizing parameters and `LOGSTREAM` wiring (RHINENG-28969).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->