### PR TITLE
feat(systems): dual-write Kafka profile fields

### DIFF
--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -33,10 +33,14 @@ module Kafka
     end
 
     def extract_system_attrs(id, payload, updated)
+      sp = relevant_system_profile(payload)
+      os = sp['operating_system'].is_a?(Hash) ? sp['operating_system'] : {}
+
       {
         id: id, account: payload.dig('account'), org_id: payload.dig('org_id'),
         display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
-        tags: payload.dig('tags') || [], system_profile: relevant_system_profile(payload),
+        tags: payload.dig('tags') || [], system_profile: sp,
+        os_major_version: os['major'], os_minor_version: os['minor'], owner_id: sp['owner_id'],
         stale_timestamp: payload.dig('stale_timestamp'), created: payload.dig('created'),
         updated: updated, insights_id: payload.dig('insights_id'),
         deleted_at: nil
@@ -59,7 +63,7 @@ module Kafka
         attrs,
         unique_by: :id,
         returning: %w[id],
-        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id, deleted_at = EXCLUDED.deleted_at WHERE COALESCE(systems.deleted_at, systems.updated) < EXCLUDED.updated')
+        on_duplicate: Arel.sql('account = EXCLUDED.account, org_id = EXCLUDED.org_id, display_name = EXCLUDED.display_name, groups = EXCLUDED.groups, tags = EXCLUDED.tags, system_profile = EXCLUDED.system_profile, os_major_version = EXCLUDED.os_major_version, os_minor_version = EXCLUDED.os_minor_version, owner_id = EXCLUDED.owner_id, stale_timestamp = EXCLUDED.stale_timestamp, created = EXCLUDED.created, updated = EXCLUDED.updated, insights_id = EXCLUDED.insights_id, deleted_at = EXCLUDED.deleted_at WHERE COALESCE(systems.deleted_at, systems.updated) < EXCLUDED.updated')
       )
       # rubocop:enable Layout/LineLength
       # rubocop:enable Rails/SkipsModelValidations

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -3,6 +3,8 @@
 module Kafka
   # Imports host events from Inventory into the systems table
   class SystemImporter
+    OWNER_ID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
+
     def initialize(message, logger = Rails.logger)
       @message = message
       @logger = logger
@@ -33,18 +35,32 @@ module Kafka
     end
 
     def extract_system_attrs(id, payload, updated)
-      sp = relevant_system_profile(payload)
-      os = sp['operating_system'].is_a?(Hash) ? sp['operating_system'] : {}
-
+      system_profile = relevant_system_profile(payload)
       {
         id: id, account: payload.dig('account'), org_id: payload.dig('org_id'),
         display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
-        tags: payload.dig('tags') || [], system_profile: sp,
-        os_major_version: os['major'], os_minor_version: os['minor'], owner_id: sp['owner_id'],
+        tags: payload.dig('tags') || [], system_profile: system_profile,
         stale_timestamp: payload.dig('stale_timestamp'), created: payload.dig('created'),
         updated: updated, insights_id: payload.dig('insights_id'),
         deleted_at: nil
+      }.merge(native_system_profile_attrs(system_profile))
+    end
+
+    def native_system_profile_attrs(system_profile)
+      operating_system = system_profile['operating_system']
+      operating_system = {} unless operating_system.is_a?(Hash)
+      {
+        os_major_version: operating_system['major'],
+        os_minor_version: operating_system['minor'],
+        owner_id: native_owner_id(system_profile['owner_id'])
       }
+    end
+
+    def native_owner_id(owner_id)
+      return owner_id if owner_id.nil? || (owner_id.is_a?(String) && OWNER_ID_FORMAT.match?(owner_id))
+
+      @logger.error("[Kafka::SystemImporter] Malformed owner_id: #{owner_id.inspect}")
+      nil
     end
 
     def relevant_system_profile(payload)

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -3,8 +3,6 @@
 module Kafka
   # Imports host events from Inventory into the systems table
   class SystemImporter
-    OWNER_ID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
-
     def initialize(message, logger = Rails.logger)
       @message = message
       @logger = logger
@@ -50,14 +48,14 @@ module Kafka
       operating_system = system_profile['operating_system']
       operating_system = {} unless operating_system.is_a?(Hash)
       {
-        os_major_version: operating_system['major'],
-        os_minor_version: operating_system['minor'],
+        os_major_version: System.type_for_attribute(:os_major_version).cast(operating_system['major']),
+        os_minor_version: System.type_for_attribute(:os_minor_version).cast(operating_system['minor']),
         owner_id: native_owner_id(system_profile['owner_id'])
       }
     end
 
     def native_owner_id(owner_id)
