### PR TITLE
chore(deps): bump kessel-sdk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem 'openscap_parser', '~> 1.6.0'
 gem 'insights-rbac-api-client', '~> 2.0.0'
 
 # Kessel SDK for RBAC v2 migration
-gem 'kessel-sdk', '~> 1.9.1'
+gem 'kessel-sdk', '~> 1.11.0'
 gem 'openid_connect', '~> 2.0'  # Required for Kessel OAuth authentication
 
 # REST API parameter type checking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,12 +202,12 @@ GEM
       fugit (>= 1.11.0)
       railties (>= 6.1.0)
       thor (>= 1.0.0)
-    google-protobuf (4.35.0)
+    google-protobuf (4.35.1)
       bigdecimal
       rake (~> 13.3)
     googleapis-common-protos-types (1.23.0)
       google-protobuf (~> 4.26)
-    grpc (1.81.0)
+    grpc (1.83.0)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     hashdiff (1.2.1)
@@ -252,7 +252,7 @@ GEM
     karafka-testing (2.5.5)
       karafka (>= 2.5.0, < 2.6.0)
       waterdrop (>= 2.8.0)
-    kessel-sdk (1.9.1)
+    kessel-sdk (1.11.0)
       grpc (>= 1.73.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -613,7 +613,7 @@ DEPENDENCIES
   jsonapi-serializer
   karafka (>= 2.4.0)
   karafka-testing
-  kessel-sdk (~> 1.9.1)
+  kessel-sdk (~> 1.11.0)
   listen (>= 3.0.5)
   minitest-reporters
   minitest-stub-const


### PR DESCRIPTION
New SDK sends `with_ancestry=true` by default on `fetchDefaultWorkspace`, preserving current permission-bypass behavior without code changes.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Bumped `kessel-sdk` from 1.9.1 to 1.11.0; the SDK’s default `with_ancestry=true` on `fetchDefaultWorkspace` preserves existing permission-bypass behavior without code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->