### PR TITLE
feat(systems): backfill native profile fields

### DIFF
--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -35,7 +35,7 @@ module Kafka
     def extract_system_attrs(id, payload, updated)
       system_profile = relevant_system_profile(payload)
       native_fields = SystemProfileNativeFields.normalize(system_profile)
-      log_malformed_owner(system_profile['owner_id']) if native_fields.malformed_owner_id?
+      log_malformed_owner if native_fields.malformed_owner_id?
       {
         id: id, account: payload.dig('account'), org_id: payload.dig('org_id'),
         display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
@@ -45,8 +45,8 @@ module Kafka
       }.merge(native_fields.native_attributes)
     end
 
-    def log_malformed_owner(owner_id)
-      @logger.error("[Kafka::SystemImporter] Malformed owner_id: #{owner_id.inspect}")
+    def log_malformed_owner
+      @logger.error('[Kafka::SystemImporter] Malformed owner_id')
     end
 
     def relevant_system_profile(payload)

--- a/app/services/kafka/system_importer.rb
+++ b/app/services/kafka/system_importer.rb
@@ -34,31 +34,19 @@ module Kafka
 
     def extract_system_attrs(id, payload, updated)
       system_profile = relevant_system_profile(payload)
+      native_fields = SystemProfileNativeFields.normalize(system_profile)
+      log_malformed_owner(system_profile['owner_id']) if native_fields.malformed_owner_id?
       {
         id: id, account: payload.dig('account'), org_id: payload.dig('org_id'),
         display_name: payload.dig('display_name'), groups: payload.dig('groups') || [],
         tags: payload.dig('tags') || [], system_profile: system_profile,
         stale_timestamp: payload.dig('stale_timestamp'), created: payload.dig('created'),
-        updated: updated, insights_id: payload.dig('insights_id'),
-        deleted_at: nil
-      }.merge(native_system_profile_attrs(system_profile))
+        updated: updated, insights_id: payload.dig('insights_id'), deleted_at: nil
+      }.merge(native_fields.native_attributes)
     end
 
-    def native_system_profile_attrs(system_profile)
-      operating_system = system_profile['operating_system']
-      operating_system = {} unless operating_system.is_a?(Hash)
-      {
-        os_major_version: System.type_for_attribute(:os_major_version).cast(operating_system['major']),
-        os_minor_version: System.type_for_attribute(:os_minor_version).cast(operating_system['minor']),
-        owner_id: native_owner_id(system_profile['owner_id'])
-      }
-    end
-
-    def native_owner_id(owner_id)
-      return owner_id if owner_id.nil? || (owner_id.is_a?(String) && UUID.validate(owner_id))
-
+    def log_malformed_owner(owner_id)
       @logger.error("[Kafka::SystemImporter] Malformed owner_id: #{owner_id.inspect}")
-      nil
     end
 
     def relevant_system_profile(payload)

--- a/app/services/system_profile_native_fields.rb
+++ b/app/services/system_profile_native_fields.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/Documentation
+class SystemProfileNativeFields
+  # rubocop:enable Style/Documentation
+  Result = Data.define(
+    :owner_id,
+    :os_major_version,
+    :os_minor_version,
+    :malformed_owner_id,
+    :malformed_os_major,
+    :malformed_os_minor
+  ) do
+    def native_attributes
+      {
+        owner_id: owner_id,
+        os_major_version: os_major_version,
+        os_minor_version: os_minor_version
+      }
+    end
+
+    def malformed_owner_id?
+      malformed_owner_id
+    end
+
+    def malformed_os_major?
+      malformed_os_major
+    end
+
+    def malformed_os_minor?
+      malformed_os_minor
+    end
+  end
+
+  class << self
+    # rubocop:disable Metrics/MethodLength
+    def normalize(system_profile)
+      profile = system_profile.is_a?(Hash) ? system_profile : {}
+      owner_id, malformed_owner_id = normalize_owner(profile['owner_id'])
+      os_values = normalize_operating_system(profile['operating_system'])
+
+      Result.new(
+        owner_id: owner_id,
+        os_major_version: os_values.fetch(:major),
+        os_minor_version: os_values.fetch(:minor),
+        malformed_owner_id: malformed_owner_id,
+        malformed_os_major: os_values.fetch(:malformed_major),
+        malformed_os_minor: os_values.fetch(:malformed_minor)
+      )
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def normalize_owner(owner_id)
+      return [nil, false] if owner_id.nil?
+
+      return [nil, true] unless owner_id.is_a?(String) && UUID.validate(owner_id)
+
+      type = System.type_for_attribute(:owner_id)
+      serialized = type.serialize(owner_id)
+      compatible = serialized.nil? ? nil : type.cast(serialized)
+      [compatible.nil? ? nil : owner_id, compatible.nil?]
+    end
+
+    def normalize_operating_system(operating_system)
+      return absent_operating_system if operating_system.nil?
+      return malformed_operating_system unless operating_system.is_a?(Hash)
+
+      major, malformed_major = cast_os_value(:os_major_version, operating_system['major'])
+      minor, malformed_minor = cast_os_value(:os_minor_version, operating_system['minor'])
+      {
+        major: major,
+        minor: minor,
+        malformed_major: malformed_major,
+        malformed_minor: malformed_minor
+      }
+    end
+
+    def cast_os_value(column, source)
+      value = System.type_for_attribute(column).cast(source)
+      [value, !source.nil? && value.nil?]
+    end
+
+    def absent_operating_system
+      { major: nil, minor: nil, malformed_major: false, malformed_minor: false }
+    end
+
+    def malformed_operating_system
+      { major: nil, minor: nil, malformed_major: true, malformed_minor: true }
+    end
+  end
+end

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -117,6 +117,87 @@ objects:
         livenessProbe:
           exec:
             command: ["pgrep" ,"-f", "rake"]
