### PR TITLE
feat(Renovate): allow dependency PR triggering with dashboard GH issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "dependencyDashboard": true,
   "extends": [
     "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
   ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Enable Renovate’s dependency dashboard to support dependency pull request triggering through a GitHub issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->