### PR TITLE
feat(parsing): auto-create tailoring on RHEL minor version upgrade

### DIFF
--- a/app/services/concerns/xccdf/tailorings.rb
+++ b/app/services/concerns/xccdf/tailorings.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
 
 module Xccdf
-  # Methods related to finding Tailorings
+  # Methods related to finding and auto-creating Tailorings during report parsing
   module Tailorings
-    # rubocop:disable Rails/FindByOrAssignmentMemoization
     def tailoring
-      @tailoring ||= ::Tailoring.find_by(
-        policy: @policy,
-        os_minor_version: @system.os_minor_version.to_i
-      )
+      @tailoring ||= find_or_create_tailoring # rubocop:disable Rails/FindByOrAssignmentMemoization
     end
-    # rubocop:enable Rails/FindByOrAssignmentMemoization
 
     def external_report?
       @policy.nil?
@@ -31,6 +26,30 @@ module Xccdf
       end
 
       @tailored_profile ||= tailoring.profile
+    end
+
+    private
+
+    def find_or_create_tailoring
+      os_minor = @system.os_minor_version.to_i
+
+      tailoring = ::Tailoring.find_or_create_by!(policy: @policy, os_minor_version: os_minor) do |t|
+        profile = @policy.profile.variant_for_minor(os_minor)
+        t.profile = profile
+        t.value_overrides = profile.value_overrides
+      end
+
+      log_tailoring_creation(tailoring, os_minor)
+      tailoring
+    rescue ::Exceptions::OSMinorVersionNotSupported
+      nil
+    end
+
+    def log_tailoring_creation(tailoring, os_minor)
+      return unless tailoring.previously_new_record?
+
+      Rails.logger.audit_success("Auto-created tailoring for policy #{@policy.id} " \
+                                 "and OS minor version #{os_minor}")
     end
   end
 end

--- a/app/services/concerns/xccdf/tailorings.rb
+++ b/app/services/concerns/xccdf/tailorings.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
 
 module Xccdf
-  # Methods related to finding Tailorings
+  # Methods related to finding and auto-creating Tailorings during report parsing
   module Tailorings
-    # rubocop:disable Rails/FindByOrAssignmentMemoization
     def tailoring
-      @tailoring ||= ::Tailoring.find_by(
-        policy: @policy,
-        os_minor_version: @system.os_minor_version.to_i
-      )
+      @tailoring ||= find_or_create_tailoring # rubocop:disable Rails/FindByOrAssignmentMemoization
     end
-    # rubocop:enable Rails/FindByOrAssignmentMemoization
 
     def external_report?
       @policy.nil?
@@ -25,6 +20,30 @@ module Xccdf
       end
 
       @tailored_profile ||= tailoring.profile
+    end
+
+    private
+
+    def find_or_create_tailoring
+      os_minor = @system.os_minor_version.to_i
+
+      tailoring = ::Tailoring.find_or_create_by!(policy: @policy, os_minor_version: os_minor) do |t|
+        profile = @policy.profile.variant_for_minor(os_minor)
+        t.profile = profile
+        t.value_overrides = profile.value_overrides
+      end
+
+      log_tailoring_creation(tailoring, os_minor)
+      tailoring
+    rescue ::Exceptions::OSMinorVersionNotSupported
+      nil
+    end
+
+    def log_tailoring_creation(tailoring, os_minor)
+      return unless tailoring.previously_new_record?
+
+      Rails.logger.audit_success("Auto-created tailoring for policy #{@policy.id} " \
+                                 "and OS minor version #{os_minor}")
     end
   end
 end

--- a/db/migrate/20260817143906_add_unique_index_on_policy_and_os_minor_to_tailorings.rb
+++ b/db/migrate/20260817143906_add_unique_index_on_policy_and_os_minor_to_tailorings.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnPolicyAndOsMinorToTailorings < ActiveRecord::Migration[8.1]
+  def change
+    add_index :tailorings, %i[policy_id os_minor_version], unique: true
+  end
+end

--- a/db/migrate/20260907113606_add_unique_index_on_policy_and_os_minor_to_tailorings.rb
+++ b/db/migrate/20260907113606_add_unique_index_on_policy_and_os_minor_to_tailorings.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnPolicyAndOsMinorToTailorings < ActiveRecord::Migration[8.1]
+  def change
+    add_index :tailorings, %i[policy_id os_minor_version], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_143906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -338,6 +338,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_122250) do
     t.uuid "profile_id", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.jsonb "value_overrides", default: {}
+    t.index ["policy_id", "os_minor_version"], name: "index_tailorings_on_policy_id_and_os_minor_version", unique: true
     t.index ["policy_id"], name: "index_tailorings_on_policy_id"
     t.index ["profile_id"], name: "index_tailorings_on_profile_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_01_125741) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_113606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -344,6 +344,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_01_125741) do
     t.uuid "profile_id", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.jsonb "value_overrides", default: {}
+    t.index ["policy_id", "os_minor_version"], name: "index_tailorings_on_policy_id_and_os_minor_version", unique: true
     t.index ["policy_id"], name: "index_tailorings_on_policy_id"
     t.index ["profile_id"], name: "index_tailorings_on_profile_id"
   end

