### PR TITLE
feat(metrics): expose GoodJob metrics and update Grafana dashboard

### DIFF
--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -38,6 +38,32 @@ module Compliance
       Rails.logger.error("Failed to collect DB table size metrics: #{e.full_message}")
     end
   end
+
+  class GoodJobQueueDepthCollector
+    def self.collect
+      return unless defined?(GoodJob::Job)
+
+      current_queues = []
+
+      GoodJob::Job.where(finished_at: nil).group(:queue_name).count.each do |queue, count|
+        queue_name = queue || 'default'
+        current_queues << queue_name
+        Yabeda.good_job_queue_depth.set({ queue: queue_name }, count)
+      end
+
+      # See the LIMITATION NOTE on TableSizeCollector for why stale entries are
+      # zeroed before being purged from the local in-memory hash.
+      metric = Yabeda.good_job_queue_depth
+      metric.values.keys.each do |tags|
+        unless current_queues.include?(tags[:queue])
+          metric.set(tags, 0)
+          metric.values.delete(tags)
+        end
+      end
+    rescue StandardError => e
+      Rails.logger.error("Failed to collect GoodJob queue depth metrics: #{e.message}")
+    end
+  end
 end
 
 # Metrics configuration
@@ -52,13 +78,18 @@ Yabeda.configure do
         comment: 'Total disk space used by each database table, including indexes and TOAST',
         tags: %i[table]
 
+  gauge :good_job_queue_depth,
+        comment: 'Number of unfinished jobs in the GoodJob queue',
+        tags: %i[queue]
+
   collect do
     Compliance::TableSizeCollector.collect
+    Compliance::GoodJobQueueDepthCollector.collect
   end
 end
 
-# Start the metrics server for sidekiq and karafka
-if %w[sidekiq karafka].any? { |p| $PROGRAM_NAME.include?(p) }
+# Start the metrics server for sidekiq, karafka, and good_job
+if %w[sidekiq karafka good_job].any? { |p| $PROGRAM_NAME.include?(p) }
   if ClowderCommonRuby::Config.clowder_enabled?
     ENV['PROMETHEUS_EXPORTER_PORT'] = ClowderCommonRuby::Config.load.metricsPort.to_s
   else

--- a/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
+++ b/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
@@ -593,13 +593,13 @@ objects:
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "max(sum(kube_pod_container_status_restarts_total{pod=~\"compliance-sidekiq-.*\"}))",
+                "expr": "max(sum(kube_pod_container_status_restarts_total{pod=~\"compliance-goodjob-.*\"}))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "refId": "A"
               }
             ],
-            "title": "Sidekiq restarts",
+            "title": "GoodJob restarts",
             "type": "stat"
           },
           {
@@ -2307,25 +2307,25 @@ objects:
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "(sum(rate(sidekiq_job_runtime_seconds_bucket{application=\"compliance\"}[$interval])) by (worker))/$qe",
+                "expr": "(sum(rate(activejob_runtime_seconds_bucket{application=\"compliance\"}[$interval])) by (activejob))/$qe",
                 "format": "time_series",
                 "intervalFactor": 1,
-                "legendFormat": "{{worker}}",
+                "legendFormat": "{{activejob}}",
                 "refId": "Total"
               },
               {
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "(sum(rate(sidekiq_job_runtime_seconds_bucket{application=\"compliance\",qe!=\"1\"}[$interval])) by (worker))/(-($qe - 1))",
+                "expr": "(sum(rate(activejob_runtime_seconds_bucket{application=\"compliance\",qe!=\"1\"}[$interval])) by (activejob))/(-($qe - 1))",
                 "format": "time_series",
                 "hide": false,
                 "intervalFactor": 1,
-                "legendFormat": "{{worker}}",
+                "legendFormat": "{{activejob}}",
                 "refId": "Excluding QE"
               }
             ],
