### PR TITLE
feat(db): create read-optimized indexes on systems

### DIFF
--- a/db/migrate/20260721150715_add_deleted_at_index_to_systems.rb
+++ b/db/migrate/20260721150715_add_deleted_at_index_to_systems.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddDeletedAtIndexToSystems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :systems, :deleted_at,
+              where: 'deleted_at IS NOT NULL',
+              name: 'index_systems_on_deleted_at_partial',
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260721150758_add_org_id_and_id_index_to_systems.rb
+++ b/db/migrate/20260721150758_add_org_id_and_id_index_to_systems.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddOrgIdAndIdIndexToSystems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :systems, [:org_id, :id],
+              where: 'deleted_at IS NULL',
+              name: 'index_systems_on_org_id_and_id_partial',
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260721150825_add_org_id_and_display_name_index_to_systems.rb
+++ b/db/migrate/20260721150825_add_org_id_and_display_name_index_to_systems.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddOrgIdAndDisplayNameIndexToSystems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :systems, [:org_id, :display_name],
+              where: 'deleted_at IS NULL',
+              name: 'index_systems_on_org_id_and_display_name_partial',
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260721150850_add_owner_id_expression_index_to_systems.rb
+++ b/db/migrate/20260721150850_add_owner_id_expression_index_to_systems.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddOwnerIdExpressionIndexToSystems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :systems, "((system_profile ->> 'owner_id'))",
+              where: 'deleted_at IS NULL',
+              name: 'index_systems_on_owner_id_partial',
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260721150939_add_os_version_expression_index_to_systems.rb
+++ b/db/migrate/20260721150939_add_os_version_expression_index_to_systems.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddOsVersionExpressionIndexToSystems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :systems,
+              "org_id, (CAST(system_profile -> 'operating_system' ->> 'major' AS int)), (CAST(system_profile -> 'operating_system' ->> 'minor' AS int))",
+              where: 'deleted_at IS NULL',
+              name: 'index_systems_on_org_id_and_os_version_partial',
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260721151037_add_tags_and_groups_gin_indexes_to_systems.rb
+++ b/db/migrate/20260721151037_add_tags_and_groups_gin_indexes_to_systems.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddTagsAndGroupsGinIndexesToSystems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :systems, :tags,
+              using: :gin,
+              opclass: :jsonb_path_ops,
+              where: 'deleted_at IS NULL',
+              name: 'index_systems_on_tags_gin_partial',
+              algorithm: :concurrently
+
+    add_index :systems, :groups,
+              using: :gin,
+              opclass: :jsonb_path_ops,
+              where: 'deleted_at IS NULL',
+              name: 'index_systems_on_groups_gin_partial',
+              algorithm: :concurrently
+
+    add_index :systems, :groups,
+              where: "deleted_at IS NULL AND groups = '[]'::jsonb",
+              name: 'index_systems_on_empty_groups_partial',
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -313,9 +313,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
     t.index "((system_profile ->> 'owner_id'::text))", name: "index_systems_on_owner_id_partial", where: "(deleted_at IS NULL)"
     t.index "org_id, ((((system_profile -> 'operating_system'::text) ->> 'major'::text))::integer), ((((system_profile -> 'operating_system'::text) ->> 'minor'::text))::integer)", name: "index_systems_on_org_id_and_os_version_partial", where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_systems_on_deleted_at_partial", where: "(deleted_at IS NOT NULL)"
+    t.index ["groups"], name: "index_systems_on_empty_groups_partial", where: "((deleted_at IS NULL) AND (groups = '[]'::jsonb))"
+    t.index ["groups"], name: "index_systems_on_groups_gin_partial", opclass: :jsonb_path_ops, where: "(deleted_at IS NULL)", using: :gin
     t.index ["insights_id"], name: "index_systems_on_insights_id"
     t.index ["org_id", "display_name"], name: "index_systems_on_org_id_and_display_name_partial", where: "(deleted_at IS NULL)"
     t.index ["org_id", "id"], name: "index_systems_on_org_id_and_id_partial", where: "(deleted_at IS NULL)"
+    t.index ["tags"], name: "index_systems_on_tags_gin_partial", opclass: :jsonb_path_ops, where: "(deleted_at IS NULL)", using: :gin
   end
 
   create_table "tailoring_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,6 +312,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
     t.datetime "updated", null: false
     t.index ["deleted_at"], name: "index_systems_on_deleted_at_partial", where: "(deleted_at IS NOT NULL)"
     t.index ["insights_id"], name: "index_systems_on_insights_id"
+    t.index ["org_id", "id"], name: "index_systems_on_org_id_and_id_partial", where: "(deleted_at IS NULL)"
   end
 
   create_table "tailoring_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -310,6 +310,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
     t.jsonb "system_profile", default: {}, null: false
     t.jsonb "tags", default: {}, null: false
     t.datetime "updated", null: false
+    t.index ["deleted_at"], name: "index_systems_on_deleted_at_partial", where: "(deleted_at IS NOT NULL)"
     t.index ["insights_id"], name: "index_systems_on_insights_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,6 +312,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
     t.datetime "updated", null: false
     t.index ["deleted_at"], name: "index_systems_on_deleted_at_partial", where: "(deleted_at IS NOT NULL)"
     t.index ["insights_id"], name: "index_systems_on_insights_id"
