### PR TITLE
[TEST] RHINENG-29281: Enable binary gems to eliminate grpc compilation

### DIFF
--- a/.github/workflows/ruby-update.yml
+++ b/.github/workflows/ruby-update.yml
@@ -32,7 +32,6 @@ jobs:
   update-bundler:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_FORCE_RUBY_PLATFORM: true
       BUNDLE_BUILD__FFI: "--enable-system-libffi"
     steps:
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgre
     ( [[ $prod != "true" ]] || bundle config set --local deployment 'true' )                      && \
     ( [[ $prod != "true" ]] || bundle config set --local path './.bundle' )                       && \
     bundle config set --local retry '2'                                                           && \
-    bundle config set --local force_ruby_platform true                                            && \
     bundle config set --local build.ffi --enable-system-libffi                                    && \
     bundle install --jobs 6                                                                       && \
     microdnf clean all -y                                                                         && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.4)
+    ffi (1.17.4-x86_64-linux-gnu)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)
     fugit (1.13.0)
@@ -202,9 +203,15 @@ GEM
     google-protobuf (4.35.1)
       bigdecimal
       rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
     googleapis-common-protos-types (1.23.0)
       google-protobuf (~> 4.26)
     grpc (1.83.0)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.83.0-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     hashdiff (1.2.1)
@@ -241,6 +248,12 @@ GEM
       karafka-rdkafka (>= 0.20.0)
       logger (>= 1.6.0)
     karafka-rdkafka (0.28.0)
+      ffi (~> 1.17.1)
+      json (> 2.0)
+      logger
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+    karafka-rdkafka (0.28.0-x86_64-linux-gnu)
       ffi (~> 1.17.1)
       json (> 2.0)
       logger
@@ -328,11 +341,17 @@ GEM
       racc
     parslet (2.0.0)
     pg (1.6.3)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
     prometheus-client-mmap (1.6.0)
+      base64
+      bigdecimal
+      logger
+      rb_sys (~> 0.9.128)
+    prometheus-client-mmap (1.6.0-x86_64-linux-gnu)
       base64
       bigdecimal
       logger
@@ -577,6 +596,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activerecord-import


### PR DESCRIPTION
## Description
This is a test PR for Jira ticket RHINENG-29281.

It temporarily removes `force_ruby_platform` to test whether binary gems (specifically `grpc`) will download correctly in CI and eliminate the ~5 minute native compilation penalty during the container build.

### Changes:
*   Removed `bundle config set --local force_ruby_platform true` from `Dockerfile`.
*   Removed `BUNDLE_FORCE_RUBY_PLATFORM` from the ruby-update workflow.
*   Added `x86_64-linux` to the `PLATFORMS` block in `Gemfile.lock`.

**NOTE:** This is marked as a test because removing this flag globally may introduce issues with other binary gems (like `nokogiri` or `google-protobuf`) that required being built locally on UBI 9 in the past. We want to see the CI results before making any final architectural decisions.