+    - name: backfill-systems
+      schedule: ${BACKFILL_SYSTEMS_SCHEDULE}
+      concurrencyPolicy: Forbid
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - command: ["/bin/sh"]
+          args: ["-c", "$HOME/scripts/abort_if_pending_migrations.sh"]
+          inheritEnv: true
+        resources: # same limits and requests as for the service
+          limits:
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
+          requests:
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
+        env:
+        - name: APPLICATION_TYPE
+          value: compliance-backfill-systems
+        - name: RAILS_ENV
+          value: "${RAILS_ENV}"
+        - name: RAILS_LOG_TO_STDOUT
+          value: "${RAILS_LOG_TO_STDOUT}"
+        - name: PATH_PREFIX
+          value: "${PATH_PREFIX}"
+        - name: RUBY_YJIT_ENABLE
+          value: "${RUBY_YJIT_ENABLE}"
+        - name: APP_NAME
+          value: "${APP_NAME}"
+        - name: BATCH_SIZE
+          value: "${BACKFILL_BATCH_SIZE}"
+        - name: MAX_ROWS_PER_RUN
+          value: "${BACKFILL_MAX_ROWS_PER_RUN}"
+        - name: SECRET_KEY_BASE
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: secret_key_base
+        - name: SETTINGS__SLACK_WEBHOOK
+          valueFrom:
+            secretKeyRef:
+              name: compliance-backend
+              key: slack_webhook
+              optional: true
+        - name: SETTINGS__REPORT_DOWNLOAD_SSL_ONLY
+          value: ${SETTINGS__REPORT_DOWNLOAD_SSL_ONLY}
+        - name: MAX_INIT_TIMEOUT_SECONDS
+          value: "${MAX_INIT_TIMEOUT_SECONDS}"
+        - name: SETTINGS__REDIS__SSL
+          value: "${REDIS_SSL}"
+        - name: PRIMARY_REDIS_AS_CACHE
+          value: "${PRIMARY_REDIS_AS_CACHE}"
+        - name: SETTINGS__REDIS__CACHE_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.endpoint
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.port
+              optional: true
+        - name: SETTINGS__REDIS__CACHE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: compliance-rails-cache
+              key: db.auth_token
+              optional: true
+        - name: IMAGE_TAG
+          value: "${IMAGE}:${IMAGE_TAG}"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOGSTREAM
+          value: "${LOGSTREAM_BACKFILL_SYSTEMS}"
+        livenessProbe:
+          exec:
+            command: ["pgrep" ,"-f", "rake"]
     - name: reindex-db
       schedule: ${REINDEX_DB_SCHEDULE}
       concurrencyPolicy: Forbid
@@ -854,6 +935,15 @@ parameters:
 - name: REINDEX_DB_SCHEDULE
   description: Cronjob schedule for DB reindex
   value: "0 5 * * *" # every day at 5 AM
+- name: BACKFILL_SYSTEMS_SCHEDULE
+  description: Cronjob schedule for native systems-column backfill
+  value: "*/5 * * * *"
+- name: BACKFILL_BATCH_SIZE
+  description: Number of candidate rows fetched per native systems-column backfill batch
+  value: "1000"
+- name: BACKFILL_MAX_ROWS_PER_RUN
+  description: Maximum successfully updated rows per native systems-column backfill run
+  value: "50000"
 - name: CLEANUP_SYSTEMS_SCHEDULE
   description: Cronjob schedule for systems cleanup
   value: "*/15 * * * *" # every 15 minutes
@@ -885,6 +975,8 @@ parameters:
   value: 'compliance-import-ssg'
 - name: LOGSTREAM_REINDEX_DB
   value: 'compliance-reindex-db'
+- name: LOGSTREAM_BACKFILL_SYSTEMS
+  value: 'compliance-backfill-systems'
 - name: LOGSTREAM_CLEANUP_SYSTEMS
   value: 'compliance-cleanup-systems'
 - name: RUBY_YJIT_ENABLE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,8 @@ elif [ "$APPLICATION_TYPE" = "compliance-import-remediations" ]; then
   exec bundle exec rake import_remediations --trace
 elif [ "$APPLICATION_TYPE" = "compliance-import-ssg" ]; then
   exec bundle exec rake ssg:import_rhel_supported --trace
+elif [ "$APPLICATION_TYPE" = "compliance-backfill-systems" ]; then
+  exec bundle exec rake systems:backfill_profile_fields --trace
 elif [ "$APPLICATION_TYPE" = "compliance-reindex-db" ]; then
   exec bundle exec rake db:reindex --trace
 elif [ "$APPLICATION_TYPE" = "compliance-cleanup-systems" ]; then

