### PR TITLE
feat(IoP): support OS minor absence in upstream SSG content

### DIFF
--- a/app/controllers/concerns/parameter_handling.rb
+++ b/app/controllers/concerns/parameter_handling.rb
@@ -24,6 +24,7 @@ module ParameterHandling
 
   ParamType = ActionController::Parameters # shorthand
   ID_TYPE = ParamType.integer | ParamType.string
+  TAGS_TYPE = ParamType.array(ParamType.string) | ParamType.string
   ParamType.action_on_unpermitted_parameters = :raise # fail on unpermitted params
 
   DEFAULT_PERMITTED = StrongerParameters::ControllerSupport::PermittedParameters::DEFAULT_PERMITTED.merge(
@@ -51,7 +52,7 @@ module ParameterHandling
       limit: ParamType.integer & ParamType.gt(0) & ParamType.lte(100),
       offset: ParamType.integer & ParamType.gte(0),
       sort_by: ParamType.array(ParamType.string) | ParamType.string,
-      tags: ParamType.array(ParamType.string) | ParamType.string,
+      tags: TAGS_TYPE,
       filter: ParamType.string,
       ids_only: ParamType.boolean
     }

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -83,19 +83,12 @@ class SystemsController < ApplicationController
     end
   end
 
-  # Candidate systems narrowed by the minor-version rule (see `Policy#supports_minor?` for the hosted
-  # vs IoP semantics). The support decision is loop-invariant for a single policy, so it is resolved
-  # once here instead of per candidate: minor-agnostic (upstream/IoP) content accepts every minor,
-  # while hosted content keeps only the minors the policy actually ships.
   def assignable_systems
     return candidate_systems if SupportedSsg.minor_agnostic?(policy.os_major_version)
 
-    supported_minors = policy.os_minor_versions
-    candidate_systems.select { |system| supported_minors.include?(system.os_minor_version) }
+    candidate_systems.os_minor_versions(policy.os_minor_versions)
   end
 
-  # Systems eligible for assignment before the minor rule is applied: the submitted `ids`, matching
-  # the policy's major version, excluding any already held by a sibling policy.
   def candidate_systems
     pundit_scope.where(id: permitted_params[:ids])
                 .os_major_versions(policy.os_major_version)

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -78,17 +78,28 @@ class SystemsController < ApplicationController
   end
 
   def new_policy_systems
-    @new_policy_systems ||= begin
-      major = policy.os_major_version
-      minors = policy.os_minor_versions
-      # Filter the passed systems based on what OS versions the policy supports
-      # and also drop any system that is assigned to a sibling policy
-      items = pundit_scope.where(id: permitted_params[:ids])
-                          .os_major_versions(major).os_minor_versions(minors)
-                          .where.not(id: systems_with_sibling_policies)
-
-      items.map { |item| PolicySystem.new(policy: policy, system: item) }
+    @new_policy_systems ||= assignable_systems.map do |system|
+      PolicySystem.new(policy: policy, system: system)
     end
+  end
+
+  # Candidate systems narrowed by the minor-version rule (see `Policy#supports_minor?` for the hosted
+  # vs IoP semantics). The support decision is loop-invariant for a single policy, so it is resolved
+  # once here instead of per candidate: minor-agnostic (upstream/IoP) content accepts every minor,
+  # while hosted content keeps only the minors the policy actually ships.
+  def assignable_systems
+    return candidate_systems if SupportedSsg.minor_agnostic?(policy.os_major_version)
+
+    supported_minors = policy.os_minor_versions
+    candidate_systems.select { |system| supported_minors.include?(system.os_minor_version) }
+  end
+
+  # Systems eligible for assignment before the minor rule is applied: the submitted `ids`, matching
+  # the policy's major version, excluding any already held by a sibling policy.
+  def candidate_systems
+    pundit_scope.where(id: permitted_params[:ids])
+                .os_major_versions(policy.os_major_version)
+                .where.not(id: systems_with_sibling_policies)
   end
 
   def old_policy_systems

--- a/app/controllers/tailorings_controller.rb
+++ b/app/controllers/tailorings_controller.rb
@@ -70,9 +70,14 @@ class TailoringsController < ApplicationController
   end
 
   def tailoring
-    @tailoring ||= authorize(
-      expand_resource.find(SupportedSsg.resolve_minor(policy.os_major_version, permitted_params[:id]))
-    )
+    @tailoring ||= authorize(expand_resource.find(resolved_tailoring_id))
+  end
+
+  def resolved_tailoring_id
+    id = permitted_params[:id]
+    return id if UUID.validate(id.to_s)
+
+    SupportedSsg.resolve_minor(policy.os_major_version, id)
   end
 
   def policy

--- a/app/controllers/tailorings_controller.rb
+++ b/app/controllers/tailorings_controller.rb
@@ -70,7 +70,9 @@ class TailoringsController < ApplicationController
   end
 
   def tailoring
