### PR TITLE
fix(Jenkins): pin kessel-kafka-connect to latest image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,7 @@ pipeline {
                             --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac=latest
                             --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory-consumer/inventory-consumer=latest
                             --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest
+                            --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect=latest
                             --set-image-tag quay.io/redhat-services-prod/insights-management-tenant/insights-compliance/compliance-ssg=latest
                             -p rbac/NOTIFICATIONS_RH_ENABLED=False
                             -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST=approval


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-30906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Pin `kessel-kafka-connect` to the `latest` image in Jenkins smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->