### PR TITLE
fix(specs): truncate time to fix precision error in SSG test

### DIFF
--- a/spec/services/concerns/xccdf/security_guides_spec.rb
+++ b/spec/services/concerns/xccdf/security_guides_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Xccdf::SecurityGuides do
 
       service.save_security_guide
 
-      expect(existing.reload.updated_at).to eq(previous_timestamp)
+      expect(existing.reload.updated_at.round(6)).to eq(previous_timestamp.round(6))
     end
   end
 


### PR DESCRIPTION
Found issue randomly while running tests locally. 

- Ruby `Time` has nanosecond precision; PostgreSQL truncates to microseconds on write, so a round-trip through the DB produces a different value
- Fix: `.round(6)` on both sides before comparing to align precision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adjust SSG security guide spec to avoid `updated_at` precision mismatches by rounding both timestamps to PostgreSQL microsecond precision before comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->