-    @tailoring ||= authorize(expand_resource.find(permitted_params[:id]))
+    @tailoring ||= authorize(
+      expand_resource.find(SupportedSsg.resolve_minor(policy.os_major_version, permitted_params[:id]))
+    )
   end
 
   def policy

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -95,6 +95,14 @@ class Policy < ApplicationRecord
     SupportedProfile.find_by!(ref_id: ref_id, os_major_version: os_major_version).os_minor_versions
   end
 
+  # A policy supports a system's minor when its SSG content covers that minor. Hosted content ships
+  # per-minor datastreams, so only the minors listed on the policy match. Upstream/IoP content ships
+  # a single minor-0 datastream per major that acts as a wildcard, so every minor of that major is
+  # supported.
+  def supports_minor?(os_minor_version)
+    SupportedSsg.minor_agnostic?(os_major_version) || os_minor_versions.include?(os_minor_version)
+  end
+
   private
 
   def ensure_default_values

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -95,10 +95,6 @@ class Policy < ApplicationRecord
     SupportedProfile.find_by!(ref_id: ref_id, os_major_version: os_major_version).os_minor_versions
   end
 
-  # A policy supports a system's minor when its SSG content covers that minor. Hosted content ships
-  # per-minor datastreams, so only the minors listed on the policy match. Upstream/IoP content ships
-  # a single minor-0 datastream per major that acts as a wildcard, so every minor of that major is
-  # supported.
   def supports_minor?(os_minor_version)
     SupportedSsg.minor_agnostic?(os_major_version) || os_minor_versions.include?(os_minor_version)
   end

--- a/app/models/policy_system.rb
+++ b/app/models/policy_system.rb
@@ -13,9 +13,9 @@ class PolicySystem < ApplicationRecord
   validate :system_unique?, on: :create
 
   after_create do
-    Tailoring.find_or_create_by!(policy_id: policy_id, os_minor_version: system.os_minor_version) do |tailoring|
-      # Look up the latest Profile supporting the given OS minor version
-      tailoring.profile = policy.profile.variant_for_minor(system.os_minor_version)
+    minor = SupportedSsg.resolve_minor(system.os_major_version, system.os_minor_version)
+    Tailoring.find_or_create_by!(policy_id: policy_id, os_minor_version: minor) do |tailoring|
+      tailoring.profile = policy.profile.variant_for_minor(minor)
       tailoring.value_overrides = tailoring.profile.value_overrides
     end
   end
@@ -25,7 +25,7 @@ class PolicySystem < ApplicationRecord
   def system_supported?
     if policy.os_major_version != system.os_major_version
       errors.add(:system, 'Unsupported OS major version')
-    elsif policy.os_minor_versions.exclude?(system.os_minor_version)
+    elsif !policy.supports_minor?(system.os_minor_version)
       errors.add(:system, 'Unsupported OS minor version')
     end
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -40,13 +40,14 @@ class Profile < ApplicationRecord
   private
 
   def find_variant_for_minor(version)
+    resolved = SupportedSsg.resolve_minor(security_guide.os_major_version, version)
     self.class.unscoped
         .joins(:security_guide, :os_minor_versions)
         .order(self.class.version_to_array(SecurityGuide.arel_table.alias('security_guide')[:version]).desc)
         .find_by(
           ref_id: ref_id,
           security_guide: { os_major_version: security_guide.os_major_version },
-          os_minor_versions: { os_minor_version: version }
+          os_minor_versions: { os_minor_version: resolved }
         )
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,10 +18,12 @@ class Profile < ApplicationRecord
   has_many :rule_groups, through: :security_guide, class_name: 'RuleGroup'
 
   def variant_for_minor(version)
-    profile = find_variant_for_minor(version)
+    os_major = security_guide.os_major_version
+    resolved = SupportedSsg.resolve_minor(os_major, version)
+    profile = find_variant_for_minor(resolved)
     return profile if profile
 
-    raise ::Exceptions::OSMinorVersionNotSupported.new(security_guide.os_major_version, version)
+    raise ::Exceptions::OSMinorVersionNotSupported.new(os_major, version)
   end
 
   def self.from_parser(obj, existing: nil, security_guide_id: nil, value_overrides: nil)
@@ -39,15 +41,14 @@ class Profile < ApplicationRecord
 
   private
 
-  def find_variant_for_minor(version)
-    resolved = SupportedSsg.resolve_minor(security_guide.os_major_version, version)
+  def find_variant_for_minor(resolved_minor)
     self.class.unscoped
         .joins(:security_guide, :os_minor_versions)
         .order(self.class.version_to_array(SecurityGuide.arel_table.alias('security_guide')[:version]).desc)
         .find_by(
           ref_id: ref_id,
           security_guide: { os_major_version: security_guide.os_major_version },
-          os_minor_versions: { os_minor_version: resolved }
+          os_minor_versions: { os_minor_version: resolved_minor }
         )
   end
 end

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -33,17 +33,35 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
     end
 
     def for_os(os_major_version, os_minor_version)
