### PR TITLE
ci(jenkins): resolve exact Quay image commit SHAs for ephemeral dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,41 +88,25 @@ pipeline {
                             echo "$resolved_sha"
                         }
 
-                        USE_QUAY_LATEST_TAG_ONLY="false"
+                        RBAC_SHA=$(get_quay_sha "redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac" "https://github.com/RedHatInsights/insights-rbac.git")
+                        RBAC_SHORT_SHA=${RBAC_SHA:0:7}
 
-                        if [ "$USE_QUAY_LATEST_TAG_ONLY" = "true" ]; then
-                            echo "Option A: Using 'latest' image tag directly for dependency images..."
-                            EXTRA_OVERRIDE_ARGS="
-                                --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=latest
-                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=latest
-                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest
-                            "
-                        else
-                            echo "Option B: Resolving exact Quay commit SHAs for dependency images..."
-                            RBAC_SHA=$(get_quay_sha "redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac" "https://github.com/RedHatInsights/insights-rbac.git")
-                            RBAC_SHORT_SHA=${RBAC_SHA:0:7}
+                        KESSEL_CONSUMER_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer" "https://github.com/project-kessel/kessel-inventory-consumer.git")
+                        KESSEL_CONSUMER_SHORT_SHA=${KESSEL_CONSUMER_SHA:0:7}
 
-                            KESSEL_CONSUMER_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer" "https://github.com/project-kessel/kessel-inventory-consumer.git")
-                            KESSEL_CONSUMER_SHORT_SHA=${KESSEL_CONSUMER_SHA:0:7}
-
-                            KESSEL_INVENTORY_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api" "https://github.com/project-kessel/kessel-inventory.git")
-                            KESSEL_INVENTORY_SHORT_SHA=${KESSEL_INVENTORY_SHA:0:7}
-
-                            EXTRA_OVERRIDE_ARGS="
-                                --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA}
-                                --set-template-ref rbac=${RBAC_SHA}
-                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=${KESSEL_CONSUMER_SHORT_SHA}
-                                --set-template-ref kessel-inventory-consumer=${KESSEL_CONSUMER_SHA}
-                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=${KESSEL_INVENTORY_SHORT_SHA}
-                                --set-template-ref kessel-inventory=${KESSEL_INVENTORY_SHA}
-                            "
-                        fi
+                        KESSEL_INVENTORY_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api" "https://github.com/project-kessel/kessel-inventory.git")
+                        KESSEL_INVENTORY_SHORT_SHA=${KESSEL_INVENTORY_SHA:0:7}
 
                         export APP_NAME="host-inventory kessel rbac compliance"
                         export IMAGE_TAG="${GIT_COMMIT:0:7}"
                         export OPTIONAL_DEPS_METHOD="all"
                         export EXTRA_DEPLOY_ARGS="
-                            ${EXTRA_OVERRIDE_ARGS}
+                            --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA}
+                            --set-template-ref rbac=${RBAC_SHA}
+                            --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=${KESSEL_CONSUMER_SHORT_SHA}
+                            --set-template-ref kessel-inventory-consumer=${KESSEL_CONSUMER_SHA}
+                            --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=${KESSEL_INVENTORY_SHORT_SHA}
+                            --set-template-ref kessel-inventory=${KESSEL_INVENTORY_SHA}
                             -p rbac/NOTIFICATIONS_RH_ENABLED=False
                             -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST=approval
                             -p rbac/ROLE_CREATE_ALLOW_LIST=remediations,inventory,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,20 +88,41 @@ pipeline {
                             echo "$resolved_sha"
                         }
 
-                        RBAC_SHA=$(get_quay_sha "redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac" "https://github.com/RedHatInsights/insights-rbac.git")
-                        RBAC_SHORT_SHA=${RBAC_SHA:0:7}
+                        USE_QUAY_LATEST_TAG_ONLY="false"
 