--- a/spec/services/concerns/xccdf/tailorings_spec.rb
+++ b/spec/services/concerns/xccdf/tailorings_spec.rb
@@ -32,11 +32,63 @@ RSpec.describe Xccdf::Tailorings do
       expect(service.tailoring).to eq(expected)
     end
 
-    context 'when no tailoring exists for the system OS minor version' do
+    context 'when no tailoring exists and the OS minor version is unsupported' do
       let!(:system) { create(:system, account: user.account, os_minor_version: unsupported_os_minor_version) }
 
       it 'returns nil' do
         expect(service.tailoring).to be_nil
+      end
+    end
+
+    context 'when no tailoring exists but the OS minor version is supported by the profile' do
+      let(:upgraded_os_minor_version) { os_minor_version + 1 }
+      let(:policy) do
+        create(:policy, account: user.account, supports_minors: [os_minor_version, upgraded_os_minor_version])
+      end
+      let!(:system) { create(:system, account: user.account, os_minor_version: upgraded_os_minor_version) }
+
+      it 'auto-creates a tailoring for the OS minor version' do
+        expect { service.tailoring }.to change(Tailoring, :count).by(1)
+      end
+
+      it 'returns a persisted tailoring matching the policy and OS minor version' do
+        result = service.tailoring
+
+        expect(result).to be_persisted
+        expect(result.os_minor_version).to eq(upgraded_os_minor_version)
+        expect(result.policy).to eq(policy)
+      end
+
+      it 'assigns the correct profile variant to the new tailoring' do
+        result = service.tailoring
+        expected_profile = policy.profile.variant_for_minor(upgraded_os_minor_version)
+
+        expect(result.profile).to eq(expected_profile)
+      end
+
+      it 'populates the tailoring with rules from the canonical profile' do
+        result = service.tailoring
+
+        expect(result.tailoring_rules.pluck(:rule_id))
+          .to match_array(ProfileRule.where(profile_id: result.profile_id).pluck(:rule_id))
+      end
+
+      it 'logs an audit message after persistence' do
+        allow(Rails.logger).to receive(:audit_success)
+
+        service.tailoring
+
+        expect(Rails.logger).to have_received(:audit_success).with(/Auto-created tailoring/)
+      end
+
+      it 'does not log when the tailoring already exists' do
+        service.tailoring
+
+        allow(Rails.logger).to receive(:audit_success)
+
+        service.class.new(policy: policy, system: system, security_guide: security_guide).tailoring
+
+        expect(Rails.logger).not_to have_received(:audit_success)
       end
     end
   end
@@ -93,6 +145,21 @@ RSpec.describe Xccdf::Tailorings do
       it 'raises OSVersionMismatch instead of NoMethodError' do
         expect { service.tailored_profile }
           .to raise_error(XccdfReportParser::OSVersionMismatch)
+      end
+    end
+
+    context 'when the OS minor version is supported but has no tailoring yet' do
+      let(:upgraded_os_minor_version) { os_minor_version + 1 }
+      let(:policy) do
+        create(:policy, account: user.account, supports_minors: [os_minor_version, upgraded_os_minor_version])
+      end
+      let!(:system) { create(:system, account: user.account, os_minor_version: upgraded_os_minor_version) }
+
+      it 'returns the profile from the auto-created tailoring' do
+        result = service.tailored_profile
+        expected_profile = policy.profile.variant_for_minor(upgraded_os_minor_version)
+
+        expect(result).to eq(expected_profile)
       end
     end
   end

--- a/spec/services/concerns/xccdf/tailorings_spec.rb
+++ b/spec/services/concerns/xccdf/tailorings_spec.rb
@@ -27,11 +27,63 @@ RSpec.describe Xccdf::Tailorings do
       expect(service.tailoring).to eq(expected)
     end
 
-    context 'when no tailoring exists for the system OS minor version' do
+    context 'when no tailoring exists and the OS minor version is unsupported' do
       let!(:system) { create(:system, account: user.account, os_minor_version: unsupported_os_minor_version) }
 
       it 'returns nil' do
         expect(service.tailoring).to be_nil
