### PR TITLE
fix(tags): switch tag filtering to use OR logic instead of AND

### DIFF
--- a/app/controllers/concerns/collection.rb
+++ b/app/controllers/concerns/collection.rb
@@ -65,7 +65,7 @@ module Collection
       end
 
       tags = parse_tags(permitted_params[:tags])
-      data.where('tags @> ?', tags.to_json)
+      data.where(tags.map { 'tags @> ?' }.join(' OR '), *tags.map { |t| [t].to_json })
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/spec/controllers/concerns/taggable_spec.rb
+++ b/spec/controllers/concerns/taggable_spec.rb
@@ -45,15 +45,9 @@ RSpec.shared_examples 'taggable' do |*parents|
   end
 
   context 'looking for multiple tags' do
-    it 'returns systems matching all tags' do
-      selected.map do |s|
-        s.update(
-          tags: [
-            { namespace: 'foo', key: 'bar', value: 'baz' },
-            { namespace: 'one', key: 'two', value: 'three' }
-          ]
-        )
-      end
+    it 'returns systems matching any of the tags' do
+      selected.first.update(tags: [{ namespace: 'foo', key: 'bar', value: 'baz' }])
+      selected.second.update(tags: [{ namespace: 'one', key: 'two', value: 'three' }])
 
       get :index, params: passable_params.merge(parents: parents, tags: ['foo/bar=baz', 'one/two=three'])
       expect(response_body_data).to match_array(selected.map { |item| hash_including('id' => item.id) })


### PR DESCRIPTION
Inventory switched tag filtering from AND to OR logic in Feb 2023
(ESSNTL-3533). Our backend still uses AND, which means the same tag
filter produces different results in inventory vs compliance.

- Change `filter_by_tags` to OR individual `@>` checks instead of
  a single `@>` with all tags (AND)
- Update `taggable` shared example to verify OR behavior

Resolves: RHINENG-11780

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Changed compliance tag filtering from AND logic to OR logic.
- Updated shared tests to verify records that contain any requested tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->