### PR TITLE
ci(build): increase podman build log level to debug

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -6,6 +6,7 @@ CICD_TOOLS_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main
 # shellcheck source=/dev/null
 source <(curl -sSL "$CICD_TOOLS_URL") image_builder
 
+export CICD_LOG_DEBUG=true
 export CICD_IMAGE_BUILDER_IMAGE_NAME='quay.io/cloudservices/compliance-backend'
 
 image_exists_in_quay() {
@@ -71,12 +72,14 @@ if [[ "$IS_MASTER_BRANCH" == "true" ]]; then
 
     # On master: build fresh layers without using older cache, and populate remote cache in Quay
     cicd::image_builder::build_and_push --layers --no-cache \
-        --cache-to "$CACHE_REPO"
+        --cache-to "$CACHE_REPO" \
+        --log-level=debug
 else
     echo "PR build detected. Using outer layer cache from Quay..."
 
     # On PRs: build using remote layer cache from Quay
     cicd::image_builder::build_and_push --layers \
         --cache-from "$CACHE_REPO" \
-        --label "quay.expires-after=30d"
+        --label "quay.expires-after=30d" \
+        --log-level=debug
 fi

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -72,6 +72,7 @@ if [[ "$IS_MASTER_BRANCH" == "true" ]]; then
 
     # On master: build fresh layers without using older cache, and populate remote cache in Quay
     cicd::image_builder::build_and_push --layers --no-cache \
+        --format oci \
         --cache-to "$CACHE_REPO" \
         --log-level=debug
 else
@@ -79,6 +80,7 @@ else
 
     # On PRs: build using remote layer cache from Quay
     cicd::image_builder::build_and_push --layers \
+        --format oci \
         --cache-from "$CACHE_REPO" \
         --label "quay.expires-after=30d" \
         --log-level=debug

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -82,6 +82,7 @@ else
     cicd::image_builder::build_and_push --layers \
         --format oci \
         --cache-from "$CACHE_REPO" \
+        --cache-to "$CACHE_REPO" \
         --label "quay.expires-after=30d" \
         --log-level=debug
 fi


### PR DESCRIPTION
Enables debug log level for `podman build` and `cicd-tools` in `build_deploy.sh` to inspect cache evaluation and layer resolution during CI execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enabled CI debug logging for `cicd-tools`/image building (`CICD_LOG_DEBUG=true`, `--log-level=debug`) to inspect cache evaluation and layer resolution.
- On master and PR builds, added debug-level `cicd::image_builder::build_and_push` logging for cache behavior.
- Added `--cache-to "$CACHE_REPO"` to PR builds (while keeping `--cache-from "$CACHE_REPO"` and `quay.expires-after=30d`) so PRs also populate the remote cache.
- Forced OCI output format for the image builder.
- Avoided rebuilding images for PR checks when the target tag already exists in Quay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->