### PR TITLE
feat(Renovate): allow Compliance devs to rebase Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "dependencyDashboard": true,
+  "gitIgnoredAuthors": [
+    "jvasik@redhat.com",
+    "rblanco@redhat.com",
+    "petrblaho@redhat.com"
+  ],
   "extends": [
     "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
   ],


### PR DESCRIPTION
I need this so the Renovate bot doesn't close it's PRs I rebase. It's a security feature but the bot runs so rarely that it takes hours to get it to rebase it's own PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Allow Compliance team members to rebase Renovate pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->