--- a/lib/tasks/systems_backfill_profile_fields.rake
+++ b/lib/tasks/systems_backfill_profile_fields.rake
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength, Style/Documentation
+class SystemsProfileFieldsBackfiller
+  # rubocop:enable Style/Documentation
+  NULL_TARGET_SQL = <<~SQL.squish.freeze
+    owner_id IS NULL OR os_major_version IS NULL OR os_minor_version IS NULL
+  SQL
+
+  def initialize(batch_size:, max_updates:, logger:)
+    @batch_size = batch_size
+    @max_updates = max_updates
+    @logger = logger
+    @totals = Hash.new(0)
+  end
+
+  def run
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    log_start
+    process_candidates
+    log_completion(started)
+    @totals[:successful_rows]
+  end
+
+  private
+
+  def process_candidates
+    cursor = nil
+    loop do
+      ids = candidate_ids(cursor)
+      break if ids.empty?
+
+      @totals[:selected_rows] += ids.size
+      process_batch(ids)
+      cursor = ids.last
+      return if limit_reached?
+    end
+  end
+
+  def candidate_ids(cursor)
+    relation = System.unscoped
+                     .where(deleted_at: nil)
+                     .where(NULL_TARGET_SQL)
+                     .order(:id)
+                     .limit(@batch_size)
+    relation = relation.where('id > ?', cursor) if cursor
+    relation.pluck(:id)
+  end
+
+  def process_batch(ids)
+    System.transaction do
+      locked_candidates(ids).each do |system|
+        process_locked_candidate(system)
+        break if limit_reached?
+      end
+    end
+  end
+
+  def locked_candidates(ids)
+    System.unscoped
+          .where(id: ids, deleted_at: nil)
+          .where(NULL_TARGET_SQL)
+          .order(:id)
+          .lock('FOR UPDATE OF systems')
+  end
+
+  def process_locked_candidate(system)
+    @totals[:scanned_rows] += 1
+    result = SystemProfileNativeFields.normalize(system.system_profile)
+    updates = null_target_updates(system, result)
+    serialized_updates, serialization_failed = serialize_updates(system, updates)
+    persisted = persist_updates(system, serialized_updates)
+    @totals[:failed_rows] += 1 if serialization_failed || persisted == :failed
+    merge_outcome(candidate_outcome(system, result, persisted == :written))
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def serialize_updates(system, updates)
+    failed = false
+    accepted = updates.each_with_object({}) do |(column, value), values|
+      values[column] = System.type_for_attribute(column).serialize(value)
+    rescue ActiveModel::RangeError => e
+      failed = true
+      @totals[:rejected_fields] += 1
+      @logger.error(
+        "systems:backfill_profile_fields rejected system_id=#{system.id} " \
+        "column=#{column} error=#{e.class}"
+      )
+    end
+    [accepted, failed]
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def persist_updates(system, updates)
+    return :none if updates.empty?
+
+    System.transaction(requires_new: true) do
+      system.update_columns(updates) # rubocop:disable Rails/SkipsModelValidations
+    end
+    :written
+  rescue ActiveRecord::ActiveRecordError => e
+    @logger.error("systems:backfill_profile_fields failed system_id=#{system.id} error=#{e.class}")
+    :failed
+  end
+
+  def null_target_updates(system, result)
+    result.native_attributes.select do |column, value|
+      system[column].nil? && !value.nil?
+    end
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def candidate_outcome(system, result, updated)
+    {
+      successful_rows: updated ? 1 : 0,
+      malformed_owner_ids: system[:owner_id].nil? && result.malformed_owner_id? ? 1 : 0,
+      malformed_os_major: system[:os_major_version].nil? && result.malformed_os_major? ? 1 : 0,
+      malformed_os_minor: system[:os_minor_version].nil? && result.malformed_os_minor? ? 1 : 0
+    }
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  def merge_outcome(outcome)
+    outcome.each { |key, value| @totals[key] += value }
+  end
+
+  def limit_reached?
+    @totals[:successful_rows] >= @max_updates
+  end
+
+  def log_start
+    @logger.info(
+      "systems:backfill_profile_fields BATCH_SIZE=#{@batch_size} " \
+      "MAX_ROWS_PER_RUN=#{@max_updates}"
+    )
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def log_completion(started)
+    elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).round(2)
+    reason = if limit_reached?
+               "Stopped after reaching MAX_ROWS_PER_RUN=#{@max_updates}"
+             else
+               "Reached the end of this invocation's keyset scan"
+             end
+    @logger.info(
+      "#{reason}. selected_rows=#{@totals[:selected_rows]} " \
+      "scanned_rows=#{@totals[:scanned_rows]} " \
+      "successful_rows=#{@totals[:successful_rows]} in #{elapsed}s; " \
+      "malformed_owner_ids=#{@totals[:malformed_owner_ids]} " \
+      "malformed_os_major=#{@totals[:malformed_os_major]} " \
+      "malformed_os_minor=#{@totals[:malformed_os_minor]} " \
+      "rejected_fields=#{@totals[:rejected_fields]} " \
+      "failed_rows=#{@totals[:failed_rows]}"
+    )
+    return unless @totals[:failed_rows].positive?
+
+    @logger.warn(
+      "systems:backfill_profile_fields completed with failed_rows=#{@totals[:failed_rows]}; " \
+      'investigate persistence errors before Phase 5 cleanup'
+    )
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+end
+# rubocop:enable Metrics/ClassLength
+
+namespace :systems do
+  desc 'Backfill null native owner and OS columns from system_profile JSONB'
+  task backfill_profile_fields: :environment do
+    parse_positive = lambda do |name, default|
+      value = Integer(ENV.fetch(name, default.to_s), 10)
+      raise ArgumentError unless value.positive?
+
+      value
+    rescue ArgumentError
+      raise ArgumentError, "#{name} must be a positive integer"
+    end
+
+    SystemsProfileFieldsBackfiller.new(
+      batch_size: parse_positive.call('BATCH_SIZE', 1000),
+      max_updates: parse_positive.call('MAX_ROWS_PER_RUN', 50_000),
+      logger: Logger.new($stdout)
+    ).run
+  end
+end

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -94,21 +94,20 @@ RSpec.describe Kafka::SystemImporter do
         expect(system[:owner_id]).to eq(message.dig('host', 'system_profile', 'owner_id'))
       end
 
-      it 'validates owner_id with the shared UUID helper' do
-        owner_id = message.dig('host', 'system_profile', 'owner_id')
-        expect(UUID).to receive(:validate).with(owner_id).and_call_original
-
-        service.import
-      end
-
-      it 'casts native OS versions to their database types' do
-        major_type = instance_double(ActiveModel::Type::Integer, cast: 9)
-        minor_type = instance_double(ActiveModel::Type::Integer, cast: 4)
-        allow(System).to receive(:type_for_attribute).and_call_original
-        expect(System).to receive(:type_for_attribute).with(:os_major_version).and_return(major_type)
-        expect(System).to receive(:type_for_attribute).with(:os_minor_version).and_return(minor_type)
-        expect(major_type).to receive(:cast).with(9)
-        expect(minor_type).to receive(:cast).with(4)
+      it 'uses the shared native-field projection' do
+        result = instance_double(
+          SystemProfileNativeFields::Result,
+          native_attributes: {
+            owner_id: message.dig('host', 'system_profile', 'owner_id'),
+            os_major_version: 9,
+            os_minor_version: 4
+          },
+          malformed_owner_id?: false
+        )
+        expect(SystemProfileNativeFields)
+          .to receive(:normalize)
+          .with(message.dig('host', 'system_profile'))
+          .and_return(result)
 
         service.import
       end

