### PR TITLE
fix(ci): optimize ephemeral deployment probes and init DB pre-check

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -473,13 +473,13 @@ objects:
         livenessProbe:
           tcpSocket:
             port: web
-          initialDelaySeconds: 10
+          initialDelaySeconds: 180
           periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /api/compliance/v2/status
             port: web
-          initialDelaySeconds: 10
+          initialDelaySeconds: 180
           periodSeconds: 30
         resources:
           limits:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -565,10 +565,11 @@ objects:
           httpGet:
             path: /
             port: 3000
-          initialDelaySeconds: 30
+          initialDelaySeconds: 180
           timeoutSeconds: 5
           periodSeconds: 30
         readinessProbe:
+          initialDelaySeconds: 180
           timeoutSeconds: 15
           periodSeconds: 30
           exec:
@@ -601,12 +602,14 @@ objects:
           httpGet:
             path: /status
             port: ${{GOOD_JOB_PROBE_PORT}}
+          initialDelaySeconds: 180
           timeoutSeconds: 5
           periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /status
             port: ${{GOOD_JOB_PROBE_PORT}}
+          initialDelaySeconds: 180
           timeoutSeconds: 5
           periodSeconds: 30
         env:
@@ -698,9 +701,11 @@ objects:
           httpGet:
             path: /metrics
             port: metrics
+          initialDelaySeconds: 180
           timeoutSeconds: 5
           periodSeconds: 30
         readinessProbe:
+          initialDelaySeconds: 180
           timeoutSeconds: 15
           periodSeconds: 30
           exec:

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -2,6 +2,33 @@
 
 MAX_INIT_TIMEOUT_SECONDS=${MAX_INIT_TIMEOUT_SECONDS:-120}
 
+# Fast pre-check: wait for Database socket to open before booting full Rails framework
+bundle exec ruby -r clowder-common-ruby -r socket -e '
+  host, port = if ClowderCommonRuby::Config.clowder_enabled?
+    cfg = ClowderCommonRuby::Config.load
+    [cfg.database.hostname, cfg.database.port]
+  else
+    [ENV.fetch("POSTGRESQL_HOST", "localhost"), ENV.fetch("POSTGRESQL_PORT", "5432").to_i]
+  end
+
+  puts "Waiting for database socket at #{host}:#{port}..."
+  120.times do
+    begin
+      if host.start_with?("/")
+        UNIXSocket.new("#{host}/.s.PGSQL.#{port}").close
+      else
+        TCPSocket.new(host, port).close
+      end
+      puts "Database socket is open!"
+      exit 0
+    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH, Errno::ENOENT, SocketError
+      sleep 1
+    end
+  end
+  puts "Timed out waiting for database socket at #{host}:#{port}"
+  exit 1
+' || exit 1
+
 for ((i=1;i<=MAX_INIT_TIMEOUT_SECONDS;i++)); do
     if bundle exec rake --trace db:debug db:migrate ssg:check_synced; then
         exit 0

--- a/scripts/check_migration_status_and_ssg_synced.sh
+++ b/scripts/check_migration_status_and_ssg_synced.sh
@@ -11,17 +11,18 @@ bundle exec ruby -r clowder-common-ruby -r socket -e '
     [ENV.fetch("POSTGRESQL_HOST", "localhost"), ENV.fetch("POSTGRESQL_PORT", "5432").to_i]
   end
 
-  puts "Waiting for database socket at #{host}:#{port}..."
-  120.times do
+  max_timeout = ENV.fetch("MAX_INIT_TIMEOUT_SECONDS", "120").to_i
+  puts "Waiting for database socket at #{host}:#{port} (max #{max_timeout}s)..."
+  max_timeout.times do
     begin
       if host.start_with?("/")
         UNIXSocket.new("#{host}/.s.PGSQL.#{port}").close
       else
-        TCPSocket.new(host, port).close
+        TCPSocket.new(host, port, connect_timeout: 5).close
       end
       puts "Database socket is open!"
       exit 0
-    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH, Errno::ENOENT, SocketError
+    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH, Errno::ENOENT, SocketError, IO::TimeoutError
       sleep 1
     end
   end


### PR DESCRIPTION
## Summary
Fixes 100% of ephemeral test deployment timeouts in Jenkins caused by CPU quota throttling (`67m` limit) during Rails Puma preloading and database init retries.

## Problem
App-interface recently reconciled a `67m` CPU limit override for `compliance-service` in ephemeral (`insights-pr`) test environments. Under this tight CPU quota:
1. **Puma Rails Preload Delay**: Puma preloading Rails across 3 workers takes ~90 seconds. With the default `initialDelaySeconds: 10` + 90s failure window, Kubernetes repeatedly kills Puma via `SIGTERM` (`Container compliance-service failed liveness probe, will be restarted`) right before port 8000 opens, entering an endless restart loop.
2. **Init Container Retries**: `compliance-service-init` runs `scripts/check_migration_status_and_ssg_synced.sh`. When PostgreSQL or `compliance-ssg-service` takes time to start up, every retry boots full Rails (taking ~50-90s per boot), causing 10 retries to waste ~8-10 minutes before the main application container even starts.

Together, these issues caused Bonfire to hit its 20-minute deployment timeout across all recent Jenkins PR runs.

## Solution
1. **Increase Liveness/Readiness Probe Initial Delays** (`deploy/clowdapp.yaml`):
   - Increased `initialDelaySeconds` from `10` to `180` seconds for `compliance-service`.
   - Gives Puma 3 minutes to safely preload Rails and bind to port 8000 on low CPU without being prematurely terminated by Kubernetes.
2. **Fast Database Socket Pre-check** (`scripts/check_migration_status_and_ssg_synced.sh`):
   - Added a lightweight Ruby database connection socket check (using `ClowderCommonRuby` & stdlib `socket`) before executing `bundle exec rake`.
   - Polling the database socket takes ~0.05s per loop, avoiding heavy 90-second Rails reboots during startup connection retries.

## Verification
- Verified on Jenkins build **`PR-2890 #2`** (Ephemeral namespace: `ephemeral-ulb3j1`).
- All ClowdApps (`compliance` 6/6, `rbac` 7/7, `host-inventory` 12/12, etc.) reached **100% READY with 0 container restarts**.
- Bonfire completed deployment cleanly and launched IQE smoke tests (`compliance-iqe`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Increased ClowdApp probe delays to 180 seconds to allow Rails/Puma startup under CPU constraints.
- Added database socket readiness checks to reduce unnecessary Rails boot retries while dependencies initialize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->