### PR TITLE
feat(Grafana): add graphs for system ingress

### DIFF
--- a/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
+++ b/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
@@ -763,12 +763,87 @@ objects:
             "type": "stat"
           },
           {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "description": "",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "mappings": [],
+                "min": 0,
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 4,
+              "x": 0,
+              "y": 4
+            },
+            "id": 23763572027,
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "last"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "value",
+              "wideLayout": true
+            },
+            "pluginVersion": "11.6.11",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "ceil(\n  (sum(increase(compliance_system_import_invalid_total{application=\"compliance\"}[$__range])) or vector(0))\n  +\n  (sum(increase(compliance_system_import_failures_total{application=\"compliance\"}[$__range])) or vector(0))\n)",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "Total system import failures",
+            "type": "stat"
+          },
+          {
             "collapsed": false,
             "gridPos": {
               "h": 1,
               "w": 24,
               "x": 0,
-              "y": 4
+              "y": 7
             },
             "id": 18,
             "panels": [],
@@ -916,7 +991,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 5
+              "y": 8
             },
             "id": 10,
             "options": {
@@ -1024,7 +1099,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 5
+              "y": 8
             },
             "id": 27,
             "options": {
@@ -1132,7 +1207,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 11
+              "y": 14
             },
             "id": 5,
             "options": {
@@ -1228,7 +1303,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 11
+              "y": 14
             },
             "id": 4,
             "options": {
@@ -1266,7 +1341,7 @@ objects:
               "h": 1,
               "w": 24,
               "x": 0,
-              "y": 17
+              "y": 20
             },
             "id": 31,
             "panels": [],
@@ -1337,7 +1412,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 18
+              "y": 21
             },
             "id": 29,
             "options": {
@@ -1435,7 +1510,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 18
+              "y": 21
             },
             "id": 33,
             "options": {
@@ -1535,7 +1610,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 24
+              "y": 27
             },
             "id": 35,
             "options": {
@@ -1646,7 +1721,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 24
+              "y": 27
             },
             "id": 57,
             "options": {
@@ -1759,7 +1834,7 @@ objects:
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 30
+              "y": 33
             },
             "id": 23763572011,
             "options": {
@@ -1870,7 +1945,7 @@ objects:
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 30
+              "y": 33
             },
             "id": 23763572007,
             "options": {
@@ -1983,7 +2058,7 @@ objects:
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 38
+              "y": 41
             },
             "id": 23763572014,
             "options": {
@@ -2096,7 +2171,7 @@ objects:
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 38
+              "y": 41
             },
             "id": 23763572015,
             "options": {
@@ -2285,7 +2360,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 46
+              "y": 49
             },
             "id": 42,
             "options": {
@@ -2392,7 +2467,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 46
+              "y": 49
             },
             "id": 23763572016,
             "options": {
@@ -2580,7 +2655,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 52
+              "y": 55
             },
             "id": 53,
             "options": {
@@ -2751,7 +2826,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 52
+              "y": 55
             },
             "id": 58,
             "options": {
@@ -2947,7 +3022,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 58
+              "y": 61
             },
             "id": 60,
             "options": {
@@ -3156,7 +3231,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 58
+              "y": 61
             },
             "id": 52,
             "options": {
@@ -3338,7 +3413,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 64
+              "y": 67
             },
             "id": 23763571993,
             "options": {
@@ -3526,7 +3601,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 64
+              "y": 67
             },
             "id": 61,
             "options": {
@@ -3636,7 +3711,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 0,
-              "y": 70
+              "y": 73
             },
             "id": 23763572017,
             "options": {
@@ -3809,7 +3884,7 @@ objects:
               "h": 6,
               "w": 12,
               "x": 12,
-              "y": 70
+              "y": 73
             },
             "id": 23763571992,
             "options": {
@@ -3848,17 +3923,169 @@ objects:
               "h": 1,
               "w": 24,
               "x": 0,
-              "y": 76
+              "y": 79
             },
-            "id": 34,
+            "id": 23763572018,
             "panels": [],
