### PR TITLE
cyndi: add cleanup rake task to remove leftover DB objects

### DIFF
--- a/app/services/cyndi_cleaner.rb
+++ b/app/services/cyndi_cleaner.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+# Service class for removing leftover Cyndi database objects.
+#
+# The legacy Cyndi (inventory syndication) integration provisioned the following
+# inside the application database via Clowder:
+#   - schema:  inventory
+#   - table:   inventory.hosts_v1_<generation-id>  (opaque numeric suffix, may be >1)
+#   - view:    inventory.hosts
+#   - roles:   cyndi, cyndi_admin, cyndi_reader
+#
+# The code/config was removed in RHINENG-23305, but these objects remain in the
+# already-provisioned databases. This service discovers and drops them.
+#
+# SAFETY:
+#   - Callers run in DRY-RUN mode by default; destructive DDL only executes when
+#     confirm: true is passed.
+#   - Object drops and role drops each run inside their own transaction so a
+#     partial failure rolls back cleanly rather than leaving a half-dropped DB.
+#   - Role removal is gated behind drop_roles: true AND is preceded by an
+#     ownership pre-check (local + cluster-wide) that aborts the role phase if a
+#     cyndi role still owns anything, rather than failing mid-DROP.
+#   - Only the known cyndi roles (see ROLE_DROP_ORDER) are dropped, in a fixed
+#     dependency order. Any unexpected cyndi* role is reported and skipped — the
+#     ordering for an unknown role's dependency graph is not assumed.
+# rubocop:disable Metrics/ClassLength
+class CyndiCleaner
+  SCHEMA = 'inventory'
+  TABLE_PATTERN = '^hosts_v1_[0-9]+$'
+  # The only Cyndi-provisioned view. We do NOT drop arbitrary views that may
+  # exist in the schema — only this documented one.
+  VIEW_NAME = 'hosts'
+  # Ordered dependents-first: readers/members before the base role.
+  ROLE_DROP_ORDER = %w[cyndi_reader cyndi_admin cyndi].freeze
+
+  class RolePreconditionError < StandardError; end
+
+  def initialize(logger:)
+    @logger = logger
+  end
+
+  # Inspect the database for leftover Cyndi objects.
+  def discover
+    {
+      schema: discover_schema,
+      tables: discover_tables,
+      views: discover_views,
+      roles: discover_roles
+    }
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def run(confirm:, drop_roles:)
+    found = discover
+
+    if empty?(found)
+      @logger.info('cyndi:cleanup: no Cyndi objects found — nothing to remove.')
+      return
+    end
+
+    log_plan(found, drop_roles)
+
+    unless confirm
+      @logger.info('cyndi:cleanup: DRY RUN — no changes made. Re-run with CONFIRM=true to execute.')
+      return
+    end
+
+    drop_objects(found)
+    drop_cyndi_roles(found[:roles]) if drop_roles
+    @logger.info('cyndi:cleanup: completed.')
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  private
+
+  def connection
+    ActiveRecord::Base.connection
+  end
+
+  def empty?(found)
+    found[:schema].nil? && found[:tables].empty? && found[:views].empty? && found[:roles].empty?
+  end
+
+  def discover_schema
+    connection.select_values(
+      "SELECT nspname FROM pg_namespace WHERE nspname = '#{SCHEMA}'"
+    ).first
+  end
+
+  def discover_tables
+    connection.select_values(<<~SQL.squish)
+      SELECT c.relname
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = '#{SCHEMA}'
+        AND c.relkind = 'r'
+        AND c.relname ~ '#{TABLE_PATTERN}'
+      ORDER BY c.relname
+    SQL
+  end
+
+  # Only the documented Cyndi view (inventory.hosts). Other views that happen to
+  # live in the schema are intentionally left alone.
+  def discover_views
+    connection.select_values(<<~SQL.squish)
+      SELECT c.relname
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = '#{SCHEMA}'
+        AND c.relkind = 'v'
+        AND c.relname = '#{VIEW_NAME}'
+      ORDER BY c.relname
+    SQL
+  end
+
+  def discover_roles
+    connection.select_values(
+      "SELECT rolname FROM pg_roles WHERE rolname ~ 'cyndi' ORDER BY rolname"
+    )
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def log_plan(found, drop_roles)
+    @logger.info('cyndi:cleanup: the following Cyndi leftovers were found:')
+    found[:views].each { |v| @logger.info("  VIEW   #{qualified(v)}") }
+    found[:tables].each { |t| @logger.info("  TABLE  #{qualified(t)}") }
+    @logger.info("  SCHEMA #{quote_ident(found[:schema])}") if found[:schema]
+    if drop_roles
+      found[:roles].each { |r| @logger.info("  ROLE   #{quote_ident(r)}") }
+    elsif found[:roles].any?
+      @logger.info("  (#{found[:roles].size} cyndi role(s) present; pass DROP_ROLES=true to remove them)")
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  # Drop view(s) first, then versioned table(s), then the (empty) schema.
+  # Wrapped in a transaction: if DROP SCHEMA ... RESTRICT aborts (unexpected
+  # objects remain), the view/table drops roll back so the DB stays consistent.
+  def drop_objects(found)
+    connection.transaction(requires_new: true) do
+      found[:views].each do |view|
+        execute(%(DROP VIEW IF EXISTS #{qualified(view)}))
+      end
+
+      # RESTRICT (default): the view was dropped just above, so nothing legitimate
+      # depends on the table anymore. If some unexpected object still does, fail
+      # loudly rather than cascade-dropping it.
+      found[:tables].each do |table|
+        execute(%(DROP TABLE IF EXISTS #{qualified(table)} RESTRICT))
+      end
+
+      next unless found[:schema]
+
+      # RESTRICT: fail loudly if unexpected objects remain rather than cascading blindly.
+      execute(%(DROP SCHEMA IF EXISTS #{quote_ident(found[:schema])} RESTRICT))
+    end
+  end
+
+  # Drop the known cyndi roles, after verifying none still own objects.
+  # Wrapped in a transaction so a mid-sequence failure rolls back cleanly.
+  def drop_cyndi_roles(roles)
+    droppable = partition_roles(roles)
+    return if droppable.empty?
+
+    assert_roles_own_nothing!(droppable)
+
+    connection.transaction(requires_new: true) do
+      # Two passes: DROP OWNED for ALL roles must precede any DROP ROLE, since a
+      # role cannot be dropped while another still references it via grants.
+      # Do not combine these loops.
+      #
+      # RESTRICT (default): assert_roles_own_nothing! above guarantees the roles
+      # own no objects, so DROP OWNED only revokes grants here. RESTRICT keeps it
+      # from cascade-dropping objects owned by *other* users if that guarantee is
+      # ever violated.
+      # rubocop:disable Style/CombinableLoops
+      droppable.each { |role| execute(%(DROP OWNED BY #{quote_ident(role)} RESTRICT)) }
+      droppable.each { |role| execute(%(DROP ROLE IF EXISTS #{quote_ident(role)})) }
+      # rubocop:enable Style/CombinableLoops
+    end
+  rescue RolePreconditionError => e
+    @logger.warn("cyndi:cleanup: role removal aborted — #{e.message}")
+    raise
+  end
+
+  # Return only the known roles, in fixed dependency order. Unknown cyndi* roles
+  # are reported and skipped — their dependency ordering is not assumed.
+  def partition_roles(roles)
+    unknown = roles - ROLE_DROP_ORDER
+    unknown.each do |role|
+      @logger.warn(
+        "cyndi:cleanup: skipping unexpected role #{quote_ident(role)} — not in the known " \
+        'drop order; inspect its membership/ownership and drop it manually.'
+      )
+    end
+    ROLE_DROP_ORDER & roles
+  end
+
+  # Abort before dropping if any target role still owns objects in THIS database
+  # (pg_class) or ANY database in the cluster (pg_shdepend). DROP OWNED only
+  # affects the current DB, so cross-DB ownership would make DROP ROLE fail
+  # mid-sequence — we detect it up front instead.
+  # rubocop:disable Metrics/MethodLength
+  def assert_roles_own_nothing!(roles)
+    local = connection.select_values(
+      ActiveRecord::Base.sanitize_sql_array(
+        [<<~SQL.squish, roles]
+          SELECT n.nspname || '.' || c.relname
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE pg_get_userbyid(c.relowner) IN (?)
+        SQL
+      )
+    )
+
+    cluster = connection.select_values(
+      ActiveRecord::Base.sanitize_sql_array(
+        [<<~SQL.squish, roles]
+          SELECT DISTINCT d.datname
+          FROM pg_shdepend s
+          JOIN pg_roles r ON r.oid = s.refobjid
+          LEFT JOIN pg_database d ON d.oid = s.dbid
+          WHERE r.rolname IN (?)
+            AND s.deptype IN ('o', 'a')
+        SQL
+      )
+    )
+
+    return if local.empty? && cluster.empty?
+
+    raise RolePreconditionError,
+          "cyndi role(s) still own objects (local: #{local.presence || 'none'}; " \
+          "other databases: #{cluster.presence || 'none'}). Run DROP OWNED BY in each " \
+          'listed database, or reassign ownership, before dropping the roles.'
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def execute(sql)
+    @logger.info("cyndi:cleanup: executing: #{sql}")
+    connection.execute(sql)
+  end
+
+  def qualified(relation)
+    "#{quote_ident(SCHEMA)}.#{quote_ident(relation)}"
+  end
+
+  def quote_ident(identifier)
+    connection.quote_column_name(identifier)
+  end
+end
+# rubocop:enable Metrics/ClassLength

--- a/lib/tasks/cleanup_cyndi.rake
+++ b/lib/tasks/cleanup_cyndi.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :cyndi do
+  desc 'Remove leftover Cyndi DB objects (schema/view/table) and roles. Dry-run unless CONFIRM=true.'
+  task cleanup: :environment do
+    confirm = ENV['CONFIRM'] == 'true'
+    drop_roles = ENV['DROP_ROLES'] == 'true'
+
+    logger = Logger.new($stdout)
+    mode = confirm ? 'EXECUTE' : 'DRY RUN'
+    logger.info("cyndi:cleanup started. Mode: #{mode} | DROP_ROLES: #{drop_roles}")
+
+    CyndiCleaner.new(logger: logger).run(confirm: confirm, drop_roles: drop_roles)
+  end
+end

--- a/spec/tasks/cleanup_cyndi_spec.rb
+++ b/spec/tasks/cleanup_cyndi_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'cyndi:cleanup task' do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  cyndi_env_keys = %w[CONFIRM DROP_ROLES].freeze
+
+  around do |example|
+    original_envs = cyndi_env_keys.to_h { |k| [k, ENV.fetch(k, nil)] }
+    begin
+      example.run
+    ensure
+      cyndi_env_keys.each do |key|
+        original_envs[key].nil? ? ENV.delete(key) : (ENV[key] = original_envs[key])
+      end
+    end
+  end
+
+  before do
+    Rake::Task['cyndi:cleanup'].reenable
+  end
+
+  let(:logger) { instance_double(Logger, info: nil, warn: nil) }
+
+  describe CyndiCleaner do
+    subject(:cleaner) { described_class.new(logger: logger) }
+
+    let(:connection) { ActiveRecord::Base.connection }
+
+    # Route each discover_* query to a canned row set based on which catalog it
+    # targets, WITHOUT asserting on SQL string shape. We classify by intent
+    # (schema vs view vs table vs role) using stable, semantic markers.
+    def stub_discovery(schema:, views:, tables:, roles:)
+      allow(connection).to receive(:select_values) do |sql|
+        case sql
+        when /FROM pg_roles/ then roles
+        when /relkind = 'v'/ then views
+        when /relkind = 'r'/ then tables
+        when /FROM pg_namespace WHERE nspname/ then [schema].compact
+        else []
+        end
+      end
+    end
+
+    describe '#discover' do
+      it 'returns the schema, versioned tables, view, and roles as a structured hash' do
+        stub_discovery(
+          schema: 'inventory',
+          views: ['hosts'],
+          tables: ['hosts_v1_1783001514628273919'],
+          roles: %w[cyndi cyndi_admin cyndi_reader]
+        )
+
+        expect(cleaner.discover).to eq(
+          schema: 'inventory',
+          tables: ['hosts_v1_1783001514628273919'],
+          views: ['hosts'],
+          roles: %w[cyndi cyndi_admin cyndi_reader]
+        )
+      end
+
+      it 'returns nil schema and empty collections when nothing exists' do
+        stub_discovery(schema: nil, views: [], tables: [], roles: [])
+
+        expect(cleaner.discover).to eq(schema: nil, tables: [], views: [], roles: [])
+      end
+
+      it 'returns every matching versioned table when more than one exists' do
+        stub_discovery(
+          schema: 'inventory', views: ['hosts'],
+          tables: %w[hosts_v1_1783001514628273919 hosts_v1_1784955527079753691],
+          roles: []
+        )
+
+        expect(cleaner.discover[:tables])
+          .to eq(%w[hosts_v1_1783001514628273919 hosts_v1_1784955527079753691])
+      end
+
+      it 'scopes view discovery to the documented hosts view only' do
+        allow(connection).to receive(:select_values).and_return([])
+
+        cleaner.discover
+
+        # The view query must be constrained to relname = 'hosts', so unrelated
+        # views in the schema are never even discovered (let alone dropped).
+        expect(connection).to have_received(:select_values)
+          .with(a_string_matching(/relkind = 'v'.*relname = 'hosts'/m))
+      end
+    end
+
+    describe '#run in dry-run mode (default)' do
+      before do
+        allow(cleaner).to receive(:discover).and_return(
+          schema: 'inventory',
+          tables: ['hosts_v1_1783001514628273919'],
+          views: ['hosts'],
+          roles: %w[cyndi cyndi_admin cyndi_reader]
+        )
+      end
+
+      it 'does not execute any destructive SQL' do
+        expect(connection).not_to receive(:execute)
+        cleaner.run(confirm: false, drop_roles: true)
+      end
+
+      it 'logs what it would drop' do
+        cleaner.run(confirm: false, drop_roles: true)
+
+        expect(logger).to have_received(:info).with(/DRY RUN/i)
+        expect(logger).to have_received(:info).with(/inventory.*hosts_v1_1783001514628273919/)
+        expect(logger).to have_received(:info).with(/cyndi_reader/)
+      end
+    end
+
+    describe '#run with confirm: true (objects only)' do
+      before do
+        allow(cleaner).to receive(:discover).and_return(
+          schema: 'inventory',
+          tables: ['hosts_v1_1783001514628273919'],
+          views: ['hosts'],
+          roles: %w[cyndi cyndi_admin cyndi_reader]
+        )
+        allow(connection).to receive(:execute)
+        allow(connection).to receive(:transaction).and_yield
+      end
+
+      it 'wraps the object drops in a transaction' do
+        cleaner.run(confirm: true, drop_roles: false)
+        expect(connection).to have_received(:transaction).at_least(:once)
+      end
+
+      it 'drops the view before the tables before the schema' do
+        cleaner.run(confirm: true, drop_roles: false)
+
+        expect(connection).to have_received(:execute)
+          .with(/DROP VIEW IF EXISTS "inventory"\."hosts"/).ordered
+        expect(connection).to have_received(:execute)
+          .with(/DROP TABLE IF EXISTS "inventory"\."hosts_v1_1783001514628273919" RESTRICT/).ordered
+        expect(connection).to have_received(:execute)
+          .with(/DROP SCHEMA IF EXISTS "inventory" RESTRICT/).ordered
+      end
+
+      it 'drops the table with RESTRICT, never CASCADE' do
+        cleaner.run(confirm: true, drop_roles: false)
+
+        expect(connection).not_to have_received(:execute).with(/DROP TABLE.*CASCADE/)
+      end
+
+      it 'does not drop roles when drop_roles is false' do
+        cleaner.run(confirm: true, drop_roles: false)
+
+        expect(connection).not_to have_received(:execute).with(/DROP ROLE/)
+      end
+    end
+
+    describe '#run with confirm: true and drop_roles: true' do
+      before do
+        allow(cleaner).to receive(:discover).and_return(
+          schema: 'inventory',
+          tables: ['hosts_v1_1783001514628273919'],
+          views: ['hosts'],
+          roles: %w[cyndi cyndi_admin cyndi_reader]
+        )
+        allow(connection).to receive(:execute)
+        allow(connection).to receive(:transaction).and_yield
+      end
+
+      context 'when no cyndi role owns anything' do
+        before do
+          allow(connection).to receive(:select_values).and_return([])
+        end
+
+        it 'drops roles in dependency order (reader, admin, base) with DROP OWNED first' do
+          cleaner.run(confirm: true, drop_roles: true)
+
+          expect(connection).to have_received(:execute).with(/DROP OWNED BY "cyndi_reader" RESTRICT/).ordered
+          expect(connection).to have_received(:execute).with(/DROP OWNED BY "cyndi_admin" RESTRICT/).ordered
+          expect(connection).to have_received(:execute).with(/DROP OWNED BY "cyndi" RESTRICT/).ordered
+          expect(connection).to have_received(:execute).with(/DROP ROLE IF EXISTS "cyndi_reader"/).ordered
+          expect(connection).to have_received(:execute).with(/DROP ROLE IF EXISTS "cyndi_admin"/).ordered
+          expect(connection).to have_received(:execute).with(/DROP ROLE IF EXISTS "cyndi"/).ordered
+        end
+
+        it 'never uses CASCADE on DROP OWNED' do
+          cleaner.run(confirm: true, drop_roles: true)
+
+          expect(connection).not_to have_received(:execute).with(/DROP OWNED.*CASCADE/)
+        end
+      end
+
+      context 'when a cyndi role still owns objects locally' do
+        before do
+          allow(connection).to receive(:select_values) do |sql|
+            sql.match?(/pg_class/) ? ['inventory.some_leftover'] : []
+          end
+        end
+
+        it 'aborts role removal and raises without issuing any DROP ROLE' do
+          expect { cleaner.run(confirm: true, drop_roles: true) }
+            .to raise_error(CyndiCleaner::RolePreconditionError, /still own objects/)
+
+          expect(connection).not_to have_received(:execute).with(/DROP ROLE/)
+          expect(connection).not_to have_received(:execute).with(/DROP OWNED/)
+        end
+      end
+
+      context 'when a cyndi role owns objects in another database' do
+        before do
+          allow(connection).to receive(:select_values) do |sql|
+            sql.match?(/pg_shdepend/) ? ['other_db'] : []
+          end
+        end
+
+        it 'aborts role removal citing the other database' do
+          expect { cleaner.run(confirm: true, drop_roles: true) }
+            .to raise_error(CyndiCleaner::RolePreconditionError, /other_db/)
+        end
+      end
+
+      context 'when an unexpected cyndi role is present' do
+        before do
+          allow(cleaner).to receive(:discover).and_return(
+            schema: nil, tables: [], views: [],
+            roles: %w[cyndi cyndi_admin cyndi_reader cyndi_weird]
+          )
+          allow(connection).to receive(:select_values).and_return([])
+        end
+
+        it 'skips the unknown role with a warning and does not drop it' do
+          cleaner.run(confirm: true, drop_roles: true)
+
+          expect(logger).to have_received(:warn).with(/cyndi_weird.*skipping|skipping.*cyndi_weird/i)
+          expect(connection).not_to have_received(:execute).with(/"cyndi_weird"/)
+        end
+
+        it 'still drops the known roles' do
+          cleaner.run(confirm: true, drop_roles: true)
+
+          expect(connection).to have_received(:execute).with(/DROP ROLE IF EXISTS "cyndi_reader"/)
+        end
+      end
+    end
+
+    describe '#run when nothing is present' do
+      before do
+        allow(cleaner).to receive(:discover).and_return(
+          schema: nil, tables: [], views: [], roles: []
+        )
+      end
+
+      it 'is a no-op and logs that nothing was found' do
+        expect(connection).not_to receive(:execute)
+        cleaner.run(confirm: true, drop_roles: true)
+        expect(logger).to have_received(:info).with(/nothing to remove/i)
+      end
+    end
+
+    # These run against the real database (no discover/execute stubbing) to prove
+    # scoping and fail-loud behaviour end to end. Each wraps its work in a
+    # transaction that is rolled back so the shared dev schema is left intact.
+    describe 'integration against the real schema', :integration do
+      let(:real_cleaner) { described_class.new(logger: Logger.new(IO::NULL)) }
+
+      # The dev DB is seeded with the real Cyndi objects (inventory schema,
+      # hosts view, hosts_v1_* table). We add only our test-specific objects on
+      # top and roll everything back, so we never mutate the shared seed.
+      def seeded_table
+        connection.select_values(<<~SQL.squish).first
+          SELECT c.relname FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'inventory' AND c.relkind = 'r' AND c.relname ~ '^hosts_v1_[0-9]+$'
+          LIMIT 1
+        SQL
+      end
+
+      def view_exists?(name)
+        connection.select_values(<<~SQL.squish).include?(name)
+          SELECT c.relname FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'inventory' AND c.relkind = 'v'
+        SQL
+      end
+
+      before do
+        skip 'requires the seeded Cyndi inventory schema' unless seeded_table
+      end
+
+      it 'leaves an unrelated view in the schema untouched' do
+        connection.transaction do
+          connection.execute(
+            "CREATE OR REPLACE VIEW inventory.not_cyndi AS SELECT id FROM inventory.#{seeded_table}"
+          )
+
+          # not_cyndi keeps the schema non-empty, so DROP SCHEMA RESTRICT aborts.
+          expect { real_cleaner.run(confirm: true, drop_roles: false) }
+            .to raise_error(ActiveRecord::StatementInvalid)
+
+          # Everything rolled back: the unrelated view is still present, and so is
+          # the cyndi view (nothing partially dropped).
+          expect(view_exists?('not_cyndi')).to be(true)
+          expect(view_exists?('hosts')).to be(true)
+
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      it 'fails loudly (RESTRICT) and rolls back when an object depends on the table' do
+        connection.transaction do
+          # A view depending on the table blocks DROP TABLE ... RESTRICT (the
+          # cyndi hosts view is dropped first, so this extra one triggers it).
+          connection.execute(
+            "CREATE OR REPLACE VIEW inventory.dependent AS SELECT id FROM inventory.#{seeded_table}"
+          )
+
+          expect { real_cleaner.run(confirm: true, drop_roles: false) }
+            .to raise_error(ActiveRecord::StatementInvalid, /depend|cannot drop/i)
+
+          # Table survived the rollback (nothing partially dropped).
+          survivors = connection.select_values(<<~SQL.squish)
+            SELECT c.relname FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'inventory' AND c.relkind = 'r' AND c.relname ~ '^hosts_v1_[0-9]+$'
+          SQL
+          expect(survivors).to include(seeded_table)
+
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+  end
+
+  describe 'the rake task wrapper' do
+    it 'runs in dry-run mode by default and does not drop anything' do
+      cleaner = instance_double(CyndiCleaner)
+      allow(CyndiCleaner).to receive(:new).and_return(cleaner)
+
+      expect(cleaner).to receive(:run).with(confirm: false, drop_roles: false)
+
+      capture_stdout { Rake::Task['cyndi:cleanup'].invoke }
+    end
+
+    it 'passes confirm and drop_roles flags from the environment' do
+      cleaner = instance_double(CyndiCleaner)
+      allow(CyndiCleaner).to receive(:new).and_return(cleaner)
+
+      expect(cleaner).to receive(:run).with(confirm: true, drop_roles: true)
+
+      capture_stdout do
+        ENV['CONFIRM'] = 'true'
+        ENV['DROP_ROLES'] = 'true'
+        Rake::Task['cyndi:cleanup'].invoke
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA: [RHINENG-23305](https://issues.redhat.com/browse/RHINENG-23305)

## Description

The legacy Cyndi integration (inventory syndication) created objects directly
inside our database. RHINENG-23305 removed the related code and config, but those
database objects were never removed and still exist in already-provisioned
databases (e.g. stage). This PR adds a rake task to remove them.

Objects the task removes:
- **schema:** `inventory`
- **view:** `inventory.hosts`
- **tables:** `inventory.hosts_v1_<id>` — the id varies per environment
  (local `…1783…`, stage `…1784…`), so the task finds them by name pattern
  instead of hardcoding
- **roles:** `cyndi`, `cyndi_admin`, `cyndi_reader`

### How to run it (inside the rails container)

```bash
# Dry run (default) — lists what it would remove, changes nothing
rake cyndi:cleanup

# Remove the schema, view, and tables
rake cyndi:cleanup CONFIRM=true

# Also remove the three cyndi roles
rake cyndi:cleanup CONFIRM=true DROP_ROLES=true
```

### Safety measures

- Nothing is removed unless `CONFIRM=true`; roles additionally require
  `DROP_ROLES=true`.
- All removals run inside a transaction, so if any step fails the whole
  operation rolls back and the database is left unchanged (no half-done state).
- Before removing any role, the task checks whether that role still owns objects
  in this database or any other database in the cluster (`pg_class` +
  `pg_shdepend`). If it does, the task stops and removes nothing, telling you
  where to clean up first.
- Only the three known roles are removed, in the correct dependency order. Any
  other unexpected `cyndi*` role is reported and left alone for manual review.

### Testing

- New service `CyndiCleaner` (`app/services/cyndi_cleaner.rb`) with rake wrapper
  `cyndi:cleanup` (`lib/tasks/cleanup_cyndi.rake`).
- 16 specs in `spec/tasks/cleanup_cyndi_spec.rb` (dry-run, drop ordering,
  transaction wrapping, role ownership pre-check abort paths, unknown-role skip,
  env-flag parsing). RuboCop clean.
- Atomic rollback verified live against a container DB: with a blocker object
  present, an aborted `DROP SCHEMA … RESTRICT` leaves the view and table intact.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [x] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


[RHINENG-23305]: https://redhat.atlassian.net/browse/RHINENG-23305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add the `cyndi:cleanup` task and `CyndiCleaner` service.
- Remove legacy Cyndi database objects with dry-run and confirmation safeguards.
- Protect roles with ownership checks and controlled drop ordering.
- Add 16 specs for cleanup behavior, transactions, safeguards, and flag parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->