### PR TITLE
feat(systems): add native columns for system_profile fields and preserve jsonb sorting

### DIFF
--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -86,8 +86,8 @@ class System < ApplicationRecord
   )
 
   sortable_by :display_name
-  sortable_by :os_major_version
-  sortable_by :os_minor_version
+  sortable_by :os_major_version, os_major_version.left
+  sortable_by :os_minor_version, os_minor_version.left
   sortable_by :os_version, sortable_os
   sortable_by :groups, first_group_name
 

--- a/db/migrate/20260901125713_add_native_columns_to_systems.rb
+++ b/db/migrate/20260901125713_add_native_columns_to_systems.rb
@@ -1,0 +1,7 @@
+class AddNativeColumnsToSystems < ActiveRecord::Migration[8.1]
+  def change
+    add_column :systems, :owner_id, :uuid
+    add_column :systems, :os_major_version, :integer
+    add_column :systems, :os_minor_version, :integer
+  end
+end

--- a/db/migrate/20260901125741_add_concurrent_indices_to_systems.rb
+++ b/db/migrate/20260901125741_add_concurrent_indices_to_systems.rb
@@ -1,0 +1,16 @@
+class AddConcurrentIndicesToSystems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :systems, :owner_id,
+              where: 'deleted_at IS NULL',
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :systems, [:org_id, :os_major_version, :os_minor_version],
+              where: 'deleted_at IS NULL',
+              algorithm: :concurrently,
+              name: 'index_systems_on_org_id_and_os_versions',
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_100713) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_125741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "dblink"
   enable_extension "pgcrypto"
@@ -307,6 +307,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_100713) do
     t.jsonb "groups", default: []
     t.uuid "insights_id"
     t.string "org_id", limit: 36, null: false
+    t.integer "os_major_version"
+    t.integer "os_minor_version"
+    t.uuid "owner_id"
     t.datetime "stale_timestamp", null: false
     t.jsonb "system_profile", default: {}, null: false
     t.jsonb "tags", default: {}, null: false
@@ -319,6 +322,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_100713) do
     t.index ["insights_id"], name: "index_systems_on_insights_id"
     t.index ["org_id", "display_name"], name: "index_systems_on_org_id_and_display_name_partial", where: "(deleted_at IS NULL)"
     t.index ["org_id", "id"], name: "index_systems_on_org_id_and_id_partial", where: "(deleted_at IS NULL)"
+    t.index ["org_id", "os_major_version", "os_minor_version"], name: "index_systems_on_org_id_and_os_versions", where: "(deleted_at IS NULL)"
+    t.index ["owner_id"], name: "index_systems_on_owner_id", where: "(deleted_at IS NULL)"
     t.index ["tags"], name: "index_systems_on_tags_gin_partial", opclass: :jsonb_path_ops, where: "(deleted_at IS NULL)", using: :gin
   end
 


### PR DESCRIPTION
## Task Reference
Jira: https://issues.redhat.com/browse/RHINENG-30503

## Description
Part of Phase 1 of removing the `system_profile` JSONB blob.
Adds native columns (`owner_id`, `os_major_version`, and `os_minor_version`) to the `systems` table.
Also adds corresponding partial indices (`deleted_at IS NULL`) concurrently.
`system_profile` remains intact for backward compatibility until data migration is complete.

This PR ensures the existing sorting logic continues to use the JSONB payload (`system_profile->'operating_system'`) directly through explicit Arel `.left` extraction nodes. This resolves CI failures caused by the native columns being `NULL` in older test fixtures/data.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [x] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices

- Add native `owner_id`, `os_major_version`, and `os_minor_version` columns to `systems`.
- Add concurrent partial indexes for non-deleted systems.
- Force sorting on `os_major_version` and `os_minor_version` to explicitly use Arel `.left` JSONB extractions.
- Retain `system_profile` for backward compatibility during data migration.