-            "title": "Business metrics",
+            "title": "System ingress",
             "type": "row"
           },
           {
             "datasource": {
-              "uid": "$datasource"
+              "type": "prometheus",
+              "uid": "${datasource}"
             },
+            "description": "Sum of system import DB write failures in the global time range",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "mappings": [],
+                "min": 0,
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 6,
+              "x": 0,
+              "y": 80
+            },
+            "id": 23763572025,
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "value",
+              "wideLayout": true
+            },
+            "pluginVersion": "11.6.11",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "ceil(sum(increase(compliance_system_import_failures_total{application=\"compliance\"}[$__range])))",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "Import failures",
+            "type": "stat"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "description": "Sum of system import messages rejected due to invalid payload or type mismatch",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "mappings": [],
+                "min": 0,
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 6,
+              "x": 6,
+              "y": 80
+            },
+            "id": 23763572026,
+            "options": {
+              "colorMode": "background",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "value",
+              "wideLayout": true
+            },
+            "pluginVersion": "11.6.11",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "ceil(sum(increase(compliance_system_import_invalid_total{application=\"compliance\"}[$__range])))",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "Invalid imports",
+            "type": "stat"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "description": "Count of system delete events where no matching records were found during 1 minute.",
             "fieldConfig": {
               "defaults": {
                 "color": {
@@ -3897,7 +4124,6 @@ objects:
                     "mode": "off"
                   }
                 },
-                "links": [],
                 "mappings": [],
                 "thresholds": {
                   "mode": "absolute",
@@ -3907,7 +4133,7 @@ objects:
                     },
                     {
                       "color": "red",
-                      "value": 80
+                      "value": 100
                     }
                   ]
                 }
@@ -3915,19 +4141,18 @@ objects:
               "overrides": []
             },
             "gridPos": {
-              "h": 6,
+              "h": 9,
               "w": 12,
-              "x": 0,
-              "y": 77
+              "x": 12,
+              "y": 80
             },
-            "id": 51,
+            "id": 23763572023,
             "options": {
-              "alertThreshold": true,
               "legend": {
                 "calcs": [],
                 "displayMode": "list",
                 "placement": "bottom",
-                "showLegend": true
+                "showLegend": false
               },
               "tooltip": {
                 "hideZeros": false,
@@ -3939,33 +4164,135 @@ objects:
             "targets": [
               {
                 "datasource": {
-                  "uid": "$datasource"
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                 },
-                "expr": "sum(compliance_total_systems)",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "systems",
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_total_accounts)",
-                "format": "time_series",
-                "hide": false,
-                "intervalFactor": 1,
-                "legendFormat": "accounts",
-                "refId": "B"
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "sum(increase(compliance_system_delete_noop_total{application=\"compliance\"}[$__rate_interval]))\n  or vector(0)",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
               }
             ],
-            "title": "Database items (1)",
+            "title": "No-op deletes",
             "type": "timeseries"
           },
           {
             "datasource": {
-              "uid": "$datasource"
+              "type": "prometheus",
+              "uid": "${datasource}"
             },
+            "description": "Count of system import messages rejected due to invalid payload or type mismatch",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisGridShow": true,
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "axisSoftMax": 1,
+                  "axisSoftMin": 0,
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 40,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed+area"
+                  }
+                },
+                "decimals": 0,
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 12,
+              "x": 0,
+              "y": 84
+            },
+            "id": 23763572024,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "11.6.11",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+                },
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "sum(increase(compliance_system_import_invalid_total{application=\"compliance\"}[$__rate_interval]))\n  or vector(0)",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
+              }
+            ],
+            "title": "Invalid import messages",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "description": "Count of system import messages ignored because the DB record is newer during 1 minute.",
             "fieldConfig": {
               "defaults": {
                 "color": {
@@ -4004,7 +4331,6 @@ objects:
                     "mode": "off"
                   }
                 },
-                "links": [],
                 "mappings": [],
                 "thresholds": {
                   "mode": "absolute",
@@ -4014,7 +4340,7 @@ objects:
                     },
                     {
                       "color": "red",
-                      "value": 80
+                      "value": 100
                     }
                   ]
                 }
@@ -4022,213 +4348,18 @@ objects:
               "overrides": []
             },
             "gridPos": {
-              "h": 6,
+              "h": 9,
               "w": 12,
               "x": 12,
-              "y": 77
-            },
-            "id": 59,
-            "options": {
-              "alertThreshold": true,
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_total_policies)",
-                "format": "time_series",
-                "intervalFactor": 1,
-                "legendFormat": "policies",
-                "refId": "A"
-              }
-            ],
-            "title": "Database items (2)",
-            "type": "timeseries"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "mappings": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 0,
-              "y": 83
-            },
-            "id": 23763571994,
-            "options": {
-              "legend": {
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "pieType": "pie",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_total_systems_by_os) by (version)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{version}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Total number of systems reporting by OS version",
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "mappings": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 12,
-              "y": 83
-            },
-            "id": 23763571995,
-            "options": {
-              "legend": {
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "pieType": "pie",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_client_systems_by_os) by (version)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{version}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Number of client systems reporting by OS version",
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "mappings": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 0,
               "y": 89
             },
