### PR TITLE
feat(Tailorings): add cleanup rake task to clean up invalid Tailorings

### DIFF
--- a/app/services/duplicate_tailorings_cleaner.rb
+++ b/app/services/duplicate_tailorings_cleaner.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# Removes tailorings left over from two known data-integrity issues, along with every
+# dependent record, using bulk SQL (never loading/destroying records one by one):
+#
+#   1. Tailorings created with a NULL `os_minor_version` (a side effect of V1 profile cloning).
+#   2. Duplicate tailorings for the same `(policy_id, os_minor_version)` pair, created by
+#      a `find_or_create_by!` race condition that a unique index will now prevent. For each
+#      duplicate group the oldest tailoring is kept (it is the one most likely to carry
+#      real scan history); the rest are considered excess.
+#
+# `plan` is read-only and safe to call at any time. `run!` is destructive: it deletes the
+# same records `plan` reports, cascading through dependents in a single transaction so the
+# database is never left in a half-cleaned state.
+class DuplicateTailoringsCleaner
+  # Selects the ids of every tailoring that should be removed. Standalone so it can be
+  # embedded both in a read-only report query and in the temp table used by the delete.
+  TARGET_TAILORING_IDS_SQL = <<~SQL
+    SELECT id FROM tailorings WHERE os_minor_version IS NULL
+    UNION
+    SELECT id FROM (
+      SELECT id, ROW_NUMBER() OVER (
+        PARTITION BY policy_id, os_minor_version ORDER BY created_at ASC, id ASC
+      ) AS rn
+      FROM tailorings
+      WHERE os_minor_version IS NOT NULL
+    ) ranked
+    WHERE rn > 1
+  SQL
+
+  PLAN_SQL = <<~SQL.freeze
+    WITH targets AS (
+      #{TARGET_TAILORING_IDS_SQL}
+    ), target_test_results AS (
+      SELECT id FROM historical_test_results WHERE tailoring_id IN (SELECT id FROM targets)
+    )
+    SELECT
+      (SELECT count(*) FROM tailorings WHERE os_minor_version IS NULL) AS null_tailorings,
+      (SELECT count(*) FROM targets) AS tailorings,
+      (SELECT count(*) FROM tailoring_rules WHERE tailoring_id IN (SELECT id FROM targets)) AS tailoring_rules,
+      (SELECT count(*) FROM target_test_results) AS test_results,
+      (SELECT count(*) FROM rule_results WHERE test_result_id IN (SELECT id FROM target_test_results)) AS rule_results
+  SQL
+
+  COUNT_KEYS = %w[null_tailorings tailorings tailoring_rules test_results rule_results].freeze
+
+  def initialize(logger: Rails.logger)
+    @logger = logger
+  end
+
+  # Read-only. Returns a Hash of counts describing what `run!` would delete, and logs a
+  # one-line summary. Never modifies the database.
+  def plan
+    row = connection.select_one(PLAN_SQL)
+    counts = COUNT_KEYS.to_h { |key| [key, row.fetch(key).to_i] }
+    @logger.info(summary(counts))
+    counts
+  end
+
+  # Destructive. Deletes the target tailorings and every dependent record in a single
+  # transaction: if any step fails, nothing is deleted. Returns the same shape as `plan`,
+  # reflecting what was actually removed. Safe to call repeatedly (a second call with
+  # nothing left to clean is a no-op).
+  def run!
+    counts = plan
+    return counts if counts.fetch('tailorings').zero?
+
+    delete_targets_and_dependents
+    @logger.info('DuplicateTailoringsCleaner: cleanup committed successfully.')
+
+    counts
+  end
+
+  private
+
+  def connection
+    ActiveRecord::Base.connection
+  end
+
+  def summary(counts)
+    duplicates = counts.fetch('tailorings') - counts.fetch('null_tailorings')
+
+    "DuplicateTailoringsCleaner: #{counts.fetch('tailorings')} tailorings to remove " \
+    "(#{counts.fetch('null_tailorings')} with NULL os_minor_version, #{duplicates} race-condition duplicates), " \
+    "cascading to #{counts.fetch('tailoring_rules')} tailoring_rules, " \
+    "#{counts.fetch('test_results')} test_results, #{counts.fetch('rule_results')} rule_results."
+  end
+
+  def delete_targets_and_dependents
+    connection.transaction do
+      create_target_table
+      delete_rule_results
+      delete_test_results
+      delete_tailoring_rules
+      delete_tailorings
+    end
+  end
+
+  # Snapshots the ids to delete once, up front, so every subsequent DELETE in this
+  # transaction agrees on exactly the same set of tailorings, regardless of statement order.
+  def create_target_table
+    connection.execute(<<~SQL)
+      CREATE TEMP TABLE tailorings_to_delete ON COMMIT DROP AS
+      #{TARGET_TAILORING_IDS_SQL}
+    SQL
+  end
+
+  def delete_rule_results
+    deleted = connection.execute(<<~SQL).cmd_tuples
+      DELETE FROM rule_results
+      WHERE test_result_id IN (
+        SELECT id FROM historical_test_results WHERE tailoring_id IN (SELECT id FROM tailorings_to_delete)
+      )
+    SQL
+    @logger.info("DuplicateTailoringsCleaner: deleted #{deleted} rule_results.")
+  end
+
+  def delete_test_results
+    deleted = connection.execute(<<~SQL).cmd_tuples
+      DELETE FROM historical_test_results WHERE tailoring_id IN (SELECT id FROM tailorings_to_delete)
+    SQL
+    @logger.info("DuplicateTailoringsCleaner: deleted #{deleted} historical_test_results.")
+  end
+
+  def delete_tailoring_rules
+    deleted = connection.execute(<<~SQL).cmd_tuples
+      DELETE FROM tailoring_rules WHERE tailoring_id IN (SELECT id FROM tailorings_to_delete)
+    SQL
+    @logger.info("DuplicateTailoringsCleaner: deleted #{deleted} tailoring_rules.")
+  end
+
+  def delete_tailorings
+    deleted = connection.execute(<<~SQL).cmd_tuples
+      DELETE FROM tailorings WHERE id IN (SELECT id FROM tailorings_to_delete)
+    SQL
+    @logger.info("DuplicateTailoringsCleaner: deleted #{deleted} tailorings.")
+  end
+end

