### PR TITLE
fix(Grafana): measure increase for stale imports

### DIFF
--- a/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
+++ b/dashboards/grafana-dashboard-insights-compliance-general.template.yaml
@@ -4376,7 +4376,7 @@ objects:
                 },
                 "disableTextWrap": false,
                 "editorMode": "code",
-                "expr": "sum(rate(compliance_system_import_stale_total{application=\"compliance\"}[$interval]))\n  or vector(0)",
+                "expr": "sum(increase(compliance_system_import_stale_total{application=\"compliance\"}[$interval]))\n  or vector(0)",
                 "fullMetaSearch": false,
                 "includeNullMetadata": true,
                 "legendFormat": "__auto",
@@ -5743,7 +5743,7 @@ objects:
         "timezone": "",
         "title": "Compliance",
         "uid": "compliance",
-        "version": 10
+        "version": 12
       }
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
Correcting the metric so it matches our alerts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated the Grafana “No-op imports” query to use `increase` and match configured alerts.
- Increased the dashboard version from 10 to 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->