+      for_major = by_os_major[os_major_version.to_s] || []
+      exact = for_major.select { |ssg| ssg.os_minor_version == os_minor_version.to_s }
+
+      # Fall back to the minor-0 datastream when no exact minor is shipped (upstream/IoP content).
+      exact.any? ? exact : for_major.select { |ssg| ssg.os_minor_version == '0' }
+    end
+
+    def resolve_minor(os_major_version, os_minor_version)
       os_major_version = os_major_version.to_s
       os_minor_version = os_minor_version.to_s
 
-      all.select do |ssg|
+      exact = all.any? do |ssg|
         ssg.os_major_version == os_major_version &&
           ssg.os_minor_version == os_minor_version
       end
+
+      (exact ? os_minor_version : '0').to_i
+    end
+
+    # True when a major ships a single minor-0 datastream that acts as a wildcard for every minor
+    # (upstream/IoP content). Hosted content ships per-minor datastreams, so this is false and only
+    # the minors actually present are supported.
+    def minor_agnostic?(os_major_version)
+      minors = by_os_major[os_major_version.to_s]&.map(&:os_minor_version)&.uniq
+      minors == ['0']
     end
 
     def ssg_versions_for_os(os_major_version, os_minor_version)
-      for_os(os_major_version, os_minor_version).map(&:version)
+      for_os(os_major_version, os_minor_version).map(&:version).uniq
     end
 
     def versions