--- a/lib/tasks/cleanup_duplicate_tailorings.rake
+++ b/lib/tasks/cleanup_duplicate_tailorings.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :tailorings do
+  desc 'Remove NULL os_minor_version and race-condition duplicate tailorings, and their dependent records. ' \
+       'Dry run by default; pass CONFIRM=true to actually delete.'
+  task cleanup_duplicates: :environment do
+    logger = Logger.new($stdout)
+    cleaner = DuplicateTailoringsCleaner.new(logger: logger)
+    plan = cleaner.plan
+
+    if plan.fetch('tailorings').zero?
+      logger.info('tailorings:cleanup_duplicates: nothing to clean up.')
+      next
+    end
+
+    unless ENV['CONFIRM'] == 'true'
+      logger.info(
+        'tailorings:cleanup_duplicates: dry run only, no data was changed. ' \
+        'Re-run with CONFIRM=true to perform the deletion.'
+      )
+      next
+    end
+
+    result = cleaner.run!
+    logger.info("tailorings:cleanup_duplicates: done. Deleted #{result.fetch('tailorings')} tailorings.")
+  end
+end

--- a/spec/services/duplicate_tailorings_cleaner_spec.rb
+++ b/spec/services/duplicate_tailorings_cleaner_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DuplicateTailoringsCleaner do
+  let(:logger) { Logger.new(StringIO.new) }
+  let(:cleaner) { described_class.new(logger: logger) }
+
+  let(:policy) { create(:policy, :for_tailoring, supports_minors: [0], system_count: 1) }
+  let(:good_tailoring) { policy.tailorings.find_by(os_minor_version: 0) }
+
+  let(:empty_plan) do
+    { 'null_tailorings' => 0, 'tailorings' => 0, 'tailoring_rules' => 0, 'test_results' => 0, 'rule_results' => 0 }
+  end
+
+  # Builds a Tailoring bypassing app validations, mirroring how the legacy bugs produced
+  # invalid rows directly at the DB level (no unique index existed to prevent them).
+  # rubocop:disable Rails/SkipsModelValidations
+  def build_invalid_tailoring(os_minor_version:, created_at: Time.zone.now)
+    tailoring = policy.tailorings.build(
+      profile: policy.profile, os_minor_version: os_minor_version, value_overrides: {}
+    )
+    tailoring.save!(validate: false)
+    tailoring.update_column(:created_at, created_at)
+    tailoring
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def attach_test_result(tailoring)
+    test_result = TestResult.new(
+      system_id: SecureRandom.uuid,
+      tailoring_id: tailoring.id,
+      report_id: policy.id,
+      score: 0,
+      supported: true,
+      start_time: 1.hour.ago,
+      end_time: Time.zone.now
+    )
+    test_result.save!(validate: false)
+
+    RuleResult.new(
+      test_result_id: test_result.id,
+      rule_id: policy.profile.rules.first.id,
+      result: 'pass'
+    ).save!(validate: false)
+
+    test_result
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+  describe '#plan' do
+    it 'is read-only and reports nothing when there are no bad tailorings' do
+      good_tailoring
+
+      expect { cleaner.plan }.not_to change(Tailoring, :count)
+      expect(cleaner.plan).to eq(empty_plan)
+    end
+
+    it 'counts NULL os_minor_version tailorings and their dependents' do
+      good_tailoring
+      null_tailoring = build_invalid_tailoring(os_minor_version: nil)
+      attach_test_result(null_tailoring)
+
+      plan = cleaner.plan
+
+      expect(plan['null_tailorings']).to eq(1)
+      expect(plan['tailorings']).to eq(1)
+      expect(plan['test_results']).to eq(1)
+      expect(plan['rule_results']).to eq(1)
+      expect(plan['tailoring_rules']).to eq(null_tailoring.tailoring_rules.count)
+    end
+
+    it 'counts every duplicate but the oldest in a (policy_id, os_minor_version) group' do
+      good_tailoring
+      build_invalid_tailoring(os_minor_version: 5, created_at: 2.days.ago)
+      excess1 = build_invalid_tailoring(os_minor_version: 5, created_at: 1.day.ago)
+      excess2 = build_invalid_tailoring(os_minor_version: 5, created_at: 1.hour.ago)
+
+      plan = cleaner.plan
+
+      expect(plan['null_tailorings']).to eq(0)
+      expect(plan['tailorings']).to eq(2)
+      expect(plan['tailoring_rules']).to eq(excess1.tailoring_rules.count + excess2.tailoring_rules.count)
+    end
+
+    it 'never counts distinct, legitimate tailorings' do
+      good_tailoring
+      other_policy = create(:policy, :for_tailoring, supports_minors: [1], system_count: 1)
+      other_tailoring = other_policy.tailorings.find_by(os_minor_version: 1)
+
+      expect(cleaner.plan).to eq(empty_plan)
+      expect(Tailoring.exists?(good_tailoring.id)).to be true
+      expect(Tailoring.exists?(other_tailoring.id)).to be true
+    end
+  end
+
+  describe '#run!' do
+    it 'is a no-op when there is nothing to clean up' do
+      good_tailoring
+
+      expect { cleaner.run! }.not_to change(Tailoring, :count)
+      expect(cleaner.run!).to eq(empty_plan)
+    end
+
+    it 'deletes NULL os_minor_version tailorings and cascades to every dependent record' do
+      good_tailoring
+      null_tailoring = build_invalid_tailoring(os_minor_version: nil)
+      test_result = attach_test_result(null_tailoring)
+
+      result = cleaner.run!
+
+      expect(result['tailorings']).to eq(1)
+      expect(Tailoring.exists?(null_tailoring.id)).to be false
+      expect(HistoricalTestResult.exists?(test_result.id)).to be false
+      expect(RuleResult.where(test_result_id: test_result.id)).to be_empty
+      expect(TailoringRule.where(tailoring_id: null_tailoring.id)).to be_empty
+      expect(Tailoring.exists?(good_tailoring.id)).to be true
+    end
+
+    it 'keeps the oldest tailoring in a duplicate group and deletes the rest' do
+      good_tailoring
+      keeper = build_invalid_tailoring(os_minor_version: 5, created_at: 2.days.ago)
+      keeper_result = attach_test_result(keeper)
+      excess1 = build_invalid_tailoring(os_minor_version: 5, created_at: 1.day.ago)
+      excess2 = build_invalid_tailoring(os_minor_version: 5, created_at: 1.hour.ago)
+
+      result = cleaner.run!
+
+      expect(result['tailorings']).to eq(2)
+      expect(Tailoring.exists?(keeper.id)).to be true
+      expect(HistoricalTestResult.exists?(keeper_result.id)).to be true
+      expect(Tailoring.exists?(excess1.id)).to be false
+      expect(Tailoring.exists?(excess2.id)).to be false
+      expect(Tailoring.exists?(good_tailoring.id)).to be true
+    end
+
+    it 'is idempotent: a second run finds nothing left to delete' do
+      build_invalid_tailoring(os_minor_version: nil)
+
+      cleaner.run!
+
+      expect(cleaner.run!).to eq(empty_plan)
+    end
+
+    it 'rolls back every delete if any step in the transaction fails' do
+      good_tailoring
+      null_tailoring = build_invalid_tailoring(os_minor_version: nil)
+      test_result = attach_test_result(null_tailoring)
+
+      connection = ActiveRecord::Base.connection
+      error_message = Faker::Lorem.sentence
+      allow(connection).to receive(:execute).and_wrap_original do |original, sql, *args|
+        # Let earlier steps run, then fail partway through to prove the whole
+        # transaction is rolled back rather than leaving a half-cleaned database.
+        raise ActiveRecord::StatementInvalid, error_message if sql.include?('DELETE FROM historical_test_results')
+
+        original.call(sql, *args)
+      end
+
+      expect { cleaner.run! }.to raise_error(ActiveRecord::StatementInvalid, error_message)
+
+      expect(Tailoring.exists?(null_tailoring.id)).to be true
+      expect(HistoricalTestResult.exists?(test_result.id)).to be true
+      expect(RuleResult.where(test_result_id: test_result.id)).not_to be_empty
+      expect(Tailoring.exists?(good_tailoring.id)).to be true
+    end
+  end
+end