-            "id": 23763571998,
+            "id": 23763572019,
             "options": {
               "legend": {
+                "calcs": [],
                 "displayMode": "list",
                 "placement": "bottom",
-                "showLegend": true
-              },
-              "pieType": "pie",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
+                "showLegend": false
               },
               "tooltip": {
                 "hideZeros": false,
@@ -4240,318 +4371,47 @@ objects:
             "targets": [
               {
                 "datasource": {
-                  "uid": "$datasource"
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                 },
-                "expr": "sum(compliance_total_policies_by_os_major) by (version)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "RHEL {{ version }}",
-                "refId": "A"
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "sum(rate(compliance_system_import_stale_total{application=\"compliance\"}[$__rate_interval]))\n  or vector(0)",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
               }
             ],
-            "title": "Total number of policies by OS major version",
-            "type": "piechart"
+            "title": "No-op imports",
+            "type": "timeseries"
           },
           {
             "datasource": {
-              "uid": "$datasource"
+              "type": "prometheus",
+              "uid": "${datasource}"
             },
-            "description": "",
+            "description": "Count of system import DB write failures",
             "fieldConfig": {
               "defaults": {
                 "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "mappings": []
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 12,
-              "y": 89
-            },
-            "id": 23763571999,
-            "options": {
-              "legend": {
-                "displayMode": "list",
-                "placement": "bottom",
-                "showLegend": true
-              },
-              "pieType": "pie",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "hideZeros": false,
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_client_policies_by_os_major) by (version)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "RHEL {{ version }}",
-                "refId": "A"
-              }
-            ],
-            "title": "Number of client policies by OS major version",
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "links": [],
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 0,
-              "y": 95
-            },
-            "id": 23763571996,
-            "options": {
-              "minVizHeight": 75,
-              "minVizWidth": 75,
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showThresholdLabels": false,
-              "showThresholdMarkers": true,
-              "sizing": "auto"
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_total_50plus_policies)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Total",
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_client_50plus_policies)",
-                "interval": "",
-                "legendFormat": "Client",
-                "refId": "B"
-              }
-            ],
-            "title": "Number of policies with 50 or more systems",
-            "type": "gauge"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "links": [],
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 12,
-              "y": 95
-            },
-            "id": 23763571997,
-            "options": {
-              "minVizHeight": 75,
-              "minVizWidth": 75,
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showThresholdLabels": false,
-              "showThresholdMarkers": true,
-              "sizing": "auto"
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_total_accounts_with_50plus_hosts_per_policy)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Total",
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_client_accounts_with_50plus_hosts_per_policy)",
-                "interval": "",
-                "legendFormat": "Client",
-                "refId": "B"
-              }
-            ],
-            "title": "Number of accounts with one or more policies having 50 or more systems",
-            "type": "gauge"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "links": [],
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 0,
-              "y": 101
-            },
-            "id": 23763572000,
-            "options": {
-              "minVizHeight": 75,
-              "minVizWidth": 75,
-              "orientation": "auto",
-              "reduceOptions": {
-                "calcs": [
-                  "mean"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showThresholdLabels": false,
-              "showThresholdMarkers": true,
-              "sizing": "auto"
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_total_systems)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Total",
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_client_systems)",
-                "interval": "",
-                "legendFormat": "Client",
-                "refId": "B"
-              }
-            ],
-            "title": "Systems covered by at least one policy (current)",
-            "type": "gauge"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
+                  "mode": "thresholds"
                 },
                 "custom": {
                   "axisBorderShow": false,
                   "axisCenteredZero": false,
                   "axisColorMode": "text",
+                  "axisGridShow": true,
                   "axisLabel": "",
                   "axisPlacement": "auto",
+                  "axisSoftMax": 1,
+                  "axisSoftMin": 0,
                   "barAlignment": 0,
                   "barWidthFactor": 0.6,
                   "drawStyle": "line",
-                  "fillOpacity": 0,
+                  "fillOpacity": 40,
                   "gradientMode": "none",
                   "hideFrom": {
                     "legend": false,
@@ -4572,11 +4432,12 @@ objects:
                     "mode": "none"
                   },
                   "thresholdsStyle": {
-                    "mode": "off"
+                    "mode": "dashed+area"
                   }
                 },
-                "links": [],
+                "decimals": 0,
                 "mappings": [],
