### PR TITLE
fix(ClowdApp): revert "feat(ClowdApp): default inMemoryDb off"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -34,7 +34,7 @@ objects:
         partitions: 1
       - topicName: platform.inventory.host-apps
         partitions: 1
-    inMemoryDb: ${{IN_MEMORY_DB}}
+    inMemoryDb: true
     jobs:
     - name: import-ssg
       schedule: ${IMPORT_SSG_SCHEDULE}
@@ -867,9 +867,6 @@ parameters:
 - name: MAX_INIT_TIMEOUT_SECONDS
   description: Number of seconds for timeout init container operation
   value: "120"
-- name: IN_MEMORY_DB
-  description: Provision Clowder Redis. Set true in ephemeral (PRIMARY_REDIS_AS_CACHE fallback). Leave false in stage/prod.
-  value: 'false'
 - name: PRIMARY_REDIS_AS_CACHE
   description: Whether to use the clowder-provided Redis as cache or not
   value: 'false'


### PR DESCRIPTION
This reverts commit 7ccc2c6a751c7a50673850150dae9524dd3485f6.

The commit about to be reverted is a misinterpretation of Clowder behavior. This should fix the env setup on stage/prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Revert the `inMemoryDb` default change in ClowdApp.
- Enable the in-memory database by default to fix stage and production environment setup.
- Remove the `IN_MEMORY_DB` template parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->