+    t.index ["org_id", "display_name"], name: "index_systems_on_org_id_and_display_name_partial", where: "(deleted_at IS NULL)"
     t.index ["org_id", "id"], name: "index_systems_on_org_id_and_id_partial", where: "(deleted_at IS NULL)"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -310,6 +310,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
     t.jsonb "system_profile", default: {}, null: false
     t.jsonb "tags", default: {}, null: false
     t.datetime "updated", null: false
+    t.index "((system_profile ->> 'owner_id'::text))", name: "index_systems_on_owner_id_partial", where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_systems_on_deleted_at_partial", where: "(deleted_at IS NOT NULL)"
     t.index ["insights_id"], name: "index_systems_on_insights_id"
     t.index ["org_id", "display_name"], name: "index_systems_on_org_id_and_display_name_partial", where: "(deleted_at IS NULL)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -311,6 +311,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
     t.jsonb "tags", default: {}, null: false
     t.datetime "updated", null: false
     t.index "((system_profile ->> 'owner_id'::text))", name: "index_systems_on_owner_id_partial", where: "(deleted_at IS NULL)"
+    t.index "org_id, ((((system_profile -> 'operating_system'::text) ->> 'major'::text))::integer), ((((system_profile -> 'operating_system'::text) ->> 'minor'::text))::integer)", name: "index_systems_on_org_id_and_os_version_partial", where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_systems_on_deleted_at_partial", where: "(deleted_at IS NOT NULL)"
     t.index ["insights_id"], name: "index_systems_on_insights_id"
     t.index ["org_id", "display_name"], name: "index_systems_on_org_id_and_display_name_partial", where: "(deleted_at IS NULL)"


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHINENG-26775

This PR introduces read-optimized indexes to the `systems` table, ensuring safe, concurrent creation on production without write-locking. Each index has been committed separately with a detailed technical explanation in its commit body.

### Changes Summary
- **Deleted systems partial index:** `index_systems_on_deleted_at_partial` on `deleted_at` (`deleted_at IS NOT NULL`) to optimize tombstone cleanup/maintenance.
- **Tenant-scoped partial indexes:** `index_systems_on_org_id_and_id_partial` on `(org_id, id)` and `index_systems_on_org_id_and_display_name_partial` on `(org_id, display_name)` for active rows (`deleted_at IS NULL`).
- **Certificate auth owner index:** `index_systems_on_owner_id_partial` on `(system_profile ->> 'owner_id')` for active systems (`deleted_at IS NULL`).
- **OS version expression index:** `index_systems_on_org_id_and_os_version_partial` on `org_id` and integer-casted `major`/`minor` OS versions using text extraction `->>` for active rows (`deleted_at IS NULL`).
- **JSONB search GIN indexes:** `index_systems_on_tags_gin_partial` and `index_systems_on_groups_gin_partial` using `jsonb_path_ops` for active rows (`deleted_at IS NULL`).
- **Empty groups partial index:** `index_systems_on_empty_groups_partial` on `groups` (`where: "deleted_at IS NULL AND groups = '[]'::jsonb"`) to optimize ungrouped system lookups.
- **Unit test coverage:** Added specs in `spec/models/system_spec.rb` verifying all 8 partial and expression indexes on `systems`.

### Database & Security Impact
- **Zero-Downtime Migration Strategy:** All indexes use `algorithm: :concurrently` alongside `disable_ddl_transaction!`. This prevents PostgreSQL from acquiring an `ACCESS EXCLUSIVE` write lock on the `systems` table during deployment, avoiding API request timeouts or ingestion disruption in production.
- **Non-Transactional DDL Rationale:** PostgreSQL prohibits `CREATE INDEX CONCURRENTLY` inside transaction blocks. `disable_ddl_transaction!` is strictly required by Rails to enable concurrent index builds.
- **Failure Recovery Procedure:** If an index build is interrupted mid-execution (e.g. statement timeout or connection loss), PostgreSQL leaves an `INVALID` index in place. Invalid indexes do not affect read or write operations and can be safely dropped via `DROP INDEX CONCURRENTLY <index_name>` before re-running the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a concurrently-built partial index on `systems.deleted_at` for deleted rows (`deleted_at IS NOT NULL`) to speed cleanup/maintenance.
- Added concurrently-built partial composite indexes for active rows (`deleted_at IS NULL`) to optimize tenant-scoped lookups: `(org_id, id)` and `(org_id, display_name)`.
- Added concurrently-built partial expression indexes for active rows to speed filtering by `system_profile` JSON fields: `owner_id` and OS `major`/`minor`.
- Added concurrently-built partial GIN indexes on active rows for JSONB search: `systems.tags` and `systems.groups` (using `jsonb_path_ops`), including a special-case index for empty groups (`groups = '[]'`).
- Updated schema and added specs to assert the expected index set and that all `_partial` indexes include a non-empty `WHERE` clause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->