### PR TITLE
perf(resolver): implement trie construction for association joins

### DIFF
--- a/app/controllers/concerns/join_builder.rb
+++ b/app/controllers/concerns/join_builder.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Builds optimized Arel INNER JOIN nodes from a trie of association reflection chains.
+# Merges shared intermediate associations into a single join, aliasing each joined table
+# by its association name to preserve the alias contract used by select_fields,
+# searchable_by/sortable_by, and merge_with_alias.
+module JoinBuilder
+  extend ActiveSupport::Concern
+
+  private
+
+  # Builds a trie (prefix tree) from the reflection chains of all requested associations.
+  # Shared intermediate associations collapse into a single node.
+  def build_join_trie(model, associations)
+    trie = {}
+
+    associations.each do |assoc|
+      chain = association_chain(model, assoc)
+      node = trie
+      chain.each { |step| node = (node[step] ||= {}) }
+    end
+
+    trie
+  end
+
+  # Resolves the full through-chain for an association by walking through_reflection
+  # recursively. Returns the chain ordered from source to target.
+  def association_chain(model, assoc)
+    ref = model.reflect_on_association(assoc)
+    return [assoc] unless ref.through_reflection?
+
+    association_chain(model, ref.through_reflection.name) + [assoc]
+  end
+
+  # Walks the trie depth-first and emits Arel INNER JOIN nodes with association-name aliases.
+  def emit_arel_joins(trie, model, source_table, already_joined_set)
+    trie.flat_map do |assoc_name, children|
+      source_ref = resolve_source_reflection(model, assoc_name)
+      target_table = Arel::Table.new(source_ref.klass.table_name).alias(assoc_name.to_s)
+      join = if already_joined_set.include?(assoc_name)
+               []
+             else
+               [build_arel_join_node(source_ref, source_table, target_table)]
+             end
+
+      join + emit_arel_joins(children, source_ref.klass, target_table, already_joined_set)
+    end
+  end
+
+  def resolve_source_reflection(model, assoc_name)
+    ref = model.reflect_on_association(assoc_name)
+    ref.through_reflection? ? ref.source_reflection : ref
+  end
+
+  def build_arel_join_node(ref, source_table, target_table)
+    source_table.create_join(
+      target_table,
+      source_table.create_on(build_join_condition(ref, source_table, target_table)),
+      Arel::Nodes::InnerJoin
+    )
+  end
+
+  def build_join_condition(ref, source_table, target_table)
+    if ref.macro == :belongs_to
+      target_table[ref.association_primary_key].eq(source_table[ref.foreign_key])
+    else
+      target_table[ref.foreign_key].eq(source_table[ref.association_primary_key])
+    end
+  end
+end

--- a/app/controllers/concerns/resolver.rb
+++ b/app/controllers/concerns/resolver.rb
@@ -3,6 +3,7 @@
 # Concern for resolving database resources
 module Resolver
   extend ActiveSupport::Concern
+  include JoinBuilder
 
   private
 
@@ -45,12 +46,19 @@ module Resolver
     end
   end
 
-  # Select the 1:1 associations that can be satisfied without any additional WHERE clause,
-  # then join them with the relation.
+  # Join the 1:1 associations required by the serializer using a merged trie of reflection
+  # chains. This is to eliminate redundant intermediate joins that would be generated when the resolver traverses the
+  # same model multiple times.
   def join_associated(relation)
     # Do not join with the already joined parents assumed from the (nested) route
     associations = dependencies.keys.excluding(*permitted_params[:parents]).compact
-    relation.where.associated(*associations)
+    return relation if associations.empty?
+
+    trie = build_join_trie(resource, associations)
+    joined = already_joined(relation).to_set
+    arel_joins = emit_arel_joins(trie, resource, resource.arel_table, joined)
+
+    relation.joins(*arel_joins)
   end
 
   # Self-join with the requested aggregations built using 1:n associations, also select

--- a/app/controllers/rule_results_controller.rb
+++ b/app/controllers/rule_results_controller.rb
@@ -21,9 +21,4 @@ class RuleResultsController < ApplicationController
   def serializer
     RuleResultSerializer
   end
