### PR TITLE
feat(Kafka): increase topic partition request from 1 to 16

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -27,7 +27,7 @@ objects:
       - topicName: platform.payload-status
         partitions: 1
       - topicName: platform.inventory.events
-        partitions: 1
+        partitions: 16
       - topicName: platform.remediation-updates.compliance
         partitions: 1
       - topicName: platform.notifications.ingress


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Increase `platform.inventory.events` Kafka topic partitions from 1 to 16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->