-                        KESSEL_CONSUMER_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer" "https://github.com/project-kessel/kessel-inventory-consumer.git")
-                        KESSEL_CONSUMER_SHORT_SHA=${KESSEL_CONSUMER_SHA:0:7}
+                        if [ "$USE_QUAY_LATEST_TAG_ONLY" = "true" ]; then
+                            echo "Option A: Using 'latest' image tag directly for dependency images..."
+                            EXTRA_OVERRIDE_ARGS="
+                                --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=latest
+                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=latest
+                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest
+                            "
+                        else
+                            echo "Option B: Resolving exact Quay commit SHAs for dependency images..."
+                            RBAC_SHA=$(get_quay_sha "redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac" "https://github.com/RedHatInsights/insights-rbac.git")
+                            RBAC_SHORT_SHA=${RBAC_SHA:0:7}
+
+                            KESSEL_CONSUMER_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer" "https://github.com/project-kessel/kessel-inventory-consumer.git")
+                            KESSEL_CONSUMER_SHORT_SHA=${KESSEL_CONSUMER_SHA:0:7}
+
+                            KESSEL_INVENTORY_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api" "https://github.com/project-kessel/kessel-inventory.git")
+                            KESSEL_INVENTORY_SHORT_SHA=${KESSEL_INVENTORY_SHA:0:7}
+
+                            EXTRA_OVERRIDE_ARGS="
+                                --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA}
+                                --set-template-ref rbac=${RBAC_SHA}
+                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=${KESSEL_CONSUMER_SHORT_SHA}
+                                --set-template-ref kessel-inventory-consumer=${KESSEL_CONSUMER_SHA}
+                                --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=${KESSEL_INVENTORY_SHORT_SHA}
+                                --set-template-ref kessel-inventory=${KESSEL_INVENTORY_SHA}
+                            "
+                        fi
 
                         export APP_NAME="host-inventory kessel rbac compliance"
                         export IMAGE_TAG="${GIT_COMMIT:0:7}"
                         export OPTIONAL_DEPS_METHOD="all"
                         export EXTRA_DEPLOY_ARGS="