-            "title": "Sidekiq Job Duration",
+            "title": "Job Duration",
             "type": "timeseries"
           },
           {
@@ -2773,10 +2773,10 @@ objects:
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "sum(increase(sidekiq_jobs_executed_total{application=\"compliance\"}[$interval])) by (worker)/$qe",
+                "expr": "sum(increase(activejob_executed_total{application=\"compliance\"}[$interval])) by (activejob)/$qe",
                 "format": "time_series",
                 "intervalFactor": 1,
-                "legendFormat": "{{worker}}",
+                "legendFormat": "{{activejob}}",
                 "refId": "Total"
               },
               {
@@ -2784,12 +2784,12 @@ objects:
                   "type": "prometheus",
                   "uid": "$datasource"
                 },
-                "expr": "sum(increase(sidekiq_jobs_executed_total{application=\"compliance\",qe!=\"1\"}[$interval])) by (worker)/(-($qe - 1))",
+                "expr": "sum(increase(activejob_executed_total{application=\"compliance\",qe!=\"1\"}[$interval])) by (activejob)/(-($qe - 1))",
                 "hide": false,
                 "refId": "Excluding QE"
               }
             ],
-            "title": "Sidekiq Job Count",
+            "title": "Job Count",
             "type": "timeseries"
           },
           {
@@ -3360,11 +3360,11 @@ objects:
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "(sum(increase(sidekiq_jobs_executed_total{application=\"compliance\",worker=\"ParseReportJob\"}[$interval])) OR on() vector(0)) - (sum(increase(sidekiq_jobs_failed_total{application=\"compliance\",worker=\"ParseReportJob\"}[$interval])) OR on() vector(0))",
+                "expr": "sum(increase(activejob_success_total{application=\"compliance\",activejob=\"ParseReportJob\"}[$interval])) OR on() vector(0)",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,
-                "legendFormat": "{{job_name}}",
+                "legendFormat": "{{activejob}}",
                 "refId": "A"
               }
             ],
@@ -3574,6 +3574,103 @@ objects:
           },
           {
             "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 12,
+              "x": 0,
+              "y": 70
+            },
+            "id": 23763572017,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "11.6.11",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "editorMode": "code",
+                "expr": "max by (queue) (good_job_queue_depth{application=\"compliance\"})",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "Get GoodJob Queue Depth"
+              }
+            ],
+            "title": "GoodJob Queue Depth",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
               "uid": "$datasource"
             },
             "fieldConfig": {
@@ -3734,11 +3831,11 @@ objects:
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "sum(increase(sidekiq_jobs_failed_total{application=\"compliance\",worker=\"ParseReportJob\"}[$interval])) OR on() vector(0)",
+                "expr": "sum(increase(activejob_failed_total{application=\"compliance\",activejob=\"ParseReportJob\"}[$interval])) OR on() vector(0)",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,
-                "legendFormat": "{{job_name}}",
+                "legendFormat": "{{activejob}}",
                 "refId": "A"
               }
             ],

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -553,8 +553,8 @@ objects:
             memory: ${MEMORY_REQUEST_GOODJOB}
         livenessProbe:
           httpGet:
-            path: /status
-            port: ${{GOOD_JOB_PROBE_PORT}}
+            path: /metrics
+            port: metrics
           initialDelaySeconds: 180
           timeoutSeconds: 5
           periodSeconds: 30

--- a/spec/initializers/yabeda_spec.rb
+++ b/spec/initializers/yabeda_spec.rb
@@ -55,3 +55,64 @@ RSpec.describe Compliance::TableSizeCollector do
     expect(metric.values[existing_tags].value).to eq(updated_existing_size)
   end
 end
