### PR TITLE
chore(Gems): update clowder-common-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       aws-sdk-cloudwatchlogs (~> 1)
       multi_json (~> 1)
       uuid (~> 2)
-    clowder-common-ruby (0.5.6)
+    clowder-common-ruby (0.5.7)
     coderay (1.1.3)
     concurrent-ruby (1.3.8)
     config (5.6.1)

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -36,7 +36,7 @@ objects:
         partitions: 1
       - topicName: platform.compliance.dlq
         partitions: 1
-    inMemoryDb: true
+    inMemoryDb: ${{IN_MEMORY_DB}}
     jobs:
     - name: import-ssg
       schedule: ${IMPORT_SSG_SCHEDULE}
@@ -869,6 +869,9 @@ parameters:
 - name: MAX_INIT_TIMEOUT_SECONDS
   description: Number of seconds for timeout init container operation
   value: "120"
+- name: IN_MEMORY_DB
+  description: Provision Clowder Redis. Set true in ephemeral (PRIMARY_REDIS_AS_CACHE fallback). Leave false in stage/prod.
+  value: 'false'
 - name: PRIMARY_REDIS_AS_CACHE
   description: Whether to use the clowder-provided Redis as cache or not
   value: 'false'

--- a/devel.json
+++ b/devel.json
@@ -54,11 +54,6 @@
             }
         ]
     },
-    "inMemoryDb": {
-        "hostname": "redis",
-        "sslMode": "false",
-        "port": "6379"
-    },
     "database": {
         "name": "compliance_dev",
         "username": "insights",

--- a/github-ci.json
+++ b/github-ci.json
@@ -54,11 +54,6 @@
             }
         ]
     },
-    "inMemoryDb": {
-        "hostname": "redis",
-        "sslMode": "false",
-        "port": "6379"
-    },
     "database": {
         "name": "insights",
         "username": "insights",

--- a/test.json
+++ b/test.json
@@ -54,11 +54,6 @@
             }
         ]
     },
-    "inMemoryDb": {
-        "hostname": "redis",
-        "sslMode": "false",
-        "port": "6379"
-    },
     "database": {
         "name": "compliance-test",
         "username": "compliance",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-29915

Necessary support for `nil` `inMemoryDb` config so we can use https://github.com/RedHatInsights/compliance-backend/commit/7ccc2c6a751c7a50673850150dae9524dd3485f6. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update `clowder-common-ruby` to support a nullable `inMemoryDb` configuration.
- Default `inMemoryDb` to `false` in `ClowdApp` deployments.
- Add the `IN_MEMORY_DB` template parameter and remove fixed Redis `inMemoryDb` settings from environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->