+                "min": 0,
                 "thresholds": {
                   "mode": "absolute",
                   "steps": [
@@ -4584,8 +4445,8 @@ objects:
                       "color": "green"
                     },
                     {
-                      "color": "red",
-                      "value": 80
+                      "color": "dark-red",
+                      "value": 1
                     }
                   ]
                 }
@@ -4593,19 +4454,18 @@ objects:
               "overrides": []
             },
             "gridPos": {
-              "h": 6,
+              "h": 7,
               "w": 12,
-              "x": 12,
-              "y": 101
+              "x": 0,
+              "y": 91
             },
-            "id": 23763572001,
+            "id": 23763572021,
             "options": {
-              "alertThreshold": true,
               "legend": {
                 "calcs": [],
                 "displayMode": "list",
                 "placement": "bottom",
-                "showLegend": true
+                "showLegend": false
               },
               "tooltip": {
                 "hideZeros": false,
@@ -4617,327 +4477,1120 @@ objects:
             "targets": [
               {
                 "datasource": {
-                  "uid": "$datasource"
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                 },
-                "expr": "sum(compliance_total_systems)",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Total",
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "uid": "$datasource"
-                },
-                "expr": "sum(compliance_client_systems)",
-                "interval": "",
-                "legendFormat": "Client",
-                "refId": "B"
+                "disableTextWrap": false,
+                "editorMode": "code",
+                "expr": "sum(increase(compliance_system_import_failures_total{application=\"compliance\"}[$__rate_interval]))\n  or vector(0)",
+                "fullMetaSearch": false,
+                "includeNullMetadata": true,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A",
+                "useBackend": false
               }
             ],
-            "title": "Systems covered by at least one policy (trend)",
+            "title": "Import failures",
             "type": "timeseries"
           },
           {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
-                  },
-                  "filterable": false,
-                  "inspect": false
-                },
-                "links": [],
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
+            "collapsed": true,
             "gridPos": {
-              "h": 6,
-              "w": 12,
+              "h": 1,
+              "w": 24,
               "x": 0,
-              "y": 107
+              "y": 98
             },
