### PR TITLE
feat(Rake): redirect status checks to dedicated Redis

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -34,7 +34,7 @@ objects:
         partitions: 1
       - topicName: platform.inventory.host-apps
         partitions: 1
-    inMemoryDb: true
+    inMemoryDb: ${{IN_MEMORY_DB}}
     jobs:
     - name: import-ssg
       schedule: ${IMPORT_SSG_SCHEDULE}
@@ -867,6 +867,9 @@ parameters:
 - name: MAX_INIT_TIMEOUT_SECONDS
   description: Number of seconds for timeout init container operation
   value: "120"
+- name: IN_MEMORY_DB
+  description: Provision Clowder Redis. Set true in ephemeral (PRIMARY_REDIS_AS_CACHE fallback). Leave false in stage/prod.
+  value: 'false'
 - name: PRIMARY_REDIS_AS_CACHE
   description: Whether to use the clowder-provided Redis as cache or not
   value: 'false'

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -15,9 +15,16 @@ namespace :redis do
   desc 'Check for available redis connection'
   task status: [:environment] do
     begin
+      if ENV.fetch('PRIMARY_REDIS_AS_CACHE', false) == 'true'
+        redis_url = Settings.redis.url
+        redis_password = Settings.redis.password.presence
+      else
+        redis_url = "redis://#{Settings.redis.cache_hostname}:#{Settings.redis.cache_port}"
+        redis_password = Settings.redis.cache_password.presence
+      end
       Redis.new(
-        url: Settings.redis.url,
-        password: Settings.redis.password.presence,
+        url: redis_url,
+        password: redis_password,
         ssl: ActiveModel::Type::Boolean.new.cast(Settings.redis.ssl)
       ).ping
     rescue Redis::BaseError


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Make ClowdApp `inMemoryDb` configurable through the `IN_MEMORY_DB` template parameter.
- Update `redis:status` to use the primary Redis or cache Redis based on `PRIMARY_REDIS_AS_CACHE`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->