### PR TITLE
ci(security): add remote layer cache to platform security scan workflow

### DIFF
--- a/.github/workflows/platsec-security-scan.yml
+++ b/.github/workflows/platsec-security-scan.yml
@@ -44,7 +44,7 @@ jobs:
     #   base_dockerbuild_path: './testbuild.base'
     #   base_dockerfile_path: './test'
     #   base_dockerfile_name: 'Dockerfile.base'
-        build_arg: '--build-arg ALT_REPO="https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"'
+        build_arg: '--build-arg ALT_REPO="https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo" --cache-from quay.io/cloudservices/compliance-backend'
     #   only_fixed: true
     #   fail_on_vulns: true
     #   severity_fail_cutoff: high

--- a/.github/workflows/platsec-security-scan.yml
+++ b/.github/workflows/platsec-security-scan.yml
@@ -44,7 +44,7 @@ jobs:
     #   base_dockerbuild_path: './testbuild.base'
     #   base_dockerfile_path: './test'
     #   base_dockerfile_name: 'Dockerfile.base'
-        build_arg: '--build-arg ALT_REPO="https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo" --cache-from quay.io/cloudservices/compliance-backend'
+        build_arg: '--build-arg ALT_REPO="https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo" --cache-from quay.io/cloudservices/compliance-backend --cache-to type=registry,ref=quay.io/cloudservices/compliance-backend:buildkit-cache,mode=max'
     #   only_fixed: true
     #   fail_on_vulns: true
     #   severity_fail_cutoff: high


### PR DESCRIPTION
## Summary
- Passes `--cache-from quay.io/cloudservices/compliance-backend` into the `build_arg` parameter of `platsec-security-scan.yml`.
- Enables remote layer caching during container image builds in the ConsoleDot Platform Security Scan workflow, reducing build and scan times.