-            "id": 23763572002,
-            "options": {
-              "cellHeight": "sm",
-              "footer": {
-                "countRows": false,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": [
-                {
-                  "desc": true,
-                  "displayName": "Value"
-                }
-              ]
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
+            "id": 34,
+            "panels": [
               {
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "topk(4, sum(compliance_total_policies_by_account) by (ref_id))",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ ref_id }}",
-                "refId": "A"
-              }
-            ],
-            "title": "Top 4 most used profiles by accounts",
-            "type": "table"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
-                  },
-                  "filterable": false,
-                  "inspect": false
-                },
-                "links": [],
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
                     },
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "barWidthFactor": 0.6,
+                      "drawStyle": "line",
+                      "fillOpacity": 0,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "auto",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 93
+                },
+                "id": 59,
+                "options": {
+                  "alertThreshold": true,
+                  "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_policies)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "policies",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Database items (2)",
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      }
+                    },
+                    "mappings": []
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 93
+                },
+                "id": 23763571995,
+                "options": {
+                  "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_client_systems_by_os) by (version)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{version}}",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Number of client systems reporting by OS version",
+                "type": "piechart"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "barWidthFactor": 0.6,
+                      "drawStyle": "line",
+                      "fillOpacity": 0,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "auto",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 99
+                },
+                "id": 51,
+                "options": {
+                  "alertThreshold": true,
+                  "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_systems)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "systems",
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_accounts)",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "accounts",
+                    "refId": "B"
+                  }
+                ],
+                "title": "Database items (1)",
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      }
+                    },
+                    "mappings": []
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 99
+                },
+                "id": 23763571999,
+                "options": {
+                  "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_client_policies_by_os_major) by (version)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "RHEL {{ version }}",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Number of client policies by OS major version",
+                "type": "piechart"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      }
+                    },
+                    "mappings": []
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 105
+                },
+                "id": 23763571994,
+                "options": {
+                  "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_systems_by_os) by (version)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{version}}",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Total number of systems reporting by OS version",
+                "type": "piechart"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 105
+                },
+                "id": 23763571997,
+                "options": {
+                  "minVizHeight": 75,
+                  "minVizWidth": 75,
+                  "orientation": "auto",
+                  "reduceOptions": {
+                    "calcs": [
+                      "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true,
+                  "sizing": "auto"
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_accounts_with_50plus_hosts_per_policy)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total",
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_client_accounts_with_50plus_hosts_per_policy)",
+                    "interval": "",
+                    "legendFormat": "Client",
+                    "refId": "B"
+                  }
+                ],
+                "title": "Number of accounts with one or more policies having 50 or more systems",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      }
+                    },
+                    "mappings": []
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 111
+                },
+                "id": 23763571998,
+                "options": {
+                  "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "pieType": "pie",
+                  "reduceOptions": {
+                    "calcs": [
+                      "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_policies_by_os_major) by (version)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "RHEL {{ version }}",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Total number of policies by OS major version",
+                "type": "piechart"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "palette-classic"
+                    },
+                    "custom": {
+                      "axisBorderShow": false,
+                      "axisCenteredZero": false,
+                      "axisColorMode": "text",
+                      "axisLabel": "",
+                      "axisPlacement": "auto",
+                      "barAlignment": 0,
+                      "barWidthFactor": 0.6,
+                      "drawStyle": "line",
+                      "fillOpacity": 0,
+                      "gradientMode": "none",
+                      "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                      },
+                      "insertNulls": false,
+                      "lineInterpolation": "linear",
+                      "lineWidth": 1,
+                      "pointSize": 5,
+                      "scaleDistribution": {
+                        "type": "linear"
+                      },
+                      "showPoints": "auto",
+                      "spanNulls": false,
+                      "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                      },
+                      "thresholdsStyle": {
+                        "mode": "off"
+                      }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 111
+                },
+                "id": 23763572001,
+                "options": {
+                  "alertThreshold": true,
+                  "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                  },
+                  "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                  }
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_systems)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total",
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_client_systems)",
+                    "interval": "",
+                    "legendFormat": "Client",
+                    "refId": "B"
+                  }
+                ],
+                "title": "Systems covered by at least one policy (trend)",
+                "type": "timeseries"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 117
+                },
+                "id": 23763571996,
+                "options": {
+                  "minVizHeight": 75,
+                  "minVizWidth": 75,
+                  "orientation": "auto",
+                  "reduceOptions": {
+                    "calcs": [
+                      "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true,
+                  "sizing": "auto"
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_total_50plus_policies)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total",
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_client_50plus_policies)",
+                    "interval": "",
+                    "legendFormat": "Client",
+                    "refId": "B"
+                  }
+                ],
+                "title": "Number of policies with 50 or more systems",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "filterable": false,
+                      "inspect": false
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 117
+                },
+                "id": 23763572003,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
                     {
-                      "color": "red",
-                      "value": 80
+                      "desc": true,
+                      "displayName": "Value"
                     }
                   ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 12,
-              "y": 107
-            },
-            "id": 23763572003,
-            "options": {
-              "cellHeight": "sm",
-              "footer": {
-                "countRows": false,
-                "fields": "",
-                "reducer": [
-                  "sum"
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "topk(4, sum(compliance_client_policies_by_account) by (ref_id))",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ ref_id }}",
+                    "refId": "A"
+                  }
                 ],
-                "show": false
+                "title": "Top 4 most used profiles by client accounts",
+                "type": "table"
               },
-              "showHeader": true,
-              "sortBy": [
-                {
-                  "desc": true,
-                  "displayName": "Value"
-                }
-              ]
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
               {
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "topk(4, sum(compliance_client_policies_by_account) by (ref_id))",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ ref_id }}",
-                "refId": "A"
-              }
-            ],
-            "title": "Top 4 most used profiles by client accounts",
-            "type": "table"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
+                "fieldConfig": {
+                  "defaults": {
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
                   },
-                  "filterable": false,
-                  "inspect": false
+                  "overrides": []
                 },
-                "links": [],
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 123
+                },
+                "id": 23763572000,
+                "options": {
+                  "minVizHeight": 75,
+                  "minVizWidth": 75,
+                  "orientation": "auto",
+                  "reduceOptions": {
+                    "calcs": [
+                      "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                  },
+                  "showThresholdLabels": false,
+                  "showThresholdMarkers": true,
+                  "sizing": "auto"
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
                     },
+                    "expr": "sum(compliance_total_systems)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Total",
+                    "refId": "A"
+                  },
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "sum(compliance_client_systems)",
+                    "interval": "",
+                    "legendFormat": "Client",
+                    "refId": "B"
+                  }
+                ],
+                "title": "Systems covered by at least one policy (current)",
+                "type": "gauge"
+              },
+              {
+                "datasource": {
+                  "uid": "$datasource"
+                },
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "filterable": false,
+                      "inspect": false
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 123
+                },
+                "id": 23763572005,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
                     {
-                      "color": "red",
-                      "value": 80
+                      "desc": true,
+                      "displayName": "Value"
                     }
                   ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 0,
-              "y": 113
-            },
-            "id": 23763572004,
-            "options": {
-              "cellHeight": "sm",
-              "footer": {
-                "countRows": false,
-                "fields": "",
-                "reducer": [
-                  "sum"
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "topk(4, sum(compliance_client_policies_by_host) by (ref_id))",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ ref_id }}",
+                    "refId": "A"
+                  }
                 ],
-                "show": false
+                "title": "Top 4 most used profiles by client hosts",
+                "type": "table"
               },
-              "showHeader": true,
-              "sortBy": [
-                {
-                  "desc": true,
-                  "displayName": "Value"
-                }
-              ]
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
               {
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "topk(4, sum(compliance_total_policies_by_host) by (ref_id))",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ ref_id }}",
-                "refId": "A"
-              }
-            ],
-            "title": "Top 4 most used profiles by hosts",
-            "type": "table"
-          },
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "description": "",
-            "fieldConfig": {
-              "defaults": {
-                "custom": {
-                  "align": "auto",
-                  "cellOptions": {
-                    "type": "auto"
-                  },
-                  "filterable": false,
-                  "inspect": false
-                },
-                "links": [],
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "filterable": false,
+                      "inspect": false
                     },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 129
+                },
+                "id": 23763572002,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
                     {
-                      "color": "red",
-                      "value": 80
+                      "desc": true,
+                      "displayName": "Value"
                     }
                   ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 12,
-              "x": 12,
-              "y": 113
-            },
-            "id": 23763572005,
-            "options": {
-              "cellHeight": "sm",
-              "footer": {
-                "countRows": false,
-                "fields": "",
-                "reducer": [
-                  "sum"
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "topk(4, sum(compliance_total_policies_by_account) by (ref_id))",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ ref_id }}",
+                    "refId": "A"
+                  }
                 ],
-                "show": false
+                "title": "Top 4 most used profiles by accounts",
+                "type": "table"
               },
-              "showHeader": true,
-              "sortBy": [
-                {
-                  "desc": true,
-                  "displayName": "Value"
-                }
-              ]
-            },
-            "pluginVersion": "11.6.11",
-            "targets": [
               {
                 "datasource": {
                   "uid": "$datasource"
                 },
-                "expr": "topk(4, sum(compliance_client_policies_by_host) by (ref_id))",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{ ref_id }}",
-                "refId": "A"
+                "description": "",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": "auto",
+                      "cellOptions": {
+                        "type": "auto"
+                      },
+                      "filterable": false,
+                      "inspect": false
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green"
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  "overrides": []
+                },
+                "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 135
+                },
+                "id": 23763572004,
+                "options": {
+                  "cellHeight": "sm",
+                  "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                      "sum"
+                    ],
+                    "show": false
+                  },
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": "Value"
+                    }
+                  ]
+                },
+                "pluginVersion": "11.6.11",
+                "targets": [
+                  {
+                    "datasource": {
+                      "uid": "$datasource"
+                    },
+                    "expr": "topk(4, sum(compliance_total_policies_by_host) by (ref_id))",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ ref_id }}",
+                    "refId": "A"
+                  }
+                ],
+                "title": "Top 4 most used profiles by hosts",
+                "type": "table"
               }
             ],
-            "title": "Top 4 most used profiles by client hosts",
-            "type": "table"
+            "title": "Business metrics",
+            "type": "row"
           }
         ],
         "preload": false,
@@ -5090,7 +5743,7 @@ objects:
         "timezone": "",
         "title": "Compliance",
         "uid": "compliance",
-        "version": 4
+        "version": 10
       }
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
<img width="1539" height="727" alt="image" src="https://github.com/user-attachments/assets/19ef9a81-d466-4fea-bf95-5720604e8e37" />

There's a slight oscillation of the error counters and graphs, but they should be good enough for our purposes. This is due to time range interpolations. See the oscillation: (stat is 2 but the graph shows 4)

<img width="1539" height="727" alt="image" src="https://github.com/user-attachments/assets/8182f647-b5ef-4d38-8e4e-9fc87b2b816c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add a new Grafana **System ingress** section with panels for import failures, invalid imports, invalid import messages, no-op deletes, and no-op imports.
- Reposition existing dashboard panels and collapse the business-metrics layout into a row.
- Increase the Grafana dashboard version from 4 to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->