--- a/app/models/supported_ssg.rb
+++ b/app/models/supported_ssg.rb
@@ -34,27 +34,20 @@ SupportedSsg = Struct.new(:id, :package, :version, :profiles,
 
     def for_os(os_major_version, os_minor_version)
       for_major = by_os_major[os_major_version.to_s] || []
-      exact = for_major.select { |ssg| ssg.os_minor_version == os_minor_version.to_s }
 
-      # Fall back to the minor-0 datastream when no exact minor is shipped (upstream/IoP content).
-      exact.any? ? exact : for_major.select { |ssg| ssg.os_minor_version == '0' }
+      return for_major.select { |ssg| ssg.os_minor_version == '0' } if minor_agnostic?(os_major_version)
+
+      for_major.select { |ssg| ssg.os_minor_version == os_minor_version.to_s }
     end
 
     def resolve_minor(os_major_version, os_minor_version)
-      os_major_version = os_major_version.to_s
-      os_minor_version = os_minor_version.to_s
+      return 0 if minor_agnostic?(os_major_version)
 
-      exact = all.any? do |ssg|
-        ssg.os_major_version == os_major_version &&
-          ssg.os_minor_version == os_minor_version
-      end
-
-      (exact ? os_minor_version : '0').to_i
+      os_minor_version.to_s.to_i
     end
 
-    # True when a major ships a single minor-0 datastream that acts as a wildcard for every minor
-    # (upstream/IoP content). Hosted content ships per-minor datastreams, so this is false and only
-    # the minors actually present are supported.
+    # A major is minor-agnostic when it ships only a minor-0 datastream (upstream/IoP), which then
+    # acts as a wildcard covering every minor. Hosted majors ship a datastream per minor.
     def minor_agnostic?(os_major_version)
       minors = by_os_major[os_major_version.to_s]&.map(&:os_minor_version)&.uniq
       minors == ['0']

--- a/app/models/tailoring.rb
+++ b/app/models/tailoring.rb
@@ -54,6 +54,7 @@ class Tailoring < ApplicationRecord
   end
 
   def self.for_policy(policy, os_minor_version)
+    os_minor_version = SupportedSsg.resolve_minor(policy.os_major_version, os_minor_version)
     profile = policy.profile.variant_for_minor(os_minor_version)
     Tailoring.new(policy: policy, os_minor_version: os_minor_version,
                   profile: profile, value_overrides: profile.value_overrides)

--- a/app/services/concerns/xccdf/tailorings.rb
+++ b/app/services/concerns/xccdf/tailorings.rb
@@ -31,7 +31,7 @@ module Xccdf
     private
 
     def find_or_create_tailoring
-      os_minor = @system.os_minor_version.to_i
+      os_minor = ::SupportedSsg.resolve_minor(@system.os_major_version, @system.os_minor_version)
 
       tailoring = ::Tailoring.find_or_create_by!(policy: @policy, os_minor_version: os_minor) do |t|
         profile = @policy.profile.variant_for_minor(os_minor)

--- a/app/services/concerns/xccdf/tailorings.rb
+++ b/app/services/concerns/xccdf/tailorings.rb
@@ -19,10 +19,11 @@ module Xccdf
 
     def tailored_profile
       unless tailoring
+        resolved = ::SupportedSsg.resolve_minor(@system.os_major_version, @system.os_minor_version)
         raise ::XccdfReportParser::OSVersionMismatch,
               "No tailoring found for policy #{@policy&.id} and OS minor version " \
-              "#{@system.os_minor_version}. The system OS version may have changed " \
-              'after policy assignment.'
+              "#{@system.os_minor_version} (resolved to #{resolved}). The system OS version " \
+              'may have changed after policy assignment.'
       end
 
       @tailored_profile ||= tailoring.profile

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ Bundler.require(*Rails.groups)
 # (Development/Test env only)
 # Load .env* variables before the config (Settings) initializer is
 # being run.
-Dotenv::Rails.load if defined?(Dotenv::Rails) && !Rails.env.production?
+Dotenv::Rails.load if defined?(Dotenv::Rails) && Rails.env.local?
 
 module ComplianceBackend
   class Application < Rails::Application

--- a/spec/controllers/systems_controller_spec.rb
+++ b/spec/controllers/systems_controller_spec.rb
@@ -262,6 +262,38 @@ describe SystemsController do
         end
       end
 
+      context 'when the major ships a single minor-0 datastream (IoP)' do
+        before do
+          allow(SupportedSsg).to receive(:minor_agnostic?).and_return(true)
+          allow(SupportedSsg).to receive(:resolve_minor).and_return(0)
+        end
+
+        let(:unsupported_item) do
+          FactoryBot.create(
+            :system,
+            account: current_user.account,
+            os_major_version: parent.os_major_version,
+            os_minor_version: 10
+          )
+        end
+
+        it 'assigns systems of any minor when content is minor-agnostic' do
+          post :create, params: { ids: ids + [unsupported_item.id], policy_id: parent.id, parents: [:policies] }
+
+          expect(response).to have_http_status :accepted
+          expect(parent.systems.map(&:id)).to include(unsupported_item.id)
+        end
+
+        it 'creates a tailoring at resolved minor version 0' do
+          post :create, params: { ids: ids + [unsupported_item.id], policy_id: parent.id, parents: [:policies] }
+
+          expect(response).to have_http_status :accepted
+          new_tailorings = parent.tailorings.where.not(os_minor_version: 8)
+          expect(new_tailorings.count).to eq(1)
+          expect(new_tailorings.first.os_minor_version).to eq(0)
+        end
+      end
+
       context 'empty list of system IDs' do
         let(:items) { [] }
 

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -70,6 +70,35 @@ describe Policy do
     end
   end
 
+  describe '#supports_minor?' do
+    let(:policy) { FactoryBot.build(:policy, os_major_version: 9, account: account) }
+
+    subject { policy }
+
+    context 'when content ships per-minor datastreams (hosted)' do
+      before do
+        allow(SupportedSsg).to receive(:minor_agnostic?).and_return(false)
+        allow(subject).to receive(:os_minor_versions).and_return([0, 4])
+      end
+
+      it 'supports a minor listed by the policy' do
+        expect(subject.supports_minor?(4)).to be(true)
+      end
+
+      it 'rejects a minor not listed by the policy' do
+        expect(subject.supports_minor?(5)).to be(false)
+      end
+    end
+
+    context 'when content ships a single minor-0 datastream (IoP)' do
+      before { allow(SupportedSsg).to receive(:minor_agnostic?).and_return(true) }
+
+      it 'supports any minor via the wildcard datastream' do
+        expect(subject.supports_minor?(7)).to be(true)
+      end
+    end
+  end
+
   describe '#ref_id' do
     let(:profile) { FactoryBot.create(:profile) }
     let(:policy) { FactoryBot.create(:policy, account: account, profile: profile) }

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -52,5 +52,22 @@ describe Profile do
         expect { subject.variant_for_minor(0) }.to raise_exception(Exceptions::OSMinorVersionNotSupported)
       end
     end
+
+    context 'when SupportedSsg has no entry for the requested minor' do
+      before { allow(SupportedSsg).to receive(:resolve_minor).and_return(0) }
+
+      let!(:result) do
+        FactoryBot.create(
+          :profile,
+          ref_id: subject.ref_id,
+          supports_minors: [0],
+          security_guide: FactoryBot.create(:security_guide, version: '999.0.0')
+        )
+      end
+
+      it 'falls back to minor 0 via resolve_minor' do
+        expect(subject.variant_for_minor(4)).to eq(result)
+      end
+    end
   end
 end

--- a/spec/models/supported_ssg_spec.rb
+++ b/spec/models/supported_ssg_spec.rb
@@ -41,55 +41,119 @@ RSpec.describe SupportedSsg do
     end
   end
 
+  # Major 9 ships per-minor datastreams (hosted); major 8 ships only minor-0 (upstream/IoP).
+  let(:supported) do
+    [
+      described_class.new(os_major_version: '9', os_minor_version: '0', version: '0.1.73'),
+      described_class.new(os_major_version: '9', os_minor_version: '4', version: '0.1.81'),
+      described_class.new(os_major_version: '8', os_minor_version: '0', version: '0.1.72')
+    ]
+  end
+
+  before { allow(described_class).to receive(:all).and_return(supported) }
+
+  describe '.minor_agnostic?' do
+    it 'is false for a major shipping per-minor datastreams (hosted)' do
+      expect(described_class.minor_agnostic?(9)).to be(false)
+    end
+
+    it 'is true for a major shipping only a minor-0 datastream (upstream/IoP)' do
+      expect(described_class.minor_agnostic?(8)).to be(true)
+    end
+
+    it 'is false for an unknown major version' do
+      expect(described_class.minor_agnostic?(10)).to be(false)
+    end
+  end
+
   describe '.resolve_minor' do
-    let(:supported) do
-      [
-        described_class.new(os_major_version: '9', os_minor_version: '0', version: '0.1.73'),
-        described_class.new(os_major_version: '9', os_minor_version: '4', version: '0.1.81'),
-        described_class.new(os_major_version: '8', os_minor_version: '0', version: '0.1.72')
-      ]
+    context 'with per-minor (hosted) content' do
+      it 'keeps the requested minor when the exact SSG entry exists' do
+        expect(described_class.resolve_minor(9, 4)).to eq(4)
+      end
+
+      it 'keeps the requested minor even when no SSG entry ships for it' do
+        expect(described_class.resolve_minor(9, 3)).to eq(3)
+      end
+
+      it 'coerces string arguments and returns an integer' do
+        expect(described_class.resolve_minor('9', '4')).to eq(4)
+      end
+
+      it 'keeps the requested minor for an unknown major version' do
+        expect(described_class.resolve_minor(10, 1)).to eq(1)
+      end
     end
 
-    before { allow(described_class).to receive(:all).and_return(supported) }
-
-    it 'returns the exact minor when a matching SSG entry exists' do
-      expect(described_class.resolve_minor(9, 4)).to eq(4)
-    end
-
-    it 'falls back to minor 0 when no matching SSG entry exists' do
-      expect(described_class.resolve_minor(9, 3)).to eq(0)
-    end
-
-    it 'coerces string arguments and returns an integer' do
-      expect(described_class.resolve_minor('9', '4')).to eq(4)
-    end
-
-    it 'falls back to 0 for an entirely unknown major version' do
-      expect(described_class.resolve_minor(10, 1)).to eq(0)
+    context 'with minor-agnostic (upstream/IoP) content' do
+      it 'collapses every minor onto minor 0' do
+        expect(described_class.resolve_minor(8, 5)).to eq(0)
+      end
     end
   end
 
   describe '.for_os' do
+    context 'with per-minor (hosted) content' do
+      it 'returns the exact entries when a matching minor exists' do
+        expect(described_class.for_os(9, 4).map(&:os_minor_version)).to eq(['4'])
+      end
+
+      it 'returns nothing when no exact minor is shipped' do
+        expect(described_class.for_os(9, 3)).to be_empty
+      end
+
+      it 'returns an empty array when the major version is unknown' do
+        expect(described_class.for_os(10, 1)).to be_empty
+      end
+    end
+
+    context 'with minor-agnostic (upstream/IoP) content' do
+      it 'falls back to the minor-0 datastream for any minor' do
+        expect(described_class.for_os(8, 5).map(&:os_minor_version)).to eq(['0'])
+      end
+    end
+  end
+
+  # Minors must compare as integers, not strings, or 8.10 behaves like 8.1.
+  describe 'minor upgrades, downgrades and two-digit minors' do
     let(:supported) do
       [
-        described_class.new(os_major_version: '9', os_minor_version: '0', version: '0.1.73'),
-        described_class.new(os_major_version: '9', os_minor_version: '4', version: '0.1.81'),
-        described_class.new(os_major_version: '8', os_minor_version: '0', version: '0.1.72')
+        described_class.new(os_major_version: '8', os_minor_version: '0', version: '0.1.72'),
+        described_class.new(os_major_version: '8', os_minor_version: '1', version: '0.1.73'),
+        described_class.new(os_major_version: '8', os_minor_version: '10', version: '0.1.74'),
+        described_class.new(os_major_version: '9', os_minor_version: '0', version: '0.1.72'),
+        described_class.new(os_major_version: '9', os_minor_version: '1', version: '0.1.73'),
+        described_class.new(os_major_version: '9', os_minor_version: '5', version: '0.1.74'),
+        described_class.new(os_major_version: '7', os_minor_version: '0', version: '0.1.70')
       ]
     end
 
-    before { allow(described_class).to receive(:all).and_return(supported) }
-
-    it 'returns the exact entries when a matching minor exists' do
-      expect(described_class.for_os(9, 4).map(&:os_minor_version)).to eq(['4'])
+    it 'treats a two-digit minor as an integer, not a string prefix' do
+      expect(described_class.resolve_minor(8, 10)).to eq(10)
+      expect(described_class.resolve_minor(8, 1)).to eq(1)
+      expect(described_class.for_os(8, 10).map(&:os_minor_version)).to eq(['10'])
     end
 
-    it 'falls back to the minor 0 entry when no exact minor exists' do
-      expect(described_class.for_os(9, 3).map(&:os_minor_version)).to eq(['0'])
+    it 'resolves each minor to itself across an upgrade 9.1 -> 9.5 (hosted)' do
+      expect(described_class.resolve_minor(9, 1)).to eq(1)
+      expect(described_class.resolve_minor(9, 5)).to eq(5)
     end
 
-    it 'returns an empty array when the major version is unknown' do
-      expect(described_class.for_os(10, 1)).to be_empty
+    it 'resolves each minor to itself across a downgrade 8.10 -> 8.1 (hosted)' do
+      expect(described_class.resolve_minor(8, 10)).to eq(10)
+      expect(described_class.resolve_minor(8, 1)).to eq(1)
+    end
+
+    it 'keeps an unshipped in-between minor as itself so the lookup 404s (hosted)' do
+      expect(described_class.resolve_minor(9, 3)).to eq(3)
+      expect(described_class.for_os(9, 3)).to be_empty
+    end
+
+    it 'collapses every minor (single and two-digit) onto 0 for minor-agnostic content' do
+      expect(described_class.minor_agnostic?(7)).to be(true)
+      expect(described_class.resolve_minor(7, 1)).to eq(0)
+      expect(described_class.resolve_minor(7, 10)).to eq(0)
+      expect(described_class.for_os(7, 10).map(&:os_minor_version)).to eq(['0'])
     end
   end
 end

--- a/spec/models/supported_ssg_spec.rb
+++ b/spec/models/supported_ssg_spec.rb
@@ -40,4 +40,56 @@ RSpec.describe SupportedSsg do
       expect(ssg.version_with_revision).to eq(Gem::Version.new('0.1.73-2'))
     end
   end
+
+  describe '.resolve_minor' do
+    let(:supported) do
+      [
+        described_class.new(os_major_version: '9', os_minor_version: '0', version: '0.1.73'),
+        described_class.new(os_major_version: '9', os_minor_version: '4', version: '0.1.81'),
+        described_class.new(os_major_version: '8', os_minor_version: '0', version: '0.1.72')
+      ]
+    end
+
+    before { allow(described_class).to receive(:all).and_return(supported) }
+
+    it 'returns the exact minor when a matching SSG entry exists' do
+      expect(described_class.resolve_minor(9, 4)).to eq(4)
+    end
+
+    it 'falls back to minor 0 when no matching SSG entry exists' do
+      expect(described_class.resolve_minor(9, 3)).to eq(0)
+    end
+
+    it 'coerces string arguments and returns an integer' do
+      expect(described_class.resolve_minor('9', '4')).to eq(4)
+    end
+
+    it 'falls back to 0 for an entirely unknown major version' do
+      expect(described_class.resolve_minor(10, 1)).to eq(0)
+    end
+  end
+
+  describe '.for_os' do
+    let(:supported) do
+      [
+        described_class.new(os_major_version: '9', os_minor_version: '0', version: '0.1.73'),
+        described_class.new(os_major_version: '9', os_minor_version: '4', version: '0.1.81'),
+        described_class.new(os_major_version: '8', os_minor_version: '0', version: '0.1.72')
+      ]
+    end
+
+    before { allow(described_class).to receive(:all).and_return(supported) }
+
+    it 'returns the exact entries when a matching minor exists' do
+      expect(described_class.for_os(9, 4).map(&:os_minor_version)).to eq(['4'])
+    end
+
+    it 'falls back to the minor 0 entry when no exact minor exists' do
+      expect(described_class.for_os(9, 3).map(&:os_minor_version)).to eq(['0'])
+    end
+
+    it 'returns an empty array when the major version is unknown' do
+      expect(described_class.for_os(10, 1)).to be_empty
+    end
+  end
 end

--- a/spec/models/tailoring_spec.rb
+++ b/spec/models/tailoring_spec.rb
@@ -3,6 +3,16 @@
 require 'rails_helper'
 
 describe Tailoring do
+  describe '.for_policy' do
+    let(:policy) { FactoryBot.create(:policy, :for_tailoring, supports_minors: [0]) }
+
+    it 'uses the requested os_minor_version' do
+      tailoring = described_class.for_policy(policy, 0)
+
+      expect(tailoring.os_minor_version).to eq(0)
+    end
+  end
+
   describe '#value_overrides_by_ref_id' do
     subject do
       FactoryBot.create(

--- a/spec/services/concerns/xccdf/tailorings_spec.rb
+++ b/spec/services/concerns/xccdf/tailorings_spec.rb
@@ -95,7 +95,9 @@ RSpec.describe Xccdf::Tailorings do
     context 'when SupportedSsg resolves to fallback minor' do
       before { allow(SupportedSsg).to receive(:resolve_minor).and_return(os_minor_version) }
 
-      let!(:assigned_system) { create(:system, account: user.account, policy_id: policy.id, os_minor_version: os_minor_version) }
+      let!(:assigned_system) do
+        create(:system, account: user.account, policy_id: policy.id, os_minor_version: os_minor_version)
+      end
       let!(:system) { create(:system, account: user.account, os_minor_version: unsupported_os_minor_version) }
 
       it 'finds the tailoring at resolved minor version' do
@@ -173,6 +175,69 @@ RSpec.describe Xccdf::Tailorings do
         expected_profile = policy.profile.variant_for_minor(upgraded_os_minor_version)
 
         expect(result).to eq(expected_profile)
+      end
+    end
+  end
+
+  # SupportedSsg.all is stubbed but resolve_minor runs for real, so minors flow through shipping code.
+  describe '#tailoring across OS minor upgrades and downgrades' do
+    def ssg(major, minor)
+      SupportedSsg.new(os_major_version: major.to_s, os_minor_version: minor.to_s, version: '0.1.70')
+    end
+
+    context 'with per-minor (hosted) content shipping 8.0, 8.1 and two-digit 8.10' do
+      let(:policy) { create(:policy, account: user.account, os_major_version: 8, supports_minors: [1, 10]) }
+
+      before do
+        allow(SupportedSsg).to receive(:all).and_return([ssg(8, 0), ssg(8, 1), ssg(8, 10)])
+        create(:system, account: user.account, policy_id: policy.id, os_major_version: 8, os_minor_version: 1)
+        create(:system, account: user.account, policy_id: policy.id, os_major_version: 8, os_minor_version: 10)
+      end
+
+      context 'when the system runs the two-digit minor 8.10' do
+        let(:system) { create(:system, account: user.account, os_major_version: 8, os_minor_version: 10) }
+
+        it 'resolves to the 8.10 tailoring, never the 8.1 one' do
+          expect(service.tailoring).to eq(Tailoring.find_by!(policy_id: policy.id, os_minor_version: 10))
+          expect(service.tailoring).not_to eq(Tailoring.find_by!(policy_id: policy.id, os_minor_version: 1))
+        end
+      end
+
+      context 'when the system is downgraded from 8.10 to 8.1' do
+        let(:system) { create(:system, account: user.account, os_major_version: 8, os_minor_version: 1) }
+
+        it 'resolves to the 8.1 tailoring' do
+          expect(service.tailoring).to eq(Tailoring.find_by!(policy_id: policy.id, os_minor_version: 1))
+        end
+      end
+    end
+
+    context 'with per-minor (hosted) content when the system is upgraded 9.1 -> 9.5' do
+      let(:policy) { create(:policy, account: user.account, os_major_version: 9, supports_minors: [1]) }
+      let(:system) { create(:system, account: user.account, os_major_version: 9, os_minor_version: 5) }
+
+      before do
+        allow(SupportedSsg).to receive(:all).and_return([ssg(9, 0), ssg(9, 1), ssg(9, 5)])
+        create(:system, account: user.account, policy_id: policy.id, os_major_version: 9, os_minor_version: 1)
+      end
+
+      it 'finds no tailoring for the new minor and re-scan raises OSVersionMismatch' do
+        expect(service.tailoring).to be_nil
+        expect { service.tailored_profile }.to raise_error(XccdfReportParser::OSVersionMismatch)
+      end
+    end
+
+    context 'with minor-agnostic (upstream/IoP) content when the system is upgraded 8.1 -> 8.10' do
+      let(:policy) { create(:policy, account: user.account, os_major_version: 8, supports_minors: [0]) }
+      let(:system) { create(:system, account: user.account, os_major_version: 8, os_minor_version: 10) }
+
+      before do
+        allow(SupportedSsg).to receive(:all).and_return([ssg(8, 0)])
+        create(:system, account: user.account, policy_id: policy.id, os_major_version: 8, os_minor_version: 0)
+      end
+
+      it 'keeps resolving any minor to the single minor-0 tailoring' do
+        expect(service.tailoring).to eq(Tailoring.find_by!(policy_id: policy.id, os_minor_version: 0))
       end
     end
   end

--- a/spec/services/concerns/xccdf/tailorings_spec.rb
+++ b/spec/services/concerns/xccdf/tailorings_spec.rb
@@ -91,6 +91,19 @@ RSpec.describe Xccdf::Tailorings do
         expect(Rails.logger).not_to have_received(:audit_success)
       end
     end
+
+    context 'when SupportedSsg resolves to fallback minor' do
+      before { allow(SupportedSsg).to receive(:resolve_minor).and_return(os_minor_version) }
+
+      let!(:assigned_system) { create(:system, account: user.account, policy_id: policy.id, os_minor_version: os_minor_version) }
+      let!(:system) { create(:system, account: user.account, os_minor_version: unsupported_os_minor_version) }
+
+      it 'finds the tailoring at resolved minor version' do
+        expected = Tailoring.find_by!(policy_id: policy.id, os_minor_version: os_minor_version)
+
+        expect(service.tailoring).to eq(expected)
+      end
+    end
   end
 
   describe '#external_report?' do

--- a/spec/services/kafka/policy_system_importer_spec.rb
+++ b/spec/services/kafka/policy_system_importer_spec.rb
@@ -11,6 +11,11 @@ describe Kafka::PolicySystemImporter do
   let(:policy_id) { FactoryBot.create(:policy, os_major_version: 8, supports_minors: [0], empty_policy: true).id }
   let(:system_id) { FactoryBot.create(:system, account: user.account).id }
 
+  before do
+    allow(SupportedSsg).to receive(:minor_agnostic?).and_return(false)
+    allow(SupportedSsg).to receive(:resolve_minor) { |_, minor| minor.to_s.to_i }
+  end
+
   let(:type) { 'create' }
   let(:message) do
     {

--- a/spec/services/xccdf_report_parser_spec.rb
+++ b/spec/services/xccdf_report_parser_spec.rb
@@ -151,4 +151,59 @@ RSpec.describe XccdfReportParser do
       expect(parser).to have_received(:save_all_test_result_info)
     end
   end
+
+  # Ingesting a report after an in-place minor upgrade (8.1 -> 8.5): hosted content has no tailoring
+  # for the new minor (OSVersionMismatch); minor-agnostic content collapses it onto the .0 tailoring.
+  describe '#check_for_missing_tailored_profile after an OS minor upgrade' do
+    let(:os_major_version) { 8 }
+    let(:assignment_minor) { 1 }
+    let(:upgraded_minor) { 5 }
+
+    def ssg(major, minor)
+      SupportedSsg.new(os_major_version: major.to_s, os_minor_version: minor.to_s, version: '0.1.40')
+    end
+
+    let(:profile) do
+      create(:profile, ref_id_suffix: 'standard', os_major_version: os_major_version, supports_minors: supported_minors)
+    end
+    let(:policy) { create(:policy, account: user.account, os_major_version: os_major_version, profile: profile) }
+
+    # Tailoring is created at the assignment minor, then the system reports the upgraded minor.
+    let(:system) do
+      create(:system, account: user.account, policy_id: policy.id,
+                      os_major_version: os_major_version, os_minor_version: assignment_minor).tap do |sys|
+        upgraded = sys.system_profile.deep_dup
+        upgraded['operating_system']['minor'] = upgraded_minor
+        upgraded['os_release'] = "#{os_major_version}.#{upgraded_minor}"
+        sys.update!(system_profile: upgraded)
+        sys.reload
+      end
+    end
+
+    context 'with per-minor (hosted) content that ships no tailoring for the new minor' do
+      let(:supported_minors) { [assignment_minor] }
+
+      before do
+        allow(SupportedSsg).to receive(:all)
+          .and_return([ssg(os_major_version, 0), ssg(os_major_version, assignment_minor)])
+      end
+
+      it 'raises OSVersionMismatch reporting the resolved upgraded minor' do
+        expect { parser.check_for_missing_tailored_profile }
+          .to raise_error(described_class::OSVersionMismatch, /resolved to #{upgraded_minor}/)
+      end
+    end
+
+    context 'with minor-agnostic (upstream/IoP) content that ships only the .0 datastream' do
+      let(:supported_minors) { [0] }
+
+      before { allow(SupportedSsg).to receive(:all).and_return([ssg(os_major_version, 0)]) }
+
+      it 'keeps resolving the re-scan to the single .0 tailoring' do
+        expect { parser.check_for_missing_tailored_profile }.not_to raise_error
+        expect(parser.tailored_profile)
+          .to eq(Tailoring.find_by!(policy: policy, os_minor_version: 0).profile)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Upstream [SSG content](https://github.com/ComplianceAsCode/content/releases) ships only RHEL-X.0 datastreams (no per-minor-version entries). Compliance-backend assumes minor version granularity everywhere — policy assignment, system filtering, tag resolution. This breaks scenarios where only upstream content is available (IoP).

Ref.: [RHINENG-30005](https://redhat.atlassian.net/browse/RHINENG-30005)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices


[RHINENG-30005]: https://redhat.atlassian.net/browse/RHINENG-30005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Support upstream SSG content with only RHEL-X.0 datastreams.
- Resolve minor versions for policy assignment, system filtering, tailoring, and profile variants.
- Allow tag-based system lookup and filtering.
- Add coverage for minor-agnostic content, version upgrades, downgrades, and unsupported minors.
- Limit Dotenv loading to development and test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->