+      end
+    end
+
+    context 'when no tailoring exists but the OS minor version is supported by the profile' do
+      let(:upgraded_os_minor_version) { os_minor_version + 1 }
+      let(:policy) do
+        create(:policy, account: user.account, supports_minors: [os_minor_version, upgraded_os_minor_version])
+      end
+      let!(:system) { create(:system, account: user.account, os_minor_version: upgraded_os_minor_version) }
+
+      it 'auto-creates a tailoring for the OS minor version' do
+        expect { service.tailoring }.to change(Tailoring, :count).by(1)
+      end
+
+      it 'returns a persisted tailoring matching the policy and OS minor version' do
+        result = service.tailoring
+
+        expect(result).to be_persisted
+        expect(result.os_minor_version).to eq(upgraded_os_minor_version)
+        expect(result.policy).to eq(policy)
+      end
+
+      it 'assigns the correct profile variant to the new tailoring' do
+        result = service.tailoring
+        expected_profile = policy.profile.variant_for_minor(upgraded_os_minor_version)
+
+        expect(result.profile).to eq(expected_profile)
+      end
+
+      it 'populates the tailoring with rules from the canonical profile' do
+        result = service.tailoring
+
+        expect(result.tailoring_rules.pluck(:rule_id))
+          .to match_array(ProfileRule.where(profile_id: result.profile_id).pluck(:rule_id))
+      end
+
+      it 'logs an audit message after persistence' do
+        allow(Rails.logger).to receive(:audit_success)
+
+        service.tailoring
+
+        expect(Rails.logger).to have_received(:audit_success).with(/Auto-created tailoring/)
+      end
+
+      it 'does not log when the tailoring already exists' do
+        service.tailoring
+
+        allow(Rails.logger).to receive(:audit_success)
+
+        service.class.new(policy: policy, system: system).tailoring
+
+        expect(Rails.logger).not_to have_received(:audit_success)
       end
     end
   end
@@ -64,6 +116,21 @@ RSpec.describe Xccdf::Tailorings do
       it 'raises OSVersionMismatch instead of NoMethodError' do
         expect { service.tailored_profile }
           .to raise_error(XccdfReportParser::OSVersionMismatch)
+      end
+    end
+
+    context 'when the OS minor version is supported but has no tailoring yet' do
+      let(:upgraded_os_minor_version) { os_minor_version + 1 }
+      let(:policy) do
+        create(:policy, account: user.account, supports_minors: [os_minor_version, upgraded_os_minor_version])
+      end
+      let!(:system) { create(:system, account: user.account, os_minor_version: upgraded_os_minor_version) }
+
+      it 'returns the profile from the auto-created tailoring' do
+        result = service.tailored_profile
+        expected_profile = policy.profile.variant_for_minor(upgraded_os_minor_version)
+
+        expect(result).to eq(expected_profile)
       end
     end
   end

--- a/spec/services/duplicate_tailorings_cleaner_spec.rb
+++ b/spec/services/duplicate_tailorings_cleaner_spec.rb
@@ -15,8 +15,13 @@ describe DuplicateTailoringsCleaner do
 
   # Builds a Tailoring bypassing app validations, mirroring how the legacy bugs produced
   # invalid rows directly at the DB level (no unique index existed to prevent them).
+  # The unique index is dropped inside the example transaction so duplicates can be seeded;
+  # transactional fixtures roll that DROP back after the example.
   # rubocop:disable Rails/SkipsModelValidations
   def build_invalid_tailoring(os_minor_version:, created_at: Time.zone.now)
+    ActiveRecord::Base.connection.execute(
+      'DROP INDEX IF EXISTS index_tailorings_on_policy_id_and_os_minor_version'
+    )
     tailoring = policy.tailorings.build(
       profile: policy.profile, os_minor_version: os_minor_version, value_overrides: {}
     )

--- a/spec/services/xccdf_report_parser_spec.rb
+++ b/spec/services/xccdf_report_parser_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe XccdfReportParser do
     end
 
     context 'when the report contains rules not in the security guide' do
+      before { allow(parser).to receive(:version_mismatched?).and_return(false) }
+
       it 'raises UnknownRuleError' do
         expect { parser.check_for_missing_rules }.to raise_error(described_class::UnknownRuleError)
       end

--- a/spec/tasks/cleanup_duplicate_tailorings_spec.rb
+++ b/spec/tasks/cleanup_duplicate_tailorings_spec.rb
@@ -39,8 +39,15 @@ RSpec.describe 'tailorings:cleanup_duplicates task' do
   let(:policy) { create(:policy, :for_tailoring, supports_minors: [0], system_count: 1) }
   let(:good_tailoring) { policy.tailorings.find_by(os_minor_version: 0) }
 
+  # Builds a Tailoring bypassing app validations, mirroring how the legacy bugs produced
+  # invalid rows directly at the DB level (no unique index existed to prevent them).
+  # The unique index is dropped inside the example transaction so duplicates can be seeded;
+  # transactional fixtures roll that DROP back after the example.
   # rubocop:disable Rails/SkipsModelValidations
   def build_invalid_tailoring(os_minor_version:, created_at: Time.zone.now)
+    ActiveRecord::Base.connection.execute(
+      'DROP INDEX IF EXISTS index_tailorings_on_policy_id_and_os_minor_version'
+    )
     tailoring = policy.tailorings.build(
       profile: policy.profile, os_minor_version: os_minor_version, value_overrides: {}
     )


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-28323

The new Tailoring will use the original profile's default value definitions. It's not the best solution, but figuring out differences between override sets of profile versions is out of the scope of this task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Automatically create and reuse tailorings for supported RHEL minor versions.
- Apply version-specific profiles and value overrides.
- Audit-log new tailoring creation.
- Enforce unique tailorings per policy and OS minor version.
- Add tests for creation, reuse, logging, unsupported versions, and duplicate cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->