### PR TITLE
fix(ClowdApp): add kessel to dependency list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,6 @@ pipeline {
                         curl -s ${CICD_URL}/bootstrap.sh > .cicd_bootstrap.sh
                         source ./.cicd_bootstrap.sh
 
-                        export APP_NAME="host-inventory kessel rbac compliance"
                         export IMAGE_TAG="${GIT_COMMIT:0:7}"
                         export OPTIONAL_DEPS_METHOD="all"
                         export EXTRA_DEPLOY_ARGS="

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -20,6 +20,7 @@ objects:
     - host-inventory
     - ingress
     - rbac
+    - kessel
     database:
       name: compliance
       version: 16


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add `kessel` to the ClowdApp dependency list.
- Remove the multi-component `APP_NAME` override from the smoke-test script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->