### PR TITLE
fix(CodeCov): set required uploads to 1

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,4 +8,4 @@ ignore:
   - "lib/tasks"
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
       with:
         fail_ci_if_error: true
+        files: ./coverage/coverage.xml
+        disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}
         version: v10.0.1
   migration-robustness:


### PR DESCRIPTION
We need to change the legacy setting (from when we had minitests also) so CodeCov doesn't wait forever to signal it's status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Configure Codecov to report status after one build.
- Upload `./coverage/coverage.xml` explicitly in the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->