--- a/spec/services/kafka/system_importer_spec.rb
+++ b/spec/services/kafka/system_importer_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Kafka::SystemImporter do
       it 'logs an error and imports JSONB with a null native owner' do
         expect(Karafka.logger)
           .to receive(:error)
-          .with(/\[Kafka::SystemImporter\] Malformed owner_id/)
+          .with('[Kafka::SystemImporter] Malformed owner_id')
 
         expect { service.import }.to change { System.count }.by(1)
         system = System.find(message['host']['id'])
@@ -194,7 +194,7 @@ RSpec.describe Kafka::SystemImporter do
       it 'logs an error and imports JSONB with a null native owner' do
         expect(Karafka.logger)
           .to receive(:error)
-          .with(/\[Kafka::SystemImporter\] Malformed owner_id/)
+          .with('[Kafka::SystemImporter] Malformed owner_id')
 
         expect { service.import }.to change { System.count }.by(1)
         system = System.find(message['host']['id'])

--- a/spec/services/system_profile_native_fields_spec.rb
+++ b/spec/services/system_profile_native_fields_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe SystemProfileNativeFields do
       let(:canonical) { SecureRandom.uuid }
       let(:profile) { { 'owner_id' => owner_id } }
 
-      [
-        ->(uuid) { uuid },
-        ->(uuid) { uuid.upcase },
-        ->(uuid) { uuid.delete('-') }
-      ].each do |transform|
-        context "with transform #{transform.object_id}" do
+      {
+        canonical: ->(uuid) { uuid },
+        uppercase: ->(uuid) { uuid.upcase },
+        unhyphenated: ->(uuid) { uuid.delete('-') }
+      }.each do |label, transform|
+        context "with a #{label} owner_id" do
           let(:owner_id) { transform.call(canonical) }
 
           it 'preserves the accepted, persistence-compatible owner value' do

--- a/spec/services/system_profile_native_fields_spec.rb
+++ b/spec/services/system_profile_native_fields_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SystemProfileNativeFields do
+  subject(:result) { described_class.normalize(profile) }
+
+  describe '.normalize' do
+    context 'with valid values' do
+      let(:owner_id) { SecureRandom.uuid }
+      let(:profile) do
+        {
+          'owner_id' => owner_id,
+          'operating_system' => { 'major' => 9, 'minor' => 4 }
+        }
+      end
+
+      it 'returns all native attributes without malformed flags' do
+        expect(result.native_attributes).to eq(
+          owner_id: owner_id,
+          os_major_version: 9,
+          os_minor_version: 4
+        )
+        expect(result).not_to be_malformed_owner_id
+        expect(result).not_to be_malformed_os_major
+        expect(result).not_to be_malformed_os_minor
+      end
+    end
+
+    context 'with UUID forms accepted by the shared UUID helper' do
+      let(:canonical) { SecureRandom.uuid }
+      let(:profile) { { 'owner_id' => owner_id } }
+
+      [
+        ->(uuid) { uuid },
+        ->(uuid) { uuid.upcase },
+        ->(uuid) { uuid.delete('-') }
+      ].each do |transform|
+        context "with transform #{transform.object_id}" do
+          let(:owner_id) { transform.call(canonical) }
+
+          it 'preserves the accepted, persistence-compatible owner value' do
+            type = System.type_for_attribute(:owner_id)
+            expect(UUID.validate(owner_id)).to be(true)
+            expect(type.serialize(owner_id)).not_to be_nil
+            persisted_owner_id = type.cast(type.serialize(owner_id))
+            expect(persisted_owner_id).not_to be_nil
+            expect(result.owner_id).to eq(owner_id)
+            expect(result).not_to be_malformed_owner_id
+
+            system = FactoryBot.create(:system)
+            # rubocop:disable Rails/SkipsModelValidations
+            expect { system.update_columns(owner_id: result.owner_id) }.not_to raise_error
+            # rubocop:enable Rails/SkipsModelValidations
+            expect(system.reload[:owner_id]).to eq(persisted_owner_id)
+          end
+        end
+      end
+    end
+
+    context 'with missing and null values' do
+      let(:profiles) do
+        [
+          {},
+          { 'owner_id' => nil },
+          { 'operating_system' => nil },
+          { 'operating_system' => { 'major' => nil, 'minor' => nil } }
+        ]
+      end
+
+      it 'returns absence without malformed flags' do
+        profiles.each do |profile|
+          normalized = described_class.normalize(profile)
+          expect(normalized.native_attributes.values).to all(be_nil)
+          expect(normalized).not_to be_malformed_owner_id
+          expect(normalized).not_to be_malformed_os_major
+          expect(normalized).not_to be_malformed_os_minor
+        end
+      end
+    end
+
+    context 'with malformed owner values' do
+      let(:profile) { {} }
+
+      it 'classifies invalid strings and non-strings' do
+        [Faker::Lorem.word, 1, {}, []].each do |owner_id|
+          normalized = described_class.normalize('owner_id' => owner_id)
+          expect(normalized.owner_id).to be_nil
+          expect(normalized).to be_malformed_owner_id
+        end
+      end
+
+      it 'classifies a helper-valid but persistence-incompatible UUID form' do
+        owner_id = "urn:uuid:#{SecureRandom.uuid}"
+        type = System.type_for_attribute(:owner_id)
+
+        expect(UUID.validate(owner_id)).to be(true)
+        expect(type.serialize(owner_id)).to be_nil
+        expect(described_class.normalize('owner_id' => owner_id).owner_id).to be_nil
+        expect(described_class.normalize('owner_id' => owner_id)).to be_malformed_owner_id
+      end
+    end
+
+    context 'with Active Record-castable OS values' do
+      let(:profile) { {} }
+
+      it 'preserves merged importer casting behavior' do
+        {
+          '9' => 9,
+          '09' => 9,
+          '9x' => 9,
+          '1.5' => 1,
+          1.5 => 1,
+          true => 1,
+          false => 0
+        }.each do |source, expected|
+          normalized = described_class.normalize(
+            'operating_system' => { 'major' => source }
+          )
+          expect(normalized.os_major_version).to eq(expected)
+          expect(normalized).not_to be_malformed_os_major
+        end
+      end
+    end
+
+    context 'with non-null OS values that cast to nil' do
+      let(:profile) { {} }
+
+      it 'classifies each affected field independently' do
+        [[], {}].each do |source|
+          normalized = described_class.normalize(
+            'operating_system' => { 'major' => source, 'minor' => 4 }
+          )
+          expect(normalized.os_major_version).to be_nil
+          expect(normalized).to be_malformed_os_major
+          expect(normalized.os_minor_version).to eq(4)
+          expect(normalized).not_to be_malformed_os_minor
+        end
+      end
+    end
+
+    context 'with a non-null non-Hash operating_system' do
+      let(:profile) { { 'operating_system' => Faker::Lorem.word } }
+
+      it 'classifies both OS fields as malformed' do
+        expect(result.os_major_version).to be_nil
+        expect(result.os_minor_version).to be_nil
+        expect(result).to be_malformed_os_major
+        expect(result).to be_malformed_os_minor
+      end
+    end
+
+    context 'with an out-of-range OS integer' do
+      let(:overflow) { 2_147_483_648 }
+      let(:profile) { { 'operating_system' => { 'major' => overflow } } }
+
+      it 'preserves the cast value for database serialization to reject' do
+        expect(result.os_major_version).to eq(overflow)
+        expect(result).not_to be_malformed_os_major
+        expect do
+          System.type_for_attribute(:os_major_version).serialize(result.os_major_version)
+        end.to raise_error(ActiveModel::RangeError)
+      end
+    end
+  end
+end