-      return owner_id if owner_id.nil? || (owner_id.is_a?(String) && OWNER_ID_FORMAT.match?(owner_id))
+      return owner_id if owner_id.nil? || (owner_id.is_a?(String) && UUID.validate(owner_id))
 
       @logger.error("[Kafka::SystemImporter] Malformed owner_id: #{owner_id.inspect}")
       nil

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Kafka::SystemImporter do
         'groups' => [],
         'tags' => [],
         'system_profile' => {
-          'operating_system' => { 'major' => 9, 'minor' => 2 },
+          'operating_system' => { 'major' => 9, 'minor' => 4 },
           'owner_id' => SecureRandom.uuid
         },
         'stale_timestamp' => updated_time,
@@ -28,6 +28,34 @@ RSpec.describe Kafka::SystemImporter do
   let(:service) { described_class.new(message, Karafka.logger) }
 
   describe '#import' do
+    # rubocop:disable Rails/SkipsModelValidations
+    shared_context 'with an existing owned system' do
+      let(:existing_owner_id) { SecureRandom.uuid }
+      let!(:existing_system) do
+        system = FactoryBot.create(
+          :system,
+          id: message['host']['id'],
+          updated: (Time.zone.parse(updated_time) - 2.days).iso8601,
+          system_profile: { 'owner_id' => existing_owner_id }
+        )
+        system.update_columns(owner_id: existing_owner_id)
+        system
+      end
+    end
+
+    shared_context 'with existing native OS versions' do
+      let!(:existing_system) do
+        system = FactoryBot.create(
+          :system,
+          id: message['host']['id'],
+          updated: (Time.zone.parse(updated_time) - 2.days).iso8601,
+          system_profile: { 'operating_system' => { 'major' => 8, 'minor' => 0 } }
+        )
+        system.update_columns(os_major_version: 8, os_minor_version: 0)
+        system
+      end
+    end
+
     context 'when payload is invalid (missing id)' do
       before { message['host'].delete('id') }
 
@@ -55,36 +83,134 @@ RSpec.describe Kafka::SystemImporter do
     end
 
     context 'when system is new' do
-      it 'upserts system and extracts native columns' do
+      it 'upserts the JSONB profile and native fields' do
         expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
         expect { service.import }.to change { System.count }.by(1)
 
         system = System.find(message['host']['id'])
-        expect(system.os_major_version).to eq(9)
-        expect(system.os_minor_version).to eq(2)
-        expect(system.owner_id).to eq(message.dig('host', 'system_profile', 'owner_id'))
+        expect(system.system_profile).to eq(message.dig('host', 'system_profile'))
+        expect(system[:os_major_version]).to eq(9)
+        expect(system[:os_minor_version]).to eq(4)
+        expect(system[:owner_id]).to eq(message.dig('host', 'system_profile', 'owner_id'))
       end
     end
 
     context 'when message is an update to an existing system' do
       let!(:existing_system) do