+
+RSpec.describe Compliance::GoodJobQueueDepthCollector do
+  let(:active_queue_name) { "queue_#{Faker::Lorem.unique.word}" }
+  let(:stale_queue_name) { "queue_#{Faker::Lorem.unique.word}" }
+  let(:initial_active_count) { Faker::Number.between(from: 1, to: 10) }
+  let(:initial_stale_count) { Faker::Number.between(from: 1, to: 10) }
+  let(:updated_active_count) { Faker::Number.between(from: 11, to: 20) }
+
+  before do
+    metric = Yabeda.good_job_queue_depth
+    metric.set({ queue: active_queue_name }, initial_active_count)
+    metric.set({ queue: stale_queue_name }, initial_stale_count)
+  end
+
+  after do
+    Yabeda.good_job_queue_depth.values.clear
+  end
+
+  it 'removes metrics for queues with no unfinished jobs' do
+    relation = instance_double(ActiveRecord::Relation)
+    allow(GoodJob::Job).to receive(:where).with(finished_at: nil).and_return(relation)
+    allow(relation).to receive(:group).with(:queue_name).and_return(relation)
+    allow(relation).to receive(:count).and_return({ active_queue_name => updated_active_count })
+
+    allow(Yabeda.good_job_queue_depth).to receive(:set).and_call_original
+
+    described_class.collect
+
+    expect(Yabeda.good_job_queue_depth).to have_received(:set).with(
+      { application: 'compliance', qe: 0, source: 'basic', queue: stale_queue_name },
+      0
+    )
+
+    metric = Yabeda.good_job_queue_depth
+
+    expect(metric.values.keys.map { |tags| tags[:queue] }).to include(active_queue_name)
+    expect(metric.values.keys.map { |tags| tags[:queue] }).not_to include(stale_queue_name)
+
+    active_tags = { application: 'compliance', qe: 0, source: 'basic', queue: active_queue_name }
+    expect(metric.values[active_tags].value).to eq(updated_active_count)
+  end
+
+  it 'uses "default" for the nil queue name' do
+    relation = instance_double(ActiveRecord::Relation)
+    allow(GoodJob::Job).to receive(:where).with(finished_at: nil).and_return(relation)
+    allow(relation).to receive(:group).with(:queue_name).and_return(relation)
+    allow(relation).to receive(:count).and_return({ nil => 3 })
+
+    described_class.collect
+
+    default_tags = { application: 'compliance', qe: 0, source: 'basic', queue: 'default' }
+    expect(Yabeda.good_job_queue_depth.values[default_tags].value).to eq(3)
+  end
+
+  it 'rescues and logs errors instead of raising' do
+    allow(GoodJob::Job).to receive(:where).and_raise(ActiveRecord::ConnectionNotEstablished)
+    expect(Rails.logger).to receive(:error).with(/Failed to collect GoodJob queue depth metrics/)
+
+    expect { described_class.collect }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## Summary

- **Enable Prometheus exporter in GoodJob process**: Add `good_job` to the `$PROGRAM_NAME` check in `yabeda.rb` so `Yabeda::ActiveJob.install!` and `Yabeda::Prometheus::Exporter.start_metrics_server!` run in the GoodJob pod. This exposes all yabeda-activejob metrics (executed_total, success_total, failed_total, runtime, latency) on the Clowder metrics port.
- **Add queue depth gauge**: New `good_job_queue_depth` gauge metric that queries `GoodJob::Job.where(finished_at: nil)` grouped by queue name, providing visibility into pending job backlog.
- **Update GoodJob pod probes**: Liveness probe now uses the Clowder `/metrics` endpoint (matching the Sidekiq pod pattern) so Prometheus can scrape the GoodJob pod.
- **Update Grafana dashboard**: Replace Sidekiq-specific metrics with ActiveJob equivalents in all job-related panels (Job Duration, Job Count, Successfully parsed reports, Reports failed to upload, pod restarts).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added Prometheus metrics for GoodJob via Yabeda: new `good_job_queue_depth` gauge for unfinished jobs grouped by `queue_name` (with `nil` mapped to `default`), including stale per-queue label cleanup.
- Extended Yabeda metrics collection and startup wiring to run GoodJob/ActiveJob instrumentation alongside existing collectors.
- Updated the GoodJob liveness probe to use the Clowder metrics endpoint (`/metrics` on the `metrics` port).
- Updated the compliance Grafana dashboard to replace Sidekiq worker metrics with ActiveJob equivalents (`activejob_*`), adjusted “restarts” targets to GoodJob pods, and added a “GoodJob Queue Depth” panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->