-
-  def expand_resource
-    scope = join_parents(pundit_scope, permitted_params[:parents])
-    scope.with_serializer_data
-  end
 end

--- a/app/models/rule_result.rb
+++ b/app/models/rule_result.rb
@@ -23,57 +23,6 @@ class RuleResult < ApplicationRecord
   scope :passed, -> { where(result: PASSED) }
   scope :failed, -> { where(result: FAILED) }
 
-  # Eliminates redundant joins to test_results table
-  scope :with_serializer_data, lambda {
-    joins(build_rule_join)
-      .joins(test_result: [:system, { tailoring: { profile: :security_guide } }])
-      .select(*serializer_select_fields)
-  }
-
-  def self.serializer_dependencies
-    @serializer_dependencies ||= begin
-      deps = RuleResultSerializer.dependencies([], %i[rule system profile security_guide])
-      deps.transform_values(&:uniq) # remove duplicates
-    end
-  end
-
-  class << self
-    def serializer_select_fields
-      [arel_table[Arel.star]] + association_fields
-    end
-
-    def build_rule_join
-      rule_join = arel_table
-                  .join(Rule.arel_table.alias('rule'), Arel::Nodes::InnerJoin)
-                  .on(Rule.arel_table.alias('rule')[:id].eq(arel_table[:rule_id]))
-      rule_join.join_sources
-    end
-
-    private
-
-    def association_fields
-      serializer_dependencies.flat_map do |association, fields|
-        next [] if association.nil? # skip base model fields
-
-        table = arel_table_for_association(association)
-        fields.map { |field| table[field].as("#{association}__#{field}") }
-      end
-    end
-
-    def arel_table_for_association(association)
-      case association
-      when :rule
-        Rule.arel_table.alias('rule')
-      when :system
-        Arel::Table.new(:hosts, as: 'system')
-      when :profile
-        Profile.arel_table
-      when :security_guide
-        SecurityGuide.arel_table
-      end
-    end
-  end
-
   scope :with_groups, lambda { |groups, table = System.arel_table|
     # Skip the [] representing ungrouped hosts from the array when generating the query
     grouped = arel_json_lookup(table[:groups], System.groups_as_json(groups.flatten, :id))

--- a/spec/controllers/rule_results_controller_spec.rb
+++ b/spec/controllers/rule_results_controller_spec.rb
@@ -80,25 +80,6 @@ describe RuleResultsController do
       it_behaves_like 'paginable', :report, :test_result
       it_behaves_like 'sortable', :report, :test_result
       it_behaves_like 'searchable', :report, :test_result
-
-      it 'optimizes queries by using single join path through test_result' do
-        controller = described_class.new
-
-        allow(controller).to receive(:permitted_params).and_return(parents: %i[report test_result])
-        allow(controller).to receive(:pundit_scope).and_return(RuleResult.all)
-        allow(controller).to receive(:join_parents) { |scope, _| scope }
-
-        query = controller.send(:expand_resource).to_sql
-
-        %w[test_result tailoring profile security_guide].each do |association|
-          expect(query).to include(association)
-        end
-        # Verify the optimized query includes the required rule table with proper alias
-        expect(query).to include('"rule"')
-
-        join_clauses = query.scan(/JOIN "test_results"/i).count
-        expect(join_clauses).to eq(1)
-      end
     end
   end
 end


### PR DESCRIPTION
The recent [perf change](https://github.com/RedHatInsights/compliance-backend/pull/2879) I did made the duplicated join issue resurface.

We [put a plaster on it back when](https://github.com/RedHatInsights/compliance-backend/pull/2593/changes/28c37d6582fb8bcaf8c8df447218363079078f64), but this PR should fix the issue in one place for all endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Build trie-based Arel joins to merge shared association paths and prevent duplicate joins.
- Use `JoinBuilder` in `Resolver#join_associated` for all endpoints.
- Remove the hardcoded serializer-query optimization from `RuleResult`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->