-                            --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA}
-                            --set-template-ref rbac=${RBAC_SHA}
-                            --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=${KESSEL_CONSUMER_SHORT_SHA}
-                            --set-template-ref kessel-inventory-consumer=${KESSEL_CONSUMER_SHA}
+                            ${EXTRA_OVERRIDE_ARGS}
                             -p rbac/NOTIFICATIONS_RH_ENABLED=False
                             -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST=approval
                             -p rbac/ROLE_CREATE_ALLOW_LIST=remediations,inventory,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,25 +59,40 @@ pipeline {
                         curl -s ${CICD_URL}/bootstrap.sh > .cicd_bootstrap.sh
                         source ./.cicd_bootstrap.sh
 
-                        QUAY_URL="https://quay.io/api/v1/repository/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac/tag?onlyActiveTags=true&limit=50"
-                        if ! QUAY_TAGS=$(curl -sL --fail --connect-timeout 10 --max-time 30 "$QUAY_URL" 2>/dev/null); then
-                            QUAY_TAGS=""
-                        fi
+                        get_quay_sha() {
+                            local quay_repo="$1"
+                            local git_repo="$2"
+                            local quay_url="https://quay.io/api/v1/repository/${quay_repo}/tag?onlyActiveTags=true&limit=50"
+                            local quay_tags=""
 
-                        LATEST_MANIFEST=$(echo "$QUAY_TAGS" | jq -r '.tags[] | select(.name == "latest") | .manifest_digest' 2>/dev/null)
-                        RBAC_SHA=$(echo "$QUAY_TAGS" | jq -r --arg manifest "$LATEST_MANIFEST" '.tags[] | select(.manifest_digest == $manifest) | .name | select(test("^[0-9a-f]{40}$"))' 2>/dev/null | head -n 1)
+                            if ! quay_tags=$(curl -sL --fail --connect-timeout 10 --max-time 30 "$quay_url" 2>/dev/null); then
+                                quay_tags=""
+                            fi
 
-                        if [ -z "$RBAC_SHA" ] || [ "$RBAC_SHA" = "null" ]; then
-                            echo "Warning: Could not resolve full git SHA from Quay 'latest' tag. Falling back to git ls-remote..."
-                            RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
-                        fi
+                            local latest_manifest
+                            latest_manifest=$(echo "$quay_tags" | jq -r '.tags[] | select(.name == "latest") | .manifest_digest' 2>/dev/null)
 
-                        if ! printf '%s' "$RBAC_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
-                            echo "Error: Could not resolve a valid 40-character RBAC commit SHA." >&2
-                            exit 1
-                        fi
+                            local resolved_sha
+                            resolved_sha=$(echo "$quay_tags" | jq -r --arg manifest "$latest_manifest" '.tags[] | select(.manifest_digest == $manifest) | .name | select(test("^[0-9a-f]{40}$"))' 2>/dev/null | head -n 1)
 
+                            if [ -z "$resolved_sha" ] || [ "$resolved_sha" = "null" ]; then
+                                echo "Warning: Could not resolve full git SHA from Quay 'latest' tag for ${quay_repo}. Falling back to git ls-remote..." >&2
+                                resolved_sha=$(git ls-remote "$git_repo" HEAD | cut -f1)
+                            fi
+
+                            if ! printf '%s' "$resolved_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+                                echo "Error: Could not resolve a valid 40-character commit SHA for ${quay_repo}." >&2
+                                exit 1
+                            fi
+
+                            echo "$resolved_sha"
+                        }
+
+                        RBAC_SHA=$(get_quay_sha "redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac" "https://github.com/RedHatInsights/insights-rbac.git")
                         RBAC_SHORT_SHA=${RBAC_SHA:0:7}
+
+                        KESSEL_CONSUMER_SHA=$(get_quay_sha "redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer" "https://github.com/project-kessel/kessel-inventory-consumer.git")
+                        KESSEL_CONSUMER_SHORT_SHA=${KESSEL_CONSUMER_SHA:0:7}
 
                         export APP_NAME="host-inventory kessel rbac compliance"
                         export IMAGE_TAG="${GIT_COMMIT:0:7}"
@@ -85,6 +100,8 @@ pipeline {
                         export EXTRA_DEPLOY_ARGS="
                             --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA}
                             --set-template-ref rbac=${RBAC_SHA}
+                            --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=${KESSEL_CONSUMER_SHORT_SHA}
+                            --set-template-ref kessel-inventory-consumer=${KESSEL_CONSUMER_SHA}
                             -p rbac/NOTIFICATIONS_RH_ENABLED=False
                             -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST=approval
                             -p rbac/ROLE_CREATE_ALLOW_LIST=remediations,inventory,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,17 +59,25 @@ pipeline {
                         curl -s ${CICD_URL}/bootstrap.sh > .cicd_bootstrap.sh
                         source ./.cicd_bootstrap.sh
 
-                        QUAY_TAGS=$(curl -sL "https://quay.io/api/v1/repository/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac/tag?onlyActiveTags=true&limit=50")
-                        LATEST_MANIFEST=$(echo "$QUAY_TAGS" | jq -r '.tags[] | select(.name == "latest") | .manifest_digest' 2>/dev/null)
-                        RBAC_SHORT_SHA=$(echo "$QUAY_TAGS" | jq -r --arg manifest "$LATEST_MANIFEST" '.tags[] | select(.manifest_digest == $manifest) | .name | select(test("^[0-9a-f]{7}$"))' 2>/dev/null | head -n 1)
-
-                        if [ -z "$RBAC_SHORT_SHA" ] || [ "$RBAC_SHORT_SHA" = "null" ]; then
-                            echo "Warning: Could not resolve short git SHA from Quay 'latest' tag. Falling back to git ls-remote..."
-                            RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
-                            RBAC_SHORT_SHA=${RBAC_SHA:0:7}
-                        else
-                            RBAC_SHA="$RBAC_SHORT_SHA"
+                        QUAY_URL="https://quay.io/api/v1/repository/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac/tag?onlyActiveTags=true&limit=50"
+                        if ! QUAY_TAGS=$(curl -sL --fail --connect-timeout 10 --max-time 30 "$QUAY_URL" 2>/dev/null); then
+                            QUAY_TAGS=""
                         fi
+
+                        LATEST_MANIFEST=$(echo "$QUAY_TAGS" | jq -r '.tags[] | select(.name == "latest") | .manifest_digest' 2>/dev/null)
+                        RBAC_SHA=$(echo "$QUAY_TAGS" | jq -r --arg manifest "$LATEST_MANIFEST" '.tags[] | select(.manifest_digest == $manifest) | .name | select(test("^[0-9a-f]{40}$"))' 2>/dev/null | head -n 1)
+
+                        if [ -z "$RBAC_SHA" ] || [ "$RBAC_SHA" = "null" ]; then
+                            echo "Warning: Could not resolve full git SHA from Quay 'latest' tag. Falling back to git ls-remote..."
+                            RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
+                        fi
+
+                        if ! printf '%s' "$RBAC_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+                            echo "Error: Could not resolve a valid 40-character RBAC commit SHA." >&2
+                            exit 1
+                        fi
+
+                        RBAC_SHORT_SHA=${RBAC_SHA:0:7}
 
                         export APP_NAME="host-inventory kessel rbac compliance"
                         export IMAGE_TAG="${GIT_COMMIT:0:7}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,8 +59,17 @@ pipeline {
                         curl -s ${CICD_URL}/bootstrap.sh > .cicd_bootstrap.sh
                         source ./.cicd_bootstrap.sh
 
-                        RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
-                        RBAC_SHORT_SHA=${RBAC_SHA:0:7}
+                        QUAY_TAGS=$(curl -sL "https://quay.io/api/v1/repository/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac/tag?onlyActiveTags=true&limit=50")
+                        LATEST_MANIFEST=$(echo "$QUAY_TAGS" | jq -r '.tags[] | select(.name == "latest") | .manifest_digest' 2>/dev/null)
+                        RBAC_SHORT_SHA=$(echo "$QUAY_TAGS" | jq -r --arg manifest "$LATEST_MANIFEST" '.tags[] | select(.manifest_digest == $manifest) | .name | select(test("^[0-9a-f]{7}$"))' 2>/dev/null | head -n 1)
+
+                        if [ -z "$RBAC_SHORT_SHA" ] || [ "$RBAC_SHORT_SHA" = "null" ]; then
+                            echo "Warning: Could not resolve short git SHA from Quay 'latest' tag. Falling back to git ls-remote..."
+                            RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
+                            RBAC_SHORT_SHA=${RBAC_SHA:0:7}
+                        else
+                            RBAC_SHA="$RBAC_SHORT_SHA"
+                        fi
 
                         export APP_NAME="host-inventory kessel rbac compliance"
                         export IMAGE_TAG="${GIT_COMMIT:0:7}"


### PR DESCRIPTION
## Description

Upstream dependency images (such as `insights-rbac`, `kessel-inventory-consumer`, and `kessel-inventory`) are often published to Quay a few minutes after Git commits are merged to `master`. Relying solely on Git `HEAD` causes smoke test deployments in Jenkins to fail with `ErrImagePull` / `manifest unknown` when Bonfire attempts to pull image tags that Quay has not finished building yet.

This PR implements **Option B**: introducing a generic `get_quay_sha` helper function in `Jenkinsfile` to:
1. Query Quay API for active tags on a specified repository.
2. Resolve the `manifest_digest` for tag `latest` in Quay.
3. Extract the 40-character full Git commit SHA sharing that manifest digest.
4. Fall back to `git ls-remote HEAD` if Quay API lookup fails.
5. Fail closed (`exit 1`) with strict regex validation (`^[0-9a-f]{40}$`) if no valid commit SHA is returned.
6. Derive the 7-character short SHA for `--set-image-tag` and pass the 40-character SHA to `--set-template-ref`.

### Applied Services
- `insights-rbac` (`quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac`)
- `kessel-inventory-consumer` (`quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer`)
- `kessel-inventory` (`quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api`)

---
*Note: This PR is mutually exclusive with PR #2889 (Option A: overriding dependency image tags directly to `:latest`).*