### PR TITLE
ci(image): enable remote layer cache lookup on master builds

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -82,12 +82,13 @@ else
 fi
 
 if [[ "$IS_MASTER_BRANCH" == "true" ]]; then
-    echo "Master branch build detected. Building fresh image and populating cache in Quay..."
+    echo "Master branch build detected. Building image with remote cache and populating Quay..."
 
-    # On master: build fresh layers without using older cache, and populate remote cache in Quay
-    cicd::image_builder::build_and_push --layers --no-cache \
+    # On master: build using remote layer cache from Quay and populate remote cache in Quay
+    cicd::image_builder::build_and_push --layers \
         --format oci \
         --timestamp "$BUILD_TIMESTAMP" \
+        --cache-from "$CACHE_REPO" \
         --cache-to "$CACHE_REPO"
 else
     echo "PR build detected. Using outer layer cache from Quay..."

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -84,7 +84,15 @@ fi
 if [[ "$IS_MASTER_BRANCH" == "true" ]]; then
     echo "Master branch build detected. Building image with remote cache and populating Quay..."
 
-    # On master: build using remote layer cache from Quay and populate remote cache in Quay
+    # On master: build and populate remote cache for intermediate build stage first
+    cicd::image_builder::build --layers \
+        --target build \
+        --format oci \
+        --timestamp "$BUILD_TIMESTAMP" \
+        --cache-from "$CACHE_REPO" \
+        --cache-to "$CACHE_REPO"
+
+    # On master: build using remote layer cache from Quay and populate remote cache in Quay for final image
     cicd::image_builder::build_and_push --layers \
         --format oci \
         --timestamp "$BUILD_TIMESTAMP" \


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHINENG-29216

## Description
Enables `--cache-from quay.io/cloudservices/compliance-backend` and removes `--no-cache` on `master` branch builds in `build_deploy.sh`.

### Why this is needed
Previously, `master` builds ran with `--no-cache` and only pushed to `--cache-to`. Consequently, every `master` build had to re-download all RPMs and re-compile all C/Rust extension gems (`grpc`, `panko_serializer`, `oj`, etc.) from scratch—taking 17–44 minutes per run depending on worker node CPU load.

By passing both `--cache-from "$CACHE_REPO"` and `--cache-to "$CACHE_REPO"` on `master` builds:
1. `master` builds can reuse existing cached layers from Quay when files/dependencies (`Gemfile.lock`, `Dockerfile`) haven't changed.
2. `master` builds still push and populate updated layer caches to Quay when layers do change.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation (N/A)
- [ ] Output Encoding (N/A)
- [ ] Authentication and Password Management (N/A)
- [ ] Session Management (N/A)
- [ ] Access Control (N/A)
- [ ] Cryptographic Practices (N/A)
- [x] Error Handling and Logging (N/A)
- [ ] Data Protection (N/A)
- [ ] Communication Security (N/A)
- [x] System Configuration (CI container builder flags for master branch caching)
- [ ] Database Security (N/A)
- [ ] File Management (N/A)
- [ ] Memory Management (N/A)
- [x] General Coding Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enable Quay remote layer caching for master builds in `build_deploy.sh` (`--cache-from quay.io/cloudservices/compliance-backend`) instead of building without cache.
- Continue pushing/publishing updated layers to Quay (`--cache-to quay.io/cloudservices/compliance-backend`).
- Improve Quay tag existence checking to skip builds when the target tag already exists, with clearer error output when tag data can’t be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->