### PR TITLE
feat(Kafka): implement batch consuming and DLQ

### DIFF
--- a/app/consumers/application_consumer.rb
+++ b/app/consumers/application_consumer.rb
@@ -21,13 +21,7 @@ class ApplicationConsumer < Karafka::BaseConsumer
 
   def process(message)
     @message = message
-
-    if attempt > 3
-      logger.error 'Discarded message'
-    else
-      consume_one
-    end
-
+    consume_one
     mark_as_consumed(message)
   end
 

--- a/config/initializers/0_env_config.rb
+++ b/config/initializers/0_env_config.rb
@@ -16,7 +16,8 @@ if !ClowderCommonRuby::Config.clowder_enabled? && defined?(Settings)
         'payload_status'                 => ENV.fetch('KAFKA_TOPIC_PAYLOAD_STATUS', 'platform.payload-status'),
         'notifications_ingress'          => ENV.fetch('KAFKA_TOPIC_NOTIFICATIONS_INGRESS', 'platform.notifications.ingress'),
         'remediation_updates_compliance' => ENV.fetch('KAFKA_TOPIC_REMEDIATION_UPDATES', 'platform.remediation-updates.compliance'),
-        'inventory_host_apps'            => ENV.fetch('KAFKA_TOPIC_INVENTORY_HOST_APPS', 'platform.inventory.host-apps')
+        'inventory_host_apps'            => ENV.fetch('KAFKA_TOPIC_INVENTORY_HOST_APPS', 'platform.inventory.host-apps'),
+        'compliance_dlq'                 => ENV.fetch('KAFKA_TOPIC_COMPLIANCE_DLQ', 'platform.compliance.dlq')
       }
     },
     'redis' => {

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -34,6 +34,8 @@ objects:
         partitions: 1
       - topicName: platform.inventory.host-apps
         partitions: 1
+      - topicName: platform.compliance.dlq
+        partitions: 1
     inMemoryDb: true
     jobs:
     - name: import-ssg

--- a/devel.json
+++ b/devel.json
@@ -45,6 +45,10 @@
                 "name": "platform.inventory.host-apps"
             },
             {
+                "requestedName": "platform.compliance.dlq",
+                "name": "platform.compliance.dlq"
+            },
+            {
                 "requestedName": "originalName",
                 "name": "someTopic"
             }

--- a/github-ci.json
+++ b/github-ci.json
@@ -45,6 +45,10 @@
                 "name": "platform.inventory.host-apps"
             },
             {
+                "requestedName": "platform.compliance.dlq",
+                "name": "platform.compliance.dlq"
+            },
+            {
                 "requestedName": "originalName",
                 "name": "someTopic"
             }

--- a/karafka.rb
+++ b/karafka.rb
@@ -49,7 +49,13 @@ class KarafkaApp < Karafka::App
     consumer_group :'complianceinventory-events-consumer' do
       topic Settings.kafka.topics.inventory_events do
         consumer InventoryEventsConsumer
-        max_messages 1
+        max_messages 100
+        max_wait_time 100
+        dead_letter_queue(
+          topic: Settings.kafka.topics.compliance_dlq,
+          max_retries: 3,
+          independent: true
+        )
       end
     end
   end

--- a/spec/consumers/inventory_events_consumer_spec.rb
+++ b/spec/consumers/inventory_events_consumer_spec.rb
@@ -29,20 +29,6 @@ describe InventoryEventsConsumer do
     end
   end
 
-  describe 'handling messages after three retries' do
-    let(:type) { 'delete' }
-
-    before do
-      allow(consumer).to receive(:attempt).and_return(4)
-    end
-
-    it 'logs and discards message' do
-      expect(Karafka.logger).to receive(:error).with('Discarded message')
-
-      consumer.consume
-    end
-  end
-
   describe 'handling messages by type' do
     context 'when message is delete' do
       let(:type) { 'delete' }

--- a/test.json
+++ b/test.json
@@ -45,6 +45,10 @@
                 "name": "platform.inventory.host-apps"
             },
             {
+                "requestedName": "platform.compliance.dlq",
+                "name": "platform.compliance.dlq"
+            },
+            {
                 "requestedName": "originalName",
                 "name": "someTopic"
             }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-29315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Process up to 100 `inventory_events` messages per batch.
- Retry failed messages up to three times, then route them to `platform.compliance.dlq`.
- Add the compliance DLQ topic to application, deployment, and test configurations.
- Remove the attempt-counter discard logic and its related test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->