-        FactoryBot.create(
+        system = FactoryBot.create(
           :system,
           id: message['host']['id'],
-          display_name: 'old-name',
-          updated: (Time.zone.parse(updated_time) - 2.days).iso8601
+          display_name: Faker::Internet.domain_word,
+          updated: (Time.zone.parse(updated_time) - 2.days).iso8601,
+          system_profile: {
+            'operating_system' => { 'major' => 8, 'minor' => 0 },
+            'owner_id' => SecureRandom.uuid
+          }
         )
+        system.update_columns(
+          os_major_version: 8,
+          os_minor_version: 0,
+          owner_id: SecureRandom.uuid
+        )
+        system
       end
 
-      it 'updates the existing system attributes and native columns' do
+      it 'updates the JSONB profile and native fields' do
         expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
         expect { service.import }.not_to(change { System.count })
 
         system = System.find(message['host']['id'])
         expect(system.display_name).to eq(message.dig('host', 'display_name'))
-        expect(system.os_major_version).to eq(9)
-        expect(system.os_minor_version).to eq(2)
-        expect(system.owner_id).to eq(message.dig('host', 'system_profile', 'owner_id'))
+        expect(system.system_profile).to eq(message.dig('host', 'system_profile'))
+        expect(system[:os_major_version]).to eq(9)
+        expect(system[:os_minor_version]).to eq(4)
+        expect(system[:owner_id]).to eq(message.dig('host', 'system_profile', 'owner_id'))
+      end
+    end
+
+    context 'when a newer message omits owner_id' do
+      include_context 'with an existing owned system'
+
+      before { message['host']['system_profile'].delete('owner_id') }
+
+      it 'removes owner_id from JSONB and clears the native column' do
+        service.import
+        system = System.find(message['host']['id'])
+        expect(system.system_profile).not_to have_key('owner_id')
+        expect(system[:owner_id]).to be_nil
+      end
+    end
+
+    context 'when a newer message has a null owner_id' do
+      include_context 'with an existing owned system'
+
+      before { message['host']['system_profile']['owner_id'] = nil }
+
+      it 'retains JSON null and clears the native column' do
+        service.import
+        system = System.find(message['host']['id'])
+        expect(system.system_profile).to have_key('owner_id')
+        expect(system.system_profile['owner_id']).to be_nil
+        expect(system[:owner_id]).to be_nil
+      end
+    end
+
+    context 'when owner_id is a malformed UUID string' do
+      before { message['host']['system_profile']['owner_id'] = Faker::Lorem.word }
+
+      it 'logs an error and imports JSONB with a null native owner' do
+        expect(Karafka.logger)
+          .to receive(:error)
+          .with(/\[Kafka::SystemImporter\] Malformed owner_id/)
+
+        expect { service.import }.to change { System.count }.by(1)
+        system = System.find(message['host']['id'])
+        expect(system.system_profile['owner_id']).to eq(message.dig('host', 'system_profile', 'owner_id'))
+        expect(system[:owner_id]).to be_nil
+      end
+    end
+
+    context 'when owner_id is not a string' do
+      before { message['host']['system_profile']['owner_id'] = 1 }
+
+      it 'logs an error and imports JSONB with a null native owner' do
+        expect(Karafka.logger)
+          .to receive(:error)
+          .with(/\[Kafka::SystemImporter\] Malformed owner_id/)
+
+        expect { service.import }.to change { System.count }.by(1)
+        system = System.find(message['host']['id'])
+        expect(system.system_profile['owner_id']).to eq(1)
+        expect(system[:owner_id]).to be_nil
+      end
+    end
+
+    context 'when a newer message omits operating_system' do
+      include_context 'with existing native OS versions'
+
+      before { message['host']['system_profile'].delete('operating_system') }
+
+      it 'removes operating_system from JSONB and clears native OS versions' do
+        service.import
+        system = System.find(message['host']['id'])
+        expect(system.system_profile).not_to have_key('operating_system')
+        expect(system[:os_major_version]).to be_nil
+        expect(system[:os_minor_version]).to be_nil
+      end
+    end
+
+    context 'when a newer message has a non-hash operating_system' do
+      include_context 'with existing native OS versions'
+
+      before { message['host']['system_profile']['operating_system'] = Faker::Lorem.word }
+
+      it 'retains the JSONB value and clears native OS versions' do
+        service.import
+        system = System.find(message['host']['id'])
+        expect(system.system_profile['operating_system'])
+          .to eq(message.dig('host', 'system_profile', 'operating_system'))
+        expect(system[:os_major_version]).to be_nil
+        expect(system[:os_minor_version]).to be_nil
       end
     end
 
@@ -112,12 +238,23 @@ RSpec.describe Kafka::SystemImporter do
     end
 
     context 'when message is strictly stale (older than DB)' do
-      before do
-        FactoryBot.create(
+      let(:existing_owner_id) { SecureRandom.uuid }
+      let!(:existing_system) do
+        system = FactoryBot.create(
           :system,
           id: message['host']['id'],
-          updated: (Time.zone.parse(updated_time) + 1.day).iso8601
+          updated: (Time.zone.parse(updated_time) + 1.day).iso8601,
+          system_profile: {
+            'operating_system' => { 'major' => 8, 'minor' => 0 },
+            'owner_id' => existing_owner_id
+          }
         )
+        system.update_columns(
+          os_major_version: 8,
+          os_minor_version: 0,
+          owner_id: existing_owner_id
+        )
+        system
       end
 
       it 'ignores the stale message' do
@@ -128,7 +265,17 @@ RSpec.describe Kafka::SystemImporter do
       it 'increments the stale counter' do
         expect { service.import }.to increment_yabeda_counter(Yabeda.compliance_system_import_stale_total).by(1)
       end
+
+      it 'preserves the JSONB profile and native fields' do
+        service.import
+        system = System.find(message['host']['id'])
+        expect(system.system_profile).to eq(existing_system.system_profile)
+        expect(system[:os_major_version]).to eq(8)
+        expect(system[:os_minor_version]).to eq(0)
+        expect(system[:owner_id]).to eq(existing_owner_id)
+      end
     end
+    # rubocop:enable Rails/SkipsModelValidations
 
     context 'when existing system is soft-deleted (has deleted_at set)' do
       let(:system_id) { message['host']['id'] }

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Kafka::SystemImporter do
         'display_name' => Faker::Internet.domain_word,
         'groups' => [],
         'tags' => [],
-        'system_profile' => {},
+        'system_profile' => {
+          'operating_system' => { 'major' => 9, 'minor' => 2 },
+          'owner_id' => SecureRandom.uuid
+        },
         'stale_timestamp' => updated_time,
         'created' => (Time.now.utc - 1.day).iso8601,
         'updated' => updated_time,
@@ -52,9 +55,14 @@ RSpec.describe Kafka::SystemImporter do
     end
 
     context 'when system is new' do
-      it 'upserts system' do
+      it 'upserts system and extracts native columns' do
         expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
         expect { service.import }.to change { System.count }.by(1)
+
+        system = System.find(message['host']['id'])
+        expect(system.os_major_version).to eq(9)
+        expect(system.os_minor_version).to eq(2)
+        expect(system.owner_id).to eq(message.dig('host', 'system_profile', 'owner_id'))
       end
     end
 
@@ -68,12 +76,15 @@ RSpec.describe Kafka::SystemImporter do
         )
       end
 
-      it 'updates the existing system attributes' do
+      it 'updates the existing system attributes and native columns' do
         expect(Karafka.logger).to receive(:audit_success).with(/\[Kafka::SystemImporter\] Imported system/)
         expect { service.import }.not_to(change { System.count })
 
         system = System.find(message['host']['id'])
         expect(system.display_name).to eq(message.dig('host', 'display_name'))
+        expect(system.os_major_version).to eq(9)
+        expect(system.os_minor_version).to eq(2)
+        expect(system.owner_id).to eq(message.dig('host', 'system_profile', 'owner_id'))
       end
     end
 

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe Kafka::SystemImporter do
         expect(system[:os_minor_version]).to eq(4)
         expect(system[:owner_id]).to eq(message.dig('host', 'system_profile', 'owner_id'))
       end
+
+      it 'validates owner_id with the shared UUID helper' do
+        owner_id = message.dig('host', 'system_profile', 'owner_id')
+        expect(UUID).to receive(:validate).with(owner_id).and_call_original
+
+        service.import
+      end
+
+      it 'casts native OS versions to their database types' do
+        major_type = instance_double(ActiveModel::Type::Integer, cast: 9)
+        minor_type = instance_double(ActiveModel::Type::Integer, cast: 4)
+        allow(System).to receive(:type_for_attribute).and_call_original
+        expect(System).to receive(:type_for_attribute).with(:os_major_version).and_return(major_type)
+        expect(System).to receive(:type_for_attribute).with(:os_minor_version).and_return(minor_type)
+        expect(major_type).to receive(:cast).with(9)
+        expect(minor_type).to receive(:cast).with(4)
+
+        service.import
+      end
     end
 
     context 'when message is an update to an existing system' do


### PR DESCRIPTION
## Jira
RHINENG-30504

## Summary
- Dual-write Inventory operating-system versions and owner ID into native system columns.
- Preserve the trimmed JSONB profile and stale-message guard.
- Log malformed owner IDs while retaining them in JSONB and storing native NULL.

## Verification
- `podman-compose exec rails bundle exec rspec spec/services/kafka/system_importer_spec.rb` — 26 examples, 0 failures
- `podman-compose exec rails bundle exec rake spec:validate` — blocked by unrelated untracked `get_view.rb` and `test_heredoc.rb` RuboCop offenses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added native-column writes for OS versions and owner IDs during Kafka imports.
- Preserved trimmed JSONB profiles and stale-message protection.
- Logged malformed owner IDs and stored native `NULL` values.
- Expanded coverage for updates, omitted values, malformed values, and stale messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->