--- a/spec/tasks/systems_backfill_profile_fields_spec.rb
+++ b/spec/tasks/systems_backfill_profile_fields_spec.rb
@@ -343,13 +343,14 @@ RSpec.describe SystemsProfileFieldsBackfiller do
       allow(SystemProfileNativeFields).to receive(:normalize).with(profile).and_return(
         normalized.with(os_major_version: '9')
       )
-      allow_any_instance_of(System).to receive(:update_columns) do |_record, updates| # rubocop:disable RSpec/AnyInstance
-        expect(updates).to eq(os_major_version: 9)
-      end
+      integer_type = instance_double(ActiveModel::Type::Integer)
+      expect(integer_type).to receive(:serialize).with('9').and_return(9)
+      allow(System).to receive(:type_for_attribute).and_call_original
+      expect(System).to receive(:type_for_attribute).with(:os_major_version).and_return(integer_type)
 
       described_class.new(batch_size: 10, max_updates: 10, logger: Logger.new(StringIO.new)).run
 
-      expect(system.reload[:os_major_version]).to be_nil
+      expect(system.reload[:os_major_version]).to eq(9)
     end
 
     it 'returns the number of successfully updated rows and logs scanned rows' do
@@ -455,7 +456,10 @@ RSpec.describe SystemsProfileFieldsBackfiller, :postgresql_concurrency do
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
-  after { System.unscoped.where(id: [uuid(1), uuid(2)]).delete_all }
+  after do
+    System.unscoped.where(id: [uuid(1), uuid(2)]).delete_all
+    Account.where(org_id: %w[backfill-1 backfill-2]).delete_all
+  end
 
   it 'preserves a native value committed while the backfill waits for its lock' do
     concurrent_owner = uuid(900)

