### PR TITLE
ci(image): fix remote container layer caching for PR builds

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -16,9 +16,9 @@ jobs:
         run: sudo apt-get install -y skopeo
       - name: Fetch latest base image digest
         run: |
-          base_name=$(grep -Po '(?<=FROM )[^\s@]+(?=@)' Dockerfile | head -1)
+          base_name=$(grep -Po '(?<=ARG BASE_IMAGE=")[^\s@"]+(?=@)' Dockerfile | head -1)
           new_digest=$(skopeo inspect "docker://$base_name" | jq .Digest --raw-output)
-          sed -i "s|FROM ${base_name}@sha256:[a-f0-9]*|FROM ${base_name}@${new_digest}|g" Dockerfile
+          sed -i "s|ARG BASE_IMAGE=\"${base_name}@sha256:[a-f0-9]*\"|ARG BASE_IMAGE=\"${base_name}@${new_digest}\"|g" Dockerfile
       - name: Open or update pull request if digest changed
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:

--- a/.github/workflows/ruby-update.yml
+++ b/.github/workflows/ruby-update.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Fetch latest Ruby version from base image
         timeout-minutes: 10
         run: |
-          base=$(grep -Po '(?<=FROM )[^\s]+(?= AS build)' Dockerfile | cut -d@ -f1)
+          base=$(grep -Po '(?<=ARG BASE_IMAGE=")[^\s"]+' Dockerfile | cut -d@ -f1)
           docker run --rm -u 0 "${base}":latest sh -c "
             microdnf module enable -y ruby:3.3 > /dev/null;
             microdnf repoquery ruby --info | grep Version | awk '{ print \$3 }' | head -1 > .ruby-version;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG BASE_IMAGE="registry.access.redhat.com/ubi9/ubi-minimal@sha256:2e8edce823a48e51858f1fad3ff4cbf6875ce8a3f86b9eecf298bc2050c8652a"
 ARG deps="findutils hostname jq libpq openssl procps-ng ruby shared-mime-info tzdata"
 ARG devDeps="clang llvm-devel cargo gcc gcc-c++ libstdc++-static gzip libffi-devel libyaml-devel make openssl-devel patch postgresql postgresql-devel redhat-rpm-config ruby-devel rust tar which util-linux xz git"
 ARG extras=""
@@ -5,11 +6,9 @@ ARG prod="true"
 ARG pgRepo="https://copr.fedorainfracloud.org/coprs/mmraka/postgresql-16/repo/epel-9/mmraka-postgresql-16-epel-9.repo"
 ARG BUNDLE_JOBS="4"
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2e8edce823a48e51858f1fad3ff4cbf6875ce8a3f86b9eecf298bc2050c8652a AS base
-
 #############################################################
 
-FROM base AS build
+FROM ${BASE_IMAGE} AS build
 
 # Diverge stage 1 immediately to prevent cache tag collisions with final stage
 ENV IS_BUILD_STAGE=true
@@ -57,7 +56,7 @@ ENV prometheus_multiproc_dir=/opt/app-root/src/tmp prometheus_rust_mmaped_file=f
 
 #############################################################
 
-FROM base
+FROM ${BASE_IMAGE}
 
 ARG deps
 ARG devDeps

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_IMAGE ?= $(shell grep -m1 'FROM registry.access.redhat.com/ubi9/ubi-minimal' Dockerfile | awk '{print $$2}')
+BASE_IMAGE ?= $(shell sed -n 's/^ARG BASE_IMAGE="\(.*\)"/\1/p' Dockerfile)
 
 .PHONY: ubi.repo rpms.in.yaml generate-rpm-lockfile update-cargo-lockfile
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -67,6 +67,7 @@ fi
 CACHE_REPO="quay.io/cloudservices/compliance-backend"
 
 # Determine merge-base with master to extract a consistent commit timestamp for reproducible layer caching
+git fetch origin master:refs/remotes/origin/master 2>/dev/null || git fetch origin master 2>/dev/null || true
 MERGE_BASE=$(git merge-base HEAD origin/master 2>/dev/null || git merge-base HEAD master 2>/dev/null || echo "")
 BUILD_TIMESTAMP=""
 
@@ -84,15 +85,7 @@ fi
 if [[ "$IS_MASTER_BRANCH" == "true" ]]; then
     echo "Master branch build detected. Building image with remote cache and populating Quay..."
 
-    # On master: build and populate remote cache for intermediate build stage first
-    cicd::image_builder::build --layers \
-        --target build \
-        --format oci \
-        --timestamp "$BUILD_TIMESTAMP" \
-        --cache-from "$CACHE_REPO" \
-        --cache-to "$CACHE_REPO"
-
-    # On master: build using remote layer cache from Quay and populate remote cache in Quay for final image
+    # On master: build using remote layer cache from Quay and populate remote cache in Quay
     cicd::image_builder::build_and_push --layers \
         --format oci \
         --timestamp "$BUILD_TIMESTAMP" \
@@ -106,5 +99,6 @@ else
         --format oci \
         --timestamp "$BUILD_TIMESTAMP" \
         --cache-from "$CACHE_REPO" \
+        --cache-to "$CACHE_REPO" \
         --label "quay.expires-after=30d"
 fi


### PR DESCRIPTION
## Summary

This PR resolves container layer caching issues in CI (`build_deploy.sh` and `Dockerfile`), enabling PR builds to achieve 100% remote layer cache hits from Quay across worker nodes.

### Changes Included
- **Dockerfile:** Replace multi-stage base alias (`FROM base`) with global `ARG BASE_IMAGE="..."` and `FROM ${BASE_IMAGE}` across build and runtime stages. This prevents Podman/Buildah from generating node-local container storage IDs as parent cache keys.
- **build_deploy.sh:**
  - Enable `--cache-to "$CACHE_REPO"` for PR builds to publish newly compiled intermediate layers to Quay.
  - Fetch `origin/master` prior to `git merge-base` resolution to ensure shallow CI checkouts compute deterministic `BUILD_TIMESTAMP` values.
  - Consolidate master image builds into a single `build_and_push` execution with `--cache-from` and `--cache-to`.
- **Tooling & Workflows Alignment:**
  - **`Makefile`:** Update `BASE_IMAGE` extraction to parse `ARG BASE_IMAGE="..."` via `sed`.
  - **`.github/workflows/ruby-update.yml`:** Update regex pattern to extract base image name from `ARG BASE_IMAGE="..."`.
  - **`.github/workflows/checkimage.yaml`:** Update `grep` and `sed` patterns to match and update `ARG BASE_IMAGE="..."`.