--- a/spec/tasks/cleanup_duplicate_tailorings_spec.rb
+++ b/spec/tasks/cleanup_duplicate_tailorings_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'tailorings:cleanup_duplicates task' do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  around do |example|
+    original_confirm = ENV.fetch('CONFIRM', nil)
+    begin
+      example.run
+    ensure
+      if original_confirm.nil?
+        ENV.delete('CONFIRM')
+      else
+        ENV['CONFIRM'] = original_confirm
+      end
+    end
+  end
+
+  before do
+    # Re-enable the task before each test to allow multiple executions
+    Rake::Task['tailorings:cleanup_duplicates'].reenable
+    ENV.delete('CONFIRM')
+  end
+
+  let(:policy) { create(:policy, :for_tailoring, supports_minors: [0], system_count: 1) }
+  let(:good_tailoring) { policy.tailorings.find_by(os_minor_version: 0) }
+
+  # rubocop:disable Rails/SkipsModelValidations
+  def build_invalid_tailoring(os_minor_version:, created_at: Time.zone.now)
+    tailoring = policy.tailorings.build(
+      profile: policy.profile, os_minor_version: os_minor_version, value_overrides: {}
+    )
+    tailoring.save!(validate: false)
+    tailoring.update_column(:created_at, created_at)
+    tailoring
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  context 'when nothing needs cleaning' do
+    it 'reports nothing to clean up and changes nothing' do
+      good_tailoring
+      output = nil
+
+      expect do
+        output = capture_stdout { Rake::Task['tailorings:cleanup_duplicates'].invoke }
+      end.not_to(change(Tailoring, :count))
+
+      expect(output).to include('nothing to clean up')
+      expect(Tailoring.exists?(good_tailoring.id)).to be true
+    end
+  end
+
+  context 'in dry-run mode (default, no CONFIRM)' do
+    it 'reports the plan but deletes nothing' do
+      good_tailoring
+      null_tailoring = build_invalid_tailoring(os_minor_version: nil)
+      output = nil
+
+      expect do
+        output = capture_stdout { Rake::Task['tailorings:cleanup_duplicates'].invoke }
+      end.not_to(change(Tailoring, :count))
+
+      expect(Tailoring.exists?(null_tailoring.id)).to be true
+      expect(output).to include('1 tailorings to remove')
+      expect(output).to include('dry run only, no data was changed')
+    end
+
+    it 'also does not delete when CONFIRM is set to anything other than true' do
+      null_tailoring = build_invalid_tailoring(os_minor_version: nil)
+      ENV['CONFIRM'] = 'false'
+
+      expect do
+        capture_stdout { Rake::Task['tailorings:cleanup_duplicates'].invoke }
+      end.not_to(change(Tailoring, :count))
+
+      expect(Tailoring.exists?(null_tailoring.id)).to be true
+    end
+  end
+
+  context 'when CONFIRM=true' do
+    it 'deletes NULL and race-condition duplicate tailorings, keeping legitimate ones' do
+      good_tailoring
+      null_tailoring = build_invalid_tailoring(os_minor_version: nil)
+      keeper = build_invalid_tailoring(os_minor_version: 5, created_at: 2.days.ago)
+      excess = build_invalid_tailoring(os_minor_version: 5, created_at: 1.hour.ago)
+      ENV['CONFIRM'] = 'true'
+      output = nil
+
+      expect do
+        output = capture_stdout { Rake::Task['tailorings:cleanup_duplicates'].invoke }
+      end.to change(Tailoring, :count).by(-2)
+
+      expect(Tailoring.exists?(good_tailoring.id)).to be true
+      expect(Tailoring.exists?(keeper.id)).to be true
+      expect(Tailoring.exists?(null_tailoring.id)).to be false
+      expect(Tailoring.exists?(excess.id)).to be false
+      expect(output).to include('Deleted 2 tailorings')
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add `tailorings:cleanup_duplicates` to remove invalid and duplicate Tailorings.
- Support dry-run planning and require `CONFIRM=true` before deletion.
- Delete dependent records in one transaction with rollback support.
- Add service and Rake task test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->