--- a/spec/tasks/systems_backfill_profile_fields_spec.rb
+++ b/spec/tasks/systems_backfill_profile_fields_spec.rb
@@ -1,0 +1,494 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+Rails.application.load_tasks unless Rake::Task.task_defined?('systems:backfill_profile_fields')
+
+# rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+module SystemsProfileFieldsBackfillHelpers
+  def uuid(sequence)
+    format('00000000-0000-0000-0000-%012d', sequence)
+  end
+
+  def create_backfill_system(sequence:, profile:, owner_id: nil, major: nil, minor: nil, deleted_at: nil, **attrs)
+    account = Account.find_or_create_by!(org_id: "backfill-#{sequence}")
+    system = FactoryBot.create(:system, id: uuid(sequence), account: account, **attrs)
+    system.update_columns( # rubocop:disable Rails/SkipsModelValidations
+      owner_id: owner_id,
+      os_major_version: major,
+      os_minor_version: minor,
+      deleted_at: deleted_at
+    )
+    system.class.connection.exec_update(
+      "UPDATE systems SET system_profile = #{system.class.connection.quote(profile.to_json)}::jsonb " \
+      "WHERE id = #{system.class.connection.quote(system.id)}"
+    )
+    system.reload
+  end
+end
+# rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
+
+RSpec.describe 'systems:backfill_profile_fields task' do
+  include SystemsProfileFieldsBackfillHelpers
+
+  ENV_KEYS = %w[BATCH_SIZE MAX_ROWS_PER_RUN].freeze
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  def invoke_task
+    Rake::Task['systems:backfill_profile_fields'].invoke
+  end
+
+  around do |example|
+    original = ENV_KEYS.to_h { |key| [key, ENV.fetch(key, nil)] }
+    example.run
+  ensure
+    original.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+  end
+
+  before do
+    Rake::Task['systems:backfill_profile_fields'].reenable
+  end
+
+  it 'writes one, two, or three null targets and counts each row once' do
+    owner_1 = uuid(101)
+    owner_2 = uuid(102)
+    systems = [
+      create_backfill_system(
+        sequence: 1,
+        profile: { 'owner_id' => owner_1, 'operating_system' => { 'major' => 9, 'minor' => 4 } },
+        major: 8,
+        minor: 1
+      ),
+      create_backfill_system(
+        sequence: 2,
+        profile: { 'owner_id' => owner_2, 'operating_system' => { 'major' => 9, 'minor' => 4 } },
+        major: 8
+      ),
+      create_backfill_system(
+        sequence: 3,
+        profile: { 'owner_id' => uuid(103), 'operating_system' => { 'major' => 9, 'minor' => 4 } }
+      )
+    ]
+
+    output = capture_stdout { invoke_task }
+
+    native_values = systems.map do |system|
+      system.reload.attributes.values_at('owner_id', 'os_major_version', 'os_minor_version')
+    end
+    expect(native_values).to eq([[owner_1, 8, 1], [owner_2, 8, 4], [uuid(103), 9, 4]])
+    expect(output).to include('selected_rows=3', 'scanned_rows=3', 'successful_rows=3')
+  end
+
+  it 'changes only null native target columns' do
+    system = create_backfill_system(
+      sequence: 1,
+      profile: {
+        'owner_id' => uuid(101),
+        'operating_system' => { 'major' => 9, 'minor' => 4 },
+        'preserved' => { 'value' => Faker::Lorem.word }
+      },
+      major: 8,
+      display_name: Faker::Internet.domain_name,
+      tags: [{ namespace: Faker::Lorem.word, key: Faker::Lorem.word, value: Faker::Lorem.word }],
+      groups: [{ id: uuid(500), name: Faker::Company.name }]
+    )
+    before = System.unscoped.find(system.id).attributes.deep_dup
+
+    capture_stdout { invoke_task }
+
+    after = System.unscoped.find(system.id).attributes
+    targets = %w[owner_id os_major_version os_minor_version]
+    expect(after.except(*targets)).to eq(before.except(*targets))
+    expect(after.slice(*targets)).to eq(
+      'owner_id' => uuid(101),
+      'os_major_version' => 8,
+      'os_minor_version' => 4
+    )
+  end
+
+  it 'counts malformed fields only when corresponding targets remain null' do
+    create_backfill_system(
+      sequence: 1,
+      profile: {
+        'owner_id' => Faker::Lorem.word,
+        'operating_system' => Faker::Lorem.word
+      },
+      major: 8
+    )
+
+    output = capture_stdout { invoke_task }
+
+    expect(output).to include('selected_rows=1', 'scanned_rows=1')
+    expect(output).to include('malformed_owner_ids=1')
+    expect(output).to include('malformed_os_major=0')
+    expect(output).to include('malformed_os_minor=1')
+    expect(output).to include('successful_rows=0')
+  end
+
+  it 'does not classify missing or null sources as malformed' do
+    create_backfill_system(sequence: 1, profile: {})
+    create_backfill_system(
+      sequence: 2,
+      profile: {
+        'owner_id' => nil,
+        'operating_system' => { 'major' => nil, 'minor' => nil }
+      }
+    )
+
+    output = capture_stdout { invoke_task }
+
+    expect(output).to include('selected_rows=2', 'scanned_rows=2')
+    expect(output).to include('malformed_owner_ids=0')
+    expect(output).to include('malformed_os_major=0')
+    expect(output).to include('malformed_os_minor=0')
+    expect(output).to include('successful_rows=0')
+  end
+
+  it 'never selects a soft-deleted row' do
+    system = create_backfill_system(
+      sequence: 1,
+      profile: { 'owner_id' => uuid(101) },
+      deleted_at: 1.day.ago
+    )
+    before = System.unscoped.find(system.id).attributes.deep_dup
+
+    expect(SystemProfileNativeFields).not_to receive(:normalize)
+    output = capture_stdout { invoke_task }
+
+    expect(System.unscoped.find(system.id).attributes).to eq(before)
+    expect(output).to include('selected_rows=0', 'scanned_rows=0')
+  end
+
+  it 'issues a batch-level FOR UPDATE lock of systems' do
+    create_backfill_system(sequence: 1, profile: { 'owner_id' => uuid(101) })
+    sql = []
+    callback = lambda do |_name, _started, _finished, _id, payload|
+      sql << payload[:sql] unless payload[:name] == 'SCHEMA'
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+      capture_stdout { invoke_task }
+    end
+
+    expect(sql).to include(match(/FROM "systems".*FOR UPDATE OF systems/i))
+  end
+
+  it 'continues after a malformed-only batch' do
+    ENV['BATCH_SIZE'] = '2'
+    ENV['MAX_ROWS_PER_RUN'] = '10'
+    create_backfill_system(sequence: 1, profile: { 'owner_id' => Faker::Lorem.word })
+    create_backfill_system(sequence: 2, profile: { 'owner_id' => Faker::Lorem.word })
+    valid = create_backfill_system(sequence: 3, profile: { 'owner_id' => uuid(103) })
+
+    output = capture_stdout { invoke_task }
+
+    expect(valid.reload[:owner_id]).to eq(uuid(103))
+    expect(output).to include('selected_rows=3', 'scanned_rows=3')
+    expect(output).to include('malformed_owner_ids=2')
+    expect(output).to include('successful_rows=1')
+  end
+
+  it 'counts successful rows and stops immediately at the mid-batch cap' do
+    ENV['BATCH_SIZE'] = '4'
+    ENV['MAX_ROWS_PER_RUN'] = '2'
+    malformed = create_backfill_system(sequence: 1, profile: { 'owner_id' => Faker::Lorem.word })
+    first = create_backfill_system(
+      sequence: 2,
+      profile: { 'owner_id' => uuid(102), 'operating_system' => { 'major' => 9, 'minor' => 4 } }
+    )
+    second = create_backfill_system(sequence: 3, profile: { 'owner_id' => uuid(103) })
+    unprocessed = create_backfill_system(sequence: 4, profile: { 'owner_id' => uuid(104) })
+
+    output = capture_stdout { invoke_task }
+
+    expect(malformed.reload[:owner_id]).to be_nil
+    expect(first.reload.attributes.values_at('owner_id', 'os_major_version', 'os_minor_version'))
+      .to eq([uuid(102), 9, 4])
+    expect(second.reload[:owner_id]).to eq(uuid(103))
+    expect(unprocessed.reload[:owner_id]).to be_nil
+    expect(output).to include('selected_rows=4', 'scanned_rows=3', 'successful_rows=2')
+    expect(output).to include('Stopped after reaching MAX_ROWS_PER_RUN=2')
+  end
+
+  it 'processes rows left by a capped invocation on the next invocation' do
+    ENV['BATCH_SIZE'] = '3'
+    ENV['MAX_ROWS_PER_RUN'] = '1'
+    first = create_backfill_system(sequence: 1, profile: { 'owner_id' => uuid(101) })
+    second = create_backfill_system(sequence: 2, profile: { 'owner_id' => uuid(102) })
+
+    capture_stdout { invoke_task }
+    expect(first.reload[:owner_id]).to eq(uuid(101))
+    expect(second.reload[:owner_id]).to be_nil
+
+    Rake::Task['systems:backfill_profile_fields'].reenable
+    capture_stdout { invoke_task }
+    expect(second.reload[:owner_id]).to eq(uuid(102))
+  end
+
+  it 'reports permanently malformed rows on every invocation' do
+    system = create_backfill_system(sequence: 1, profile: { 'owner_id' => Faker::Lorem.word })
+
+    first = capture_stdout { invoke_task }
+    Rake::Task['systems:backfill_profile_fields'].reenable
+    second = capture_stdout { invoke_task }
+
+    expect(system.reload[:owner_id]).to be_nil
+    expect(first).to include('malformed_owner_ids=1')
+    expect(second).to include('malformed_owner_ids=1')
+  end
+
+  it 'rejects an overflowing field, persists valid siblings, and continues later rows' do
+    profile = { 'owner_id' => uuid(101), 'operating_system' => { 'minor' => 4 } }
+    partial = create_backfill_system(sequence: 1, profile: profile)
+    later = create_backfill_system(sequence: 2, profile: { 'owner_id' => uuid(102) })
+    normalized = SystemProfileNativeFields.normalize(profile)
+    allow(SystemProfileNativeFields).to receive(:normalize).and_call_original
+    allow(SystemProfileNativeFields).to receive(:normalize).with(profile).and_return(
+      normalized.with(os_major_version: 2_147_483_648)
+    )
+
+    output = capture_stdout { invoke_task }
+
+    expect(partial.reload.attributes.values_at('owner_id', 'os_major_version', 'os_minor_version'))
+      .to eq([uuid(101), nil, 4])
+    expect(later.reload[:owner_id]).to eq(uuid(102))
+    expect(output).to include('selected_rows=2', 'scanned_rows=2', 'successful_rows=2')
+    expect(output).to include('failed_rows=1')
+    expect(output).to include('rejected_fields=1', 'WARN')
+    expect(output).not_to include('2147483648')
+  end
+
+  it 'rolls back a real persistence failure savepoint and keeps the batch transaction usable' do
+    first = create_backfill_system(sequence: 1, profile: { 'owner_id' => uuid(101) })
+    failed = create_backfill_system(sequence: 2, profile: { 'owner_id' => uuid(102) })
+    last = create_backfill_system(sequence: 3, profile: { 'owner_id' => uuid(103) })
+    connection = ActiveRecord::Base.connection
+    constraint = 'systems_backfill_profile_fields_persistence_failure'
+    connection.execute(<<~SQL.squish)
+      ALTER TABLE systems
+      ADD CONSTRAINT #{constraint}
+      CHECK (id <> #{connection.quote(failed.id)} OR owner_id IS NULL)
+      NOT VALID
+    SQL
+
+    output = capture_stdout { invoke_task }
+
+    expect(first.reload[:owner_id]).to eq(uuid(101))
+    expect(failed.reload[:owner_id]).to be_nil
+    expect(last.reload[:owner_id]).to eq(uuid(103))
+    expect(output).to include('selected_rows=3', 'scanned_rows=3', 'successful_rows=2', 'failed_rows=1')
+  ensure
+    connection&.execute("ALTER TABLE systems DROP CONSTRAINT IF EXISTS #{constraint}")
+  end
+
+  %w[0 -1 invalid].each do |value|
+    it "rejects BATCH_SIZE=#{value}" do
+      ENV['BATCH_SIZE'] = value
+      expect { capture_stdout { invoke_task } }
+        .to raise_error(ArgumentError, 'BATCH_SIZE must be a positive integer')
+    end
+
+    it "rejects MAX_ROWS_PER_RUN=#{value}" do
+      ENV['MAX_ROWS_PER_RUN'] = value
+      expect { capture_stdout { invoke_task } }
+        .to raise_error(ArgumentError, 'MAX_ROWS_PER_RUN must be a positive integer')
+    end
+  end
+end
+
+RSpec.describe SystemsProfileFieldsBackfiller do
+  include SystemsProfileFieldsBackfillHelpers
+
+  describe '#run' do
+    it 'queries a full configured batch even when one success remains' do
+      4.times do |index|
+        system = FactoryBot.create(
+          :system,
+          id: uuid(index + 1),
+          system_profile: { 'owner_id' => uuid(index + 101) }
+        )
+        system.update_columns( # rubocop:disable Rails/SkipsModelValidations
+          owner_id: nil, os_major_version: 1, os_minor_version: 1
+        )
+      end
+      limits = []
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        next unless payload[:sql].match?(/SELECT "systems"\."id"/i)
+
+        limits << payload[:binds].last.value
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        described_class.new(batch_size: 4, max_updates: 1, logger: Logger.new(StringIO.new)).run
+      end
+
+      expect(limits).to include(4)
+    end
+
+    it 'passes independently serialized values to update_columns' do
+      profile = { 'operating_system' => { 'major' => 9 } }
+      system = create_backfill_system(sequence: 1, profile: profile)
+      normalized = SystemProfileNativeFields.normalize(profile)
+      allow(SystemProfileNativeFields).to receive(:normalize).with(profile).and_return(
+        normalized.with(os_major_version: '9')
+      )
+      allow_any_instance_of(System).to receive(:update_columns) do |_record, updates| # rubocop:disable RSpec/AnyInstance
+        expect(updates).to eq(os_major_version: 9)
+      end
+
+      described_class.new(batch_size: 10, max_updates: 10, logger: Logger.new(StringIO.new)).run
+
+      expect(system.reload[:os_major_version]).to be_nil
+    end
+
+    it 'returns the number of successfully updated rows and logs scanned rows' do
+      system = FactoryBot.create(
+        :system,
+        id: uuid(1),
+        system_profile: { 'owner_id' => uuid(101) }
+      )
+      system.update_columns( # rubocop:disable Rails/SkipsModelValidations
+        owner_id: nil, os_major_version: 1, os_minor_version: 1
+      )
+      io = StringIO.new
+
+      result = described_class.new(batch_size: 10, max_updates: 10, logger: Logger.new(io)).run
+
+      expect(result).to eq(1)
+      expect(io.string).to include('selected_rows=1', 'scanned_rows=1')
+    end
+
+    it 'warns without source values when failures occurred' do
+      source_owner = uuid(101)
+      profile = { 'owner_id' => source_owner }
+      create_backfill_system(sequence: 1, profile: profile)
+      normalized = SystemProfileNativeFields.normalize(profile)
+      allow(SystemProfileNativeFields).to receive(:normalize).with(profile).and_return(
+        normalized.with(os_major_version: 2_147_483_648)
+      )
+      io = StringIO.new
+
+      described_class.new(batch_size: 10, max_updates: 10, logger: Logger.new(io)).run
+
+      expect(io.string).to include('WARN', 'failed_rows=1')
+      expect(io.string).not_to include(source_owner, '2147483648')
+    end
+  end
+end
+
+RSpec.describe SystemsProfileFieldsBackfiller, :postgresql_concurrency do
+  include SystemsProfileFieldsBackfillHelpers
+
+  self.use_transactional_tests = false
+
+  # rubocop:disable Metrics/MethodLength
+  def wait_until_backend_is_lock_waiting(pid, timeout: 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      waiting = ActiveRecord::Base.connection_pool.with_connection do |observer|
+        observer.select_value(<<~SQL.squish)
+          SELECT wait_event_type = 'Lock'
+          FROM pg_stat_activity
+          WHERE pid = #{observer.quote(pid)}
+        SQL
+      end
+      return if waiting
+      raise "backend #{pid} did not enter a lock wait" if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+      sleep 0.01
+    end
+  end
+
+  # rubocop:enable Metrics/MethodLength
+
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+  def run_lock_wait_race(system_id)
+    mutation_started = Queue.new
+    release_mutation = Queue.new
+    backfill_pid = Queue.new
+    mutation = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do |connection|
+        connection.transaction do
+          yield connection
+          mutation_started << true
+          release_mutation.pop
+        end
+      end
+    end
+    mutation_started.pop
+
+    log = StringIO.new
+    backfill = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do |connection|
+        backfill_pid << connection.select_value('SELECT pg_backend_pid()')
+        SystemsProfileFieldsBackfiller.new(
+          batch_size: 1000,
+          max_updates: 50_000,
+          logger: Logger.new(log)
+        ).run
+      end
+    end
+
+    pid = backfill_pid.pop
+    wait_until_backend_is_lock_waiting(pid)
+    release_mutation << true
+    mutation.join(5) || raise('mutation thread did not finish')
+    backfill.join(5) || raise('backfill thread did not finish')
+    [System.unscoped.find(system_id), log.string]
+  ensure
+    release_mutation << true if mutation&.alive?
+    mutation&.join(5)
+    backfill&.join(5)
+    mutation&.kill if mutation&.alive?
+    backfill&.kill if backfill&.alive?
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+
+  after { System.unscoped.where(id: [uuid(1), uuid(2)]).delete_all }
+
+  it 'preserves a native value committed while the backfill waits for its lock' do
+    concurrent_owner = uuid(900)
+    system = create_backfill_system(
+      sequence: 1,
+      profile: { 'owner_id' => uuid(101) },
+      major: 9,
+      minor: 4
+    )
+
+    reloaded, output = run_lock_wait_race(system.id) do |connection|
+      connection.exec_update(
+        "UPDATE systems SET owner_id = #{connection.quote(concurrent_owner)} " \
+        "WHERE id = #{connection.quote(system.id)}"
+      )
+    end
+
+    expect(reloaded[:owner_id]).to eq(concurrent_owner)
+    expect(output).to include('selected_rows=1', 'scanned_rows=0')
+  end
+
+  it 'preserves soft deletion committed while the backfill waits for its lock' do
+    system = create_backfill_system(sequence: 2, profile: { 'owner_id' => uuid(102) })
+
+    reloaded, output = run_lock_wait_race(system.id) do |connection|
+      connection.exec_update(
+        "UPDATE systems SET deleted_at = #{connection.quote(Time.current)} " \
+        "WHERE id = #{connection.quote(system.id)}"
+      )
+    end
+
+    expect(reloaded.deleted_at).not_to be_nil
+    expect(reloaded[:owner_id]).to be_nil
+    expect(output).to include('selected_rows=1', 'scanned_rows=0')
+  end
+end


### PR DESCRIPTION
## Summary
- extract shared native-field projection used by Kafka imports and historical backfill
- add bounded, restartable systems backfill with batch locking, savepoint-isolated failures, and aggregate logging
- schedule the temporary OpenShift CronJob without overlapping runs

## Verification
- `podman-compose exec rails bundle exec rspec spec/services/system_profile_native_fields_spec.rb spec/services/kafka/system_importer_spec.rb spec/tasks/systems_backfill_profile_fields_spec.rb` — 62 examples, 0 failures
- targeted RuboCop — 6 files, no offenses
- `bash -n entrypoint.sh`
- ShellCheck container validation
- `oc process --local -f deploy/clowdapp.yaml ...`

Jira: https://redhat.atlassian.net/browse/RHINENG-30505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add shared native system field normalization for Kafka imports and backfills.
- Add a bounded, restartable systems backfill with batch locking, isolated failures, and aggregate logging.
- Schedule the backfill with a temporary non-overlapping OpenShift CronJob.
- Add coverage for normalization, backfill behavior, concurrency, configuration, and deployment validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->