### PR TITLE
feat(Konflux): utilize cache for base image download

### DIFF
--- a/.tekton/compliance-backend-pull-request.yaml
+++ b/.tekton/compliance-backend-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/compliance-backend-push.yaml
+++ b/.tekton/compliance-backend-push.yaml
@@ -26,6 +26,8 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -86,6 +88,10 @@ spec:
       default: docker
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - name: enable-cache-proxy
+      default: 'false'
+      description: Enable cache proxy configuration
+      type: string
     - name: enable-package-registry-proxy
       default: 'true'
       description: Use the package registry proxy when prefetching dependencies
@@ -121,6 +127,9 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     tasks:
     - name: init
+      params:
+      - name: enable-cache-proxy
+        value: $(params.enable-cache-proxy)
       taskRef:
         params:
         - name: name
@@ -209,6 +218,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       - name: SOURCE_DATE_EPOCH
         value: $(params.source-date-epoch)
       - name: REWRITE_TIMESTAMP


### PR DESCRIPTION
Based on: https://konflux-ci.dev/docs/building/caching-proxy/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enable the Konflux cache proxy for image builds in pull request and push pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->