### PR TITLE
fix(ci): extract shared base stage and diverge instruction chains in Dockerfile to prevent cache collisions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,15 @@ ARG BUNDLE_JOBS="4"
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8 AS base
 
-ARG deps
-ARG devDeps
-
 #############################################################
 
 FROM base AS build
 
+# Diverge stage 1 immediately to prevent cache tag collisions with final stage
+ENV IS_BUILD_STAGE=true
+
+ARG deps
+ARG devDeps
 ARG extras
 ARG prod
 ARG pgRepo
@@ -56,6 +58,9 @@ ENV prometheus_multiproc_dir=/opt/app-root/src/tmp prometheus_rust_mmaped_file=f
 #############################################################
 
 FROM base
+
+ARG deps
+ARG devDeps
 
 WORKDIR /opt/app-root/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,15 @@ ARG prod="true"
 ARG pgRepo="https://copr.fedorainfracloud.org/coprs/mmraka/postgresql-16/repo/epel-9/mmraka-postgresql-16-epel-9.repo"
 ARG BUNDLE_JOBS="4"
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8 AS build
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8 AS base
 
 ARG deps
 ARG devDeps
+
+#############################################################
+
+FROM base AS build
+
 ARG extras
 ARG prod
 ARG pgRepo
@@ -50,10 +55,7 @@ ENV prometheus_multiproc_dir=/opt/app-root/src/tmp prometheus_rust_mmaped_file=f
 
 #############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8
-
-ARG deps
-ARG devDeps
+FROM base
 
 WORKDIR /opt/app-root/src
 


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHINENG-29216

## Summary
Fixes a multi-stage layer cache collision in `Dockerfile` that caused PR builds to miss remote Quay cache layers for `bundle install`.

### Root Cause
Both Stage 1 (`AS build`) and Stage 2 (final image) previously began with the exact same initial instructions:
1. `FROM ubi-minimal`
2. `ARG deps`
3. `ARG devDeps`

When `master` builds ran `--cache-to quay.io`, Stage 2's evaluation of `ARG devDeps` pushed its layer cache tag to Quay, overwriting Stage 1's cache tag for `ARG devDeps`.

When PR builds queried Quay (`--cache-from`) during Stage 1 at Step 3 (`ARG devDeps`), Podman fetched Stage 2's layer instead of Stage 1's layer. When Stage 1 subsequently evaluated Step 4 (`ARG extras`), the cache lookup against Quay failed because Stage 2's parent layer was followed by `WORKDIR`, breaking the cache chain for all subsequent steps (including `bundle install`).

### Fix
1. **Shared `base` Stage**: Extract `FROM ubi-minimal AS base` from which both `build` and final stages inherit.
2. **Immediate Stage Divergence**: Set `ENV IS_BUILD_STAGE=true` at the top of Stage 1 (`AS build`). This ensures Stage 1 immediately diverges after `FROM base`, generating mathematically distinct parent layer digests that Stage 2 can never match or overwrite in Quay.
3. **Re-declared ARGs**: Explicitly re-declare `ARG deps` and `ARG devDeps` inside each stage to restore variable scope from above `FROM`.