### PR TITLE
ci(build): add prod=false remote layer caching to build_deploy and compose

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -91,6 +91,16 @@ if [[ "$IS_MASTER_BRANCH" == "true" ]]; then
         --timestamp "$BUILD_TIMESTAMP" \
         --cache-from "$CACHE_REPO" \
         --cache-to "$CACHE_REPO"
+
+    # Secondary non-fatal devel layer cache build pass (populates prod=false cache on Quay)
+    echo "Building secondary devel layer cache (target=build, prod=false)..."
+    cicd::image_builder::build_and_push --layers \
+        --format oci \
+        --timestamp "$BUILD_TIMESTAMP" \
+        --target build \
+        --build-arg prod=false \
+        --cache-from "$CACHE_REPO" \
+        --cache-to "$CACHE_REPO" || echo "WARNING: Devel layer cache build failed. Continuing master pipeline."
 else
     echo "PR build detected. Using outer layer cache from Quay..."
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -290,6 +290,8 @@ services:
       args:
         - prod=false
         - extras=$EXTRA_PACKAGES
+      cache_from:
+        - ${CACHE_REPO:-quay.io/cloudservices/compliance-backend}
     image: localhost/compliance-backend-rails
     entrypoint: '/opt/app-root/src/devel.entrypoint.sh'
     command: 'bundle exec rails s -b 0.0.0.0'


### PR DESCRIPTION
## Summary
- Configures `docker-compose.yml` under `rails` service to pull remote layer cache from Quay (`quay.io/cloudservices/compliance-backend`).
- Updates `build_deploy.sh` to run a non-fatal secondary build pass targeting `build` with `prod=false` when merging to `master`.
- Significantly accelerates local `podman-compose build` / `docker compose build` for developers by reusing cached RHEL/UBI base and gem dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add remote layer caching for compliance backend container builds.
- Configure Compose to use cached layers from Quay.
- Run a non-fatal cache build on `master` merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->