### PR TITLE
ci(jenkins): override dependency image tags to latest for ephemeral deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,15 +59,13 @@ pipeline {
                         curl -s ${CICD_URL}/bootstrap.sh > .cicd_bootstrap.sh
                         source ./.cicd_bootstrap.sh
 
-                        RBAC_SHA=$(git ls-remote https://github.com/RedHatInsights/insights-rbac.git HEAD | cut -f1)
-                        RBAC_SHORT_SHA=${RBAC_SHA:0:7}
-
                         export APP_NAME="host-inventory kessel rbac compliance"
                         export IMAGE_TAG="${GIT_COMMIT:0:7}"
                         export OPTIONAL_DEPS_METHOD="all"
                         export EXTRA_DEPLOY_ARGS="
-                            --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=${RBAC_SHORT_SHA}
-                            --set-template-ref rbac=${RBAC_SHA}
+                            --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=latest
+                            --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=latest
+                            --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest
                             -p rbac/NOTIFICATIONS_RH_ENABLED=False
                             -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST=approval
                             -p rbac/ROLE_CREATE_ALLOW_LIST=remediations,inventory,policies,advisor,vulnerability,compliance,automation-analytics,notifications,patch,integrations,ros,staleness,config-manager,idmsvc


### PR DESCRIPTION
## Description

Upstream dependencies (such as `insights-rbac`, `kessel-inventory-consumer`, and `kessel-inventory`) frequently experience a race condition during smoke test execution: Bonfire resolves their Git `HEAD` SHA, but the container build for that commit is still in progress on Quay, resulting in `ErrImagePull` / `manifest unknown` failures.

This PR implements **Option A**: overriding image tags for these 3 dependencies directly to `latest` in `EXTRA_DEPLOY_ARGS`. Because Quay maintains the `latest` tag on every successful build, `latest` image tags never experience `ErrImagePull` race conditions.

Note: This PR is mutually exclusive with PR #2887 (which resolves exact commit SHAs from Quay's `latest` manifest via Quay API).

- Updated Jenkins ephemeral smoke-test deployments to set `insights-rbac`, `kessel-inventory-consumer`, and `kessel-inventory` image tags to `latest` via `EXTRA_DEPLOY_ARGS`, preventing `ErrImagePull` / `manifest unknown` failures when commit-specific Quay images aren’t available yet.
- Removed RBAC commit-SHA resolution and `--set-template-ref` pinning from the smoke-test deployment argument construction (switched to `--set-image-tag